### PR TITLE
add compile flag to change compile options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,12 @@ project(ndt_omp)
 add_definitions(-std=c++14)
 set(CMAKE_CXX_FLAGS "-std=c++14")
 
-if (BUILD_WITH_MARCH_NATIVE)
-  add_compile_options(-march=native)
+if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
+  if(BUILD_WITH_MARCH_NATIVE)
+    add_compile_options(-march=native)
+  endif()
 else()
-  add_definitions(-msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2)
-  set(CMAKE_CXX_FLAGS "-msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2")
+  add_compile_options(-msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2)
 endif()
 
 # pcl 1.7 causes a segfault when it is built with debug mode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,12 +4,17 @@ project(ndt_omp)
 add_definitions(-std=c++14)
 set(CMAKE_CXX_FLAGS "-std=c++14")
 
-if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
+# Compile flags for SIMD instructions
+if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64")
+  # For x86_64 architecture, SIMD instruction set is fixed below versions,
+  add_compile_options(-msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2)
+else()
+  # For other architecture, like arm64, compile flags are generally prepared by compiler
+  # march=native is disabled as default for specific depending pcl libraries
+  # or pre-building packages for other computers.
   if(BUILD_WITH_MARCH_NATIVE)
     add_compile_options(-march=native)
   endif()
-else()
-  add_compile_options(-msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2)
 endif()
 
 # pcl 1.7 causes a segfault when it is built with debug mode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,13 @@ project(ndt_omp)
 
 add_definitions(-std=c++14)
 set(CMAKE_CXX_FLAGS "-std=c++14")
-add_compile_options(-march=native)
+
+if (BUILD_WITH_MARCH_NATIVE)
+  add_compile_options(-march=native)
+else()
+  add_definitions(-msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2)
+  set(CMAKE_CXX_FLAGS "-msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2")
+endif()
 
 # pcl 1.7 causes a segfault when it is built with debug mode
 set(CMAKE_BUILD_TYPE "RELEASE")


### PR DESCRIPTION
Added compiler flags to avoid problems related to optimization flags when generating binaries on the server.

Related link:
https://star4.slack.com/archives/C017VB9UG1L/p1647489698477679
https://github.com/koide3/ndt_omp/pull/44#issuecomment-1019079452

Signed-off-by: Keisuke Shima <19993104+KeisukeShima@users.noreply.github.com>