### PR TITLE
Support general SIMD instruction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.5)
 project(ndt_omp)
 
+add_definitions(-std=c++14)
+set(CMAKE_CXX_FLAGS "-std=c++14")
 add_compile_options(-march=native)
 
 # pcl 1.7 causes a segfault when it is built with debug mode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(ndt_omp)
 
-# should use march=native ?
-add_definitions(-std=c++14 -msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2)
-set(CMAKE_CXX_FLAGS "-std=c++14 -msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2")
+add_compile_options(-march=native)
 
 # pcl 1.7 causes a segfault when it is built with debug mode
 set(CMAKE_BUILD_TYPE "RELEASE")

--- a/include/pclomp/ndt_omp.h
+++ b/include/pclomp/ndt_omp.h
@@ -228,7 +228,7 @@ namespace pclomp
 		}
 
 		/** \brief Return the transformation array */
-		inline const std::vector<Eigen::Matrix4f>
+		inline const std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f>>
 			getFinalTransformationArray() const
 		{
 			return transformation_array_;
@@ -522,7 +522,7 @@ namespace pclomp
     int num_threads_;
 
 	Eigen::Matrix<double, 6, 6> hessian_;
-	std::vector<Eigen::Matrix4f> transformation_array_;
+	std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f>> transformation_array_;
 
 	public:
 		NeighborSearchMethod search_method;


### PR DESCRIPTION
Making ndt_omp independent to the SIMD architecture

* using compiler flag -march=native, instead of using sse flags immediately.
* using aligned allocation std::vector of Eigen::Matrix