### PR TITLE
add execute_scan_matching function

### DIFF
--- a/include/pclomp/ndt_omp.h
+++ b/include/pclomp/ndt_omp.h
@@ -65,6 +65,7 @@ namespace pclomp
 		float nearest_voxel_transformation_likelihood;
 		int iteration_num;
 		std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f>> transformation_array;
+		EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 	};
 
 
@@ -298,11 +299,8 @@ namespace pclomp
 			regularization_pose_ = boost::none;
 		}
 
-		NdtResult executeScanMatching(Eigen::Matrix4f initial_pose_matrix)
+		NdtResult getResult()
 		{
-			auto output_cloud = std::make_shared<pcl::PointCloud<PointSource>>();
-			this->align(*output_cloud, initial_pose_matrix);
-
 			NdtResult ndt_result;
 			ndt_result.pose = this->getFinalTransformation();
 			ndt_result.transformation_array = getFinalTransformationArray();

--- a/include/pclomp/ndt_omp.h
+++ b/include/pclomp/ndt_omp.h
@@ -58,6 +58,16 @@ namespace pclomp
 		DIRECT1
 	};
 
+	struct NdtResult
+	{
+		Eigen::Matrix4f pose;
+		float transform_probability;
+		float nearest_voxel_transformation_likelihood;
+		int iteration_num;
+		std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f>> transformation_array;
+	};
+
+
 	/** \brief A 3D Normal Distribution Transform registration implementation for point cloud data.
 	  * \note For more information please see
 	  * <b>Magnusson, M. (2009). The Three-Dimensional Normal-Distributions Transform —
@@ -286,6 +296,21 @@ namespace pclomp
 		inline void unsetRegularizationPose()
 		{
 			regularization_pose_ = boost::none;
+		}
+
+		NdtResult executeScanMatching(Eigen::Matrix4f initial_pose_matrix)
+		{
+			auto output_cloud = std::make_shared<pcl::PointCloud<PointSource>>();
+			this->align(*output_cloud, initial_pose_matrix);
+
+			NdtResult ndt_result;
+			ndt_result.pose = this->getFinalTransformation();
+			ndt_result.transformation_array = getFinalTransformationArray();
+			ndt_result.transform_probability = getTransformationProbability();
+			ndt_result.nearest_voxel_transformation_likelihood =
+				getNearestVoxelTransformationLikelihood();
+			ndt_result.iteration_num = getFinalNumIteration();
+			return ndt_result;
 		}
 
 	protected:


### PR DESCRIPTION
See the description at https://github.com/autowarefoundation/autoware.universe/pull/2199

I would like to add a new interface for scan matching in ndt_omp. I propose to create a new class `NdtResult` that stores all the information which is necessary to probe the NDT scan matching results.

NOTE: The above PR would not pass the CI test until this PR is merged into `tier4/main` branch.