### PR TITLE
fix(multigrid_ndt_omp_impl): changed counting timing and break confition for `nr_iterations`

### DIFF
--- a/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp
+++ b/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp
@@ -185,14 +185,13 @@ pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::compute
     if (update_visualizer_ != 0)
       update_visualizer_ (output, std::vector<int>(), *target_, std::vector<int>() );
 
-    if (nr_iterations_ > max_iterations_ ||
+    nr_iterations_++;
+
+    if (nr_iterations_ >= max_iterations_ ||
         (nr_iterations_ && (std::fabs (delta_p_norm) < transformation_epsilon_)))
     {
       converged_ = true;
     }
-
-    nr_iterations_++;
-
   }
 
   // Store transformation probability. The relative differences within each scan registration are accurate


### PR DESCRIPTION
changed counting timing and break confition for `nr_iterations`

to be the same as the original pcl ndt.hpp.

https://github.com/PointCloudLibrary/pcl/blob/424c1c6a0ca97d94ca63e5daff4b183a4db8aae4/registration/include/pcl/registration/impl/ndt.hpp#L73-L180

## Evaluation
I degraded the accuracy of the localization and set NDT to run at its maximum iterations, then ran Autoware.

(The value of the nr_iterations result is now also logged.)

#### Before

```
1697693397.9528966 [ndt_scan_matcher-32] [33m[WARN 1697693397.950331137] [localization.pose_estimator.ndt_scan_matcher]: The number of iterations has reached its upper limit. The number of iterations: 32, Limit: 32 (validate_num_iteration() at /home/shintarosakoda/autoware/src/universe/autoware.universe/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp:667)[0m
1697693397.9645364 [ndt_scan_matcher-32] [33m[WARN 1697693397.950700494] [localization.pose_estimator.ndt_scan_matcher]: ndt_result.iteration_num = 32 (callback_sensor_points() at /home/shintarosakoda/autoware/src/universe/autoware.universe/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp:470)[0m
1697693397.9658964 [ndt_scan_matcher-32] [33m[WARN 1697693397.950753594] [localization.pose_estimator.ndt_scan_matcher]: Nearest Voxel Transformation Likelihood is below the threshold. Score: 2.252171, Threshold: 2.300000 (validate_score() at /home/shintarosakoda/autoware/src/universe/autoware.universe/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp:681)[0m
1697693397.9663808 [ndt_scan_matcher-32] [33m[WARN 1697693397.950843704] [localization.pose_estimator.ndt_scan_matcher]: Not Converged (callback_sensor_points() at /home/shintarosakoda/autoware/src/universe/autoware.universe/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp:479)[0m
1697693398.1865647 [ndt_scan_matcher-32] [33m[WARN 1697693398.184562626] [localization.pose_estimator.ndt_scan_matcher]: The number of iterations has reached its upper limit. The number of iterations: 32, Limit: 32 (validate_num_iteration() at /home/shintarosakoda/autoware/src/universe/autoware.universe/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp:667)[0m
1697693398.1926742 [ndt_scan_matcher-32] [33m[WARN 1697693398.189360289] [localization.pose_estimator.ndt_scan_matcher]: ndt_result.iteration_num = 32 (callback_sensor_points() at /home/shintarosakoda/autoware/src/universe/autoware.universe/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp:470)[0m
1697693398.1938219 [ndt_scan_matcher-32] [33m[WARN 1697693398.189526006] [localization.pose_estimator.ndt_scan_matcher]: Nearest Voxel Transformation Likelihood is below the threshold. Score: 2.273700, Threshold: 2.300000 (validate_score() at /home/shintarosakoda/autoware/src/universe/autoware.universe/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp:681)[0m
```

The maximum value for `ndt_result.iteration_num` is 32.

#### After
```
1697693659.0905447 [ndt_scan_matcher-32] [33m[WARN 1697693659.079994469] [localization.pose_estimator.ndt_scan_matcher]: Not Converged (callback_sensor_points() at /home/shintarosakoda/autoware/src/universe/autoware.universe/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp:479)[0m
1697693659.4372418 [ndt_scan_matcher-32] [33m[WARN 1697693659.434358792] [localization.pose_estimator.ndt_scan_matcher]: ndt_result.iteration_num = 30 (callback_sensor_points() at /home/shintarosakoda/autoware/src/universe/autoware.universe/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp:470)[0m
1697693659.4378357 [ndt_scan_matcher-32] [33m[WARN 1697693659.434570744] [localization.pose_estimator.ndt_scan_matcher]: Nearest Voxel Transformation Likelihood is below the threshold. Score: 2.298781, Threshold: 2.300000 (validate_score() at /home/shintarosakoda/autoware/src/universe/autoware.universe/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp:681)[0m
1697693659.4379599 [ndt_scan_matcher-32] [33m[WARN 1697693659.434605390] [localization.pose_estimator.ndt_scan_matcher]: Not Converged (callback_sensor_points() at /home/shintarosakoda/autoware/src/universe/autoware.universe/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp:479)[0m
1697693659.6430864 [ndt_scan_matcher-32] [33m[WARN 1697693659.641192762] [localization.pose_estimator.ndt_scan_matcher]: ndt_result.iteration_num = 30 (callback_sensor_points() at /home/shintarosakoda/autoware/src/universe/autoware.universe/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp:470)[0m

```

The maximum value for `ndt_result.iteration_num` is 30.
