### PR TITLE
fix: clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -92,10 +92,11 @@ PenaltyBreakString: 1000
 PenaltyExcessCharacter: 0
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Left
-RawStringFormats: 
-  - Delimiter:       pb
-    Language:        TextProto
-    BasedOnStyle:    google
+RawStringFormats:
+  - Language: TextProto
+    Delimiters:
+      - pb
+    BasedOnStyle: google
 ReflowComments:  true
 SortIncludes:    false
 SortUsingDeclarations: false


### PR DESCRIPTION
Fixed clang-format

It is already fixed in upstream repositroy.
* https://github.com/koide3/ndt_omp/pull/56