### PR TITLE
rename likelihood

### DIFF
--- a/include/pclomp/ndt_omp.h
+++ b/include/pclomp/ndt_omp.h
@@ -214,9 +214,9 @@ namespace pclomp
 		}
 
 		inline double
-			getNearestVoxelTransformationProbability() const
+			getNearestVoxelTransformationLikelihood() const
 		{
-			return nearest_voxel_transformation_probability_;
+			return nearest_voxel_transformation_likelihood_;
 		}
 
 		/** \brief Get the number of iterations required to calculate alignment.
@@ -271,7 +271,7 @@ namespace pclomp
 		// lower is better
 		double calculateScore(const PointCloudSource& cloud) const;
 		double calculateTransformationProbability(const PointCloudSource& cloud) const;
-		double calculateNearestVoxelTransformationProbability(const PointCloudSource& cloud) const;
+		double calculateNearestVoxelTransformationLikelihood(const PointCloudSource& cloud) const;
 
 		inline void setRegularizationScaleFactor(float regularization_scale_factor)
 		{
@@ -548,7 +548,7 @@ namespace pclomp
 
 	Eigen::Matrix<double, 6, 6> hessian_;
 	std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f>> transformation_array_;
-	double nearest_voxel_transformation_probability_;
+	double nearest_voxel_transformation_likelihood_;
 
 	float regularization_scale_factor_;
 	boost::optional<Eigen::Matrix4f> regularization_pose_;

--- a/include/pclomp/ndt_omp_impl.hpp
+++ b/include/pclomp/ndt_omp_impl.hpp
@@ -358,10 +358,10 @@ pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeDerivativ
 	}
 
   if (found_neigborhood_voxel_num != 0) {
-    nearest_voxel_transformation_probability_ = nearest_voxel_score / static_cast<double>(found_neigborhood_voxel_num);
+    nearest_voxel_transformation_likelihood_ = nearest_voxel_score / static_cast<double>(found_neigborhood_voxel_num);
   }
   else {
-    nearest_voxel_transformation_probability_ = 0.0;
+    nearest_voxel_transformation_likelihood_ = 0.0;
   }
 
 	return (score);
@@ -1124,7 +1124,7 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::calculate
 }
 
 template<typename PointSource, typename PointTarget>
-double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::calculateNearestVoxelTransformationProbability(const PointCloudSource & trans_cloud) const
+double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::calculateNearestVoxelTransformationLikelihood(const PointCloudSource & trans_cloud) const
 {
   double nearest_voxel_score = 0;
   size_t found_neigborhood_voxel_num = 0;


### PR DESCRIPTION
Signed-off-by: YamatoAndo <yamato.ando@gmail.com>

rename `NearestVoxelTransformationProbability` to `NearestVoxelTransformationLikelihood`
related PR: https://github.com/autowarefoundation/autoware.universe/pull/364
