### PR TITLE
add simd

### DIFF
--- a/include/pclomp/ndt_omp_impl.hpp
+++ b/include/pclomp/ndt_omp_impl.hpp
@@ -208,7 +208,7 @@ pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeDerivativ
   std::vector<std::vector<float>> distancess(num_threads_);
 
 	// Update gradient and hessian for each point, line 17 in Algorithm 2 [Magnusson 2009]
-#pragma omp parallel for num_threads(num_threads_) schedule(guided, 8)
+#pragma omp parallel for simd num_threads(num_threads_) schedule(guided, 8)
 	for (std::size_t idx = 0; idx < input_->points.size(); idx++)
 	{
 		int thread_n = omp_get_thread_num();


### PR DESCRIPTION
simd適応によるCPU使用率削減の変更。

・確認内容、対象								
autowareの"ndt_scan_matcher"ノードはvendor以下のOSS"ndt_omp"を使用している。								
"ndt_omp"内の下記にてOpen MPによるマルチスレッド処理があり、LSim実行時に呼び出されている。								
									
パス: (autoware_src_path)/vendor/ndt_omp/include/pclomp/ndt_omp_impl.hpp								
関数名 :  pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeDerivatives()								
 コード : 								
` #pragma omp parallel for num_threads(num_threads_) schedule(guided, 8)		`						
							
上記Open MP使用箇所にSIMD構文を追加し、"ndt_scan_matcher"のCPU使用率の測定を実施した。								
									
`#pragma omp parallel for simd num_threads(num_threads_) schedule(guided, 8)			`					
									
・確認結果								
SIMD適応により、nod_scan_matcherのCPU使用率が最大値で300%、平均値で20%ほど減少していることを確認した。								

確認結果の詳細は下記JiraチケットのEvidenceに添付している。
https://tier4.atlassian.net/browse/T4PB-11264