### PR TITLE
refactor: Applied formatter

### DIFF
--- a/apps/align.cpp
+++ b/apps/align.cpp
@@ -12,7 +12,7 @@
 #include <pclomp/gicp_omp.h>
 
 // align point clouds and measure processing time
-pcl::PointCloud<pcl::PointXYZ>::Ptr align(pcl::Registration<pcl::PointXYZ, pcl::PointXYZ>::Ptr registration, const pcl::PointCloud<pcl::PointXYZ>::Ptr& target_cloud, const pcl::PointCloud<pcl::PointXYZ>::Ptr& source_cloud ) {
+pcl::PointCloud<pcl::PointXYZ>::Ptr align(pcl::Registration<pcl::PointXYZ, pcl::PointXYZ>::Ptr registration, const pcl::PointCloud<pcl::PointXYZ>::Ptr& target_cloud, const pcl::PointCloud<pcl::PointXYZ>::Ptr& source_cloud) {
   registration->setInputTarget(target_cloud);
   registration->setInputSource(source_cloud);
   pcl::PointCloud<pcl::PointXYZ>::Ptr aligned(new pcl::PointCloud<pcl::PointXYZ>());
@@ -22,7 +22,7 @@ pcl::PointCloud<pcl::PointXYZ>::Ptr align(pcl::Registration<pcl::PointXYZ, pcl::
   auto t2 = ros::WallTime::now();
   std::cout << "single : " << (t2 - t1).toSec() * 1000 << "[msec]" << std::endl;
 
-  for(int i=0; i<10; i++) {
+  for(int i = 0; i < 10; i++) {
     registration->align(*aligned);
   }
   auto t3 = ros::WallTime::now();
@@ -31,7 +31,6 @@ pcl::PointCloud<pcl::PointXYZ>::Ptr align(pcl::Registration<pcl::PointXYZ, pcl::
 
   return aligned;
 }
-
 
 int main(int argc, char** argv) {
   if(argc != 3) {
@@ -79,18 +78,13 @@ int main(int argc, char** argv) {
   pclomp::GeneralizedIterativeClosestPoint<pcl::PointXYZ, pcl::PointXYZ>::Ptr gicp_omp(new pclomp::GeneralizedIterativeClosestPoint<pcl::PointXYZ, pcl::PointXYZ>());
   aligned = align(gicp_omp, target_cloud, source_cloud);
 
-
   std::cout << "--- pcl::NDT ---" << std::endl;
   pcl::NormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>::Ptr ndt(new pcl::NormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>());
   ndt->setResolution(1.0);
   aligned = align(ndt, target_cloud, source_cloud);
 
   std::vector<int> num_threads = {1, omp_get_max_threads()};
-  std::vector<std::pair<std::string, pclomp::NeighborSearchMethod>> search_methods = {
-    {"KDTREE", pclomp::KDTREE},
-    {"DIRECT7", pclomp::DIRECT7},
-    {"DIRECT1", pclomp::DIRECT1}
-  };
+  std::vector<std::pair<std::string, pclomp::NeighborSearchMethod>> search_methods = {{"KDTREE", pclomp::KDTREE}, {"DIRECT7", pclomp::DIRECT7}, {"DIRECT1", pclomp::DIRECT1}};
 
   pclomp::NormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>::Ptr ndt_omp(new pclomp::NormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>());
   ndt_omp->setResolution(1.0);

--- a/include/multigrid_pclomp/multi_voxel_grid_covariance_omp.h
+++ b/include/multigrid_pclomp/multi_voxel_grid_covariance_omp.h
@@ -61,355 +61,297 @@
 #include <pcl/kdtree/kdtree_flann.h>
 #include <Eigen/Dense>
 #include <Eigen/Cholesky>
-namespace pclomp
-{
-  /** \brief A searchable voxel structure containing the mean and covariance of the data.
-    * \note For more information please see
-    * <b>Magnusson, M. (2009). The Three-Dimensional Normal-Distributions Transform —
-    * an Efficient Representation for Registration, Surface Analysis, and Loop Detection.
-    * PhD thesis, Orebro University. Orebro Studies in Technology 36</b>
-    * \author Brian Okorn (Space and Naval Warfare Systems Center Pacific)
-    */
-  template<typename PointT>
-  class MultiVoxelGridCovariance : public pcl::VoxelGrid<PointT>
-  {
-    protected:
-      using pcl::VoxelGrid<PointT>::filter_name_;
-      using pcl::VoxelGrid<PointT>::getClassName;
-      using pcl::VoxelGrid<PointT>::input_;
-      using pcl::VoxelGrid<PointT>::indices_;
-      using pcl::VoxelGrid<PointT>::filter_limit_negative_;
-      using pcl::VoxelGrid<PointT>::filter_limit_min_;
-      using pcl::VoxelGrid<PointT>::filter_limit_max_;
+namespace pclomp {
+/** \brief A searchable voxel structure containing the mean and covariance of the data.
+ * \note For more information please see
+ * <b>Magnusson, M. (2009). The Three-Dimensional Normal-Distributions Transform —
+ * an Efficient Representation for Registration, Surface Analysis, and Loop Detection.
+ * PhD thesis, Orebro University. Orebro Studies in Technology 36</b>
+ * \author Brian Okorn (Space and Naval Warfare Systems Center Pacific)
+ */
+template<typename PointT>
+class MultiVoxelGridCovariance : public pcl::VoxelGrid<PointT> {
+protected:
+  using pcl::VoxelGrid<PointT>::filter_name_;
+  using pcl::VoxelGrid<PointT>::getClassName;
+  using pcl::VoxelGrid<PointT>::input_;
+  using pcl::VoxelGrid<PointT>::indices_;
+  using pcl::VoxelGrid<PointT>::filter_limit_negative_;
+  using pcl::VoxelGrid<PointT>::filter_limit_min_;
+  using pcl::VoxelGrid<PointT>::filter_limit_max_;
 
-      // using pcl::VoxelGrid<PointT>::downsample_all_data_;
-      using pcl::VoxelGrid<PointT>::leaf_size_;
-      using pcl::VoxelGrid<PointT>::min_b_;
-      using pcl::VoxelGrid<PointT>::max_b_;
-      using pcl::VoxelGrid<PointT>::inverse_leaf_size_;
-      using pcl::VoxelGrid<PointT>::div_b_;
-      using pcl::VoxelGrid<PointT>::divb_mul_;
+  // using pcl::VoxelGrid<PointT>::downsample_all_data_;
+  using pcl::VoxelGrid<PointT>::leaf_size_;
+  using pcl::VoxelGrid<PointT>::min_b_;
+  using pcl::VoxelGrid<PointT>::max_b_;
+  using pcl::VoxelGrid<PointT>::inverse_leaf_size_;
+  using pcl::VoxelGrid<PointT>::div_b_;
+  using pcl::VoxelGrid<PointT>::divb_mul_;
 
-      typedef typename pcl::traits::fieldList<PointT>::type FieldList;
-      typedef typename pcl::Filter<PointT>::PointCloud PointCloud;
-      typedef typename PointCloud::Ptr PointCloudPtr;
-      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+  typedef typename pcl::traits::fieldList<PointT>::type FieldList;
+  typedef typename pcl::Filter<PointT>::PointCloud PointCloud;
+  typedef typename PointCloud::Ptr PointCloudPtr;
+  typedef typename PointCloud::ConstPtr PointCloudConstPtr;
 
-    public:
-
+public:
 #if PCL_VERSION >= PCL_VERSION_CALC(1, 10, 0)
-      typedef pcl::shared_ptr< pcl::VoxelGrid<PointT> > Ptr;
-      typedef pcl::shared_ptr< const pcl::VoxelGrid<PointT> > ConstPtr;
+  typedef pcl::shared_ptr<pcl::VoxelGrid<PointT> > Ptr;
+  typedef pcl::shared_ptr<const pcl::VoxelGrid<PointT> > ConstPtr;
 #else
-      typedef boost::shared_ptr< pcl::VoxelGrid<PointT> > Ptr;
-      typedef boost::shared_ptr< const pcl::VoxelGrid<PointT> > ConstPtr;
+  typedef boost::shared_ptr<pcl::VoxelGrid<PointT> > Ptr;
+  typedef boost::shared_ptr<const pcl::VoxelGrid<PointT> > ConstPtr;
 #endif
 
-      /** \brief Simple structure to hold a centroid, covariance and the number of points in a leaf.
-        * Inverse covariance, eigen vectors and eigen values are precomputed. */
-      struct Leaf
-      {
-        /** \brief Constructor.
-         * Sets \ref nr_points, \ref icov_, \ref mean_ and \ref evals_ to 0 and \ref cov_ and \ref evecs_ to the identity matrix
-         */
-        Leaf () :
-          nr_points (0),
-          mean_ (Eigen::Vector3d::Zero ()),
-          centroid (),
-          cov_ (Eigen::Matrix3d::Identity ()),
-          icov_ (Eigen::Matrix3d::Zero ()),
-          evecs_ (Eigen::Matrix3d::Identity ()),
-          evals_ (Eigen::Vector3d::Zero ())
-        {
-        }
+  /** \brief Simple structure to hold a centroid, covariance and the number of points in a leaf.
+   * Inverse covariance, eigen vectors and eigen values are precomputed. */
+  struct Leaf {
+    /** \brief Constructor.
+     * Sets \ref nr_points, \ref icov_, \ref mean_ and \ref evals_ to 0 and \ref cov_ and \ref evecs_ to the identity matrix
+     */
+    Leaf() : nr_points(0), mean_(Eigen::Vector3d::Zero()), centroid(), cov_(Eigen::Matrix3d::Identity()), icov_(Eigen::Matrix3d::Zero()), evecs_(Eigen::Matrix3d::Identity()), evals_(Eigen::Vector3d::Zero()) {}
 
-        /** \brief Get the voxel covariance.
-          * \return covariance matrix
-          */
-        Eigen::Matrix3d
-        getCov () const
-        {
-          return (cov_);
-        }
+    /** \brief Get the voxel covariance.
+     * \return covariance matrix
+     */
+    Eigen::Matrix3d getCov() const {
+      return (cov_);
+    }
 
-        /** \brief Get the inverse of the voxel covariance.
-          * \return inverse covariance matrix
-          */
-        Eigen::Matrix3d
-        getInverseCov () const
-        {
-          return (icov_);
-        }
+    /** \brief Get the inverse of the voxel covariance.
+     * \return inverse covariance matrix
+     */
+    Eigen::Matrix3d getInverseCov() const {
+      return (icov_);
+    }
 
-        /** \brief Get the voxel centroid.
-          * \return centroid
-          */
-        Eigen::Vector3d
-        getMean () const
-        {
-          return (mean_);
-        }
+    /** \brief Get the voxel centroid.
+     * \return centroid
+     */
+    Eigen::Vector3d getMean() const {
+      return (mean_);
+    }
 
-        /** \brief Get the eigen vectors of the voxel covariance.
-          * \note Order corresponds with \ref getEvals
-          * \return matrix whose columns contain eigen vectors
-          */
-        Eigen::Matrix3d
-        getEvecs () const
-        {
-          return (evecs_);
-        }
+    /** \brief Get the eigen vectors of the voxel covariance.
+     * \note Order corresponds with \ref getEvals
+     * \return matrix whose columns contain eigen vectors
+     */
+    Eigen::Matrix3d getEvecs() const {
+      return (evecs_);
+    }
 
-        /** \brief Get the eigen values of the voxel covariance.
-          * \note Order corresponds with \ref getEvecs
-          * \return vector of eigen values
-          */
-        Eigen::Vector3d
-        getEvals () const
-        {
-          return (evals_);
-        }
+    /** \brief Get the eigen values of the voxel covariance.
+     * \note Order corresponds with \ref getEvecs
+     * \return vector of eigen values
+     */
+    Eigen::Vector3d getEvals() const {
+      return (evals_);
+    }
 
-        /** \brief Get the number of points contained by this voxel.
-          * \return number of points
-          */
-        int
-        getPointCount () const
-        {
-          return (nr_points);
-        }
+    /** \brief Get the number of points contained by this voxel.
+     * \return number of points
+     */
+    int getPointCount() const {
+      return (nr_points);
+    }
 
-        /** \brief Number of points contained by voxel */
-        int nr_points;
+    /** \brief Number of points contained by voxel */
+    int nr_points;
 
-        /** \brief 3D voxel centroid */
-        Eigen::Vector3d mean_;
+    /** \brief 3D voxel centroid */
+    Eigen::Vector3d mean_;
 
-        /** \brief Nd voxel centroid
-         * \note Differs from \ref mean_ when color data is used
-         */
-        Eigen::VectorXf centroid;
+    /** \brief Nd voxel centroid
+     * \note Differs from \ref mean_ when color data is used
+     */
+    Eigen::VectorXf centroid;
 
-        /** \brief Voxel covariance matrix */
-        Eigen::Matrix3d cov_;
+    /** \brief Voxel covariance matrix */
+    Eigen::Matrix3d cov_;
 
-        /** \brief Inverse of voxel covariance matrix */
-        Eigen::Matrix3d icov_;
+    /** \brief Inverse of voxel covariance matrix */
+    Eigen::Matrix3d icov_;
 
-        /** \brief Eigen vectors of voxel covariance matrix */
-        Eigen::Matrix3d evecs_;
+    /** \brief Eigen vectors of voxel covariance matrix */
+    Eigen::Matrix3d evecs_;
 
-        /** \brief Eigen values of voxel covariance matrix */
-        Eigen::Vector3d evals_;
-
-      };
-
-      struct LeafID {
-        std::string parent_grid_id;
-        int leaf_index;
-        bool operator < (const LeafID& rhs) const {
-          if (parent_grid_id < rhs.parent_grid_id) {
-            return true;
-          }
-          if (parent_grid_id > rhs.parent_grid_id) {
-            return false;
-          }
-          if (leaf_index < rhs.leaf_index) {
-            return true;
-          }
-          if (leaf_index > rhs.leaf_index) {
-            return false;
-          }
-          return false;
-        }
-      };
-
-      /** \brief Pointer to MultiVoxelGridCovariance leaf structure */
-      typedef Leaf* LeafPtr;
-
-      /** \brief Const pointer to MultiVoxelGridCovariance leaf structure */
-      typedef const Leaf* LeafConstPtr;
-
-      typedef std::map<LeafID, Leaf> LeafDict;
-
-      struct BoundingBox
-      {
-        Eigen::Vector4i max;
-        Eigen::Vector4i min;
-        Eigen::Vector4i div_mul;
-      };
-
-    public:
-
-      /** \brief Constructor.
-       * Sets \ref leaf_size_ to 0
-       */
-      MultiVoxelGridCovariance () :
-        min_points_per_voxel_ (6),
-        min_covar_eigvalue_mult_ (0.01),
-        leaves_ (),
-        grid_leaves_ (),
-        leaf_indices_ (),
-        kdtree_ ()
-      {
-        leaf_size_.setZero ();
-        min_b_.setZero ();
-        max_b_.setZero ();
-        filter_name_ = "MultiVoxelGridCovariance";
-      }
-
-      /** \brief Initializes voxel structure.
-       */
-      inline void
-      setInputCloudAndFilter (const PointCloudConstPtr &cloud, const std::string &grid_id)
-      {
-        LeafDict leaves;
-        applyFilter (cloud, grid_id, leaves);
-
-        grid_leaves_[grid_id] = leaves;
-      }
-
-      inline void 
-      removeCloud (const std::string &grid_id)
-      {
-        grid_leaves_.erase(grid_id);
-      }
-
-      inline void 
-      createKdtree ()
-      {
-        leaves_.clear();
-        for (const auto &kv: grid_leaves_)
-        {
-          leaves_.insert(kv.second.begin(), kv.second.end());
-        }
-
-        leaf_indices_.clear();
-        voxel_centroids_ptr_.reset(new PointCloud);
-        voxel_centroids_ptr_->height = 1;
-        voxel_centroids_ptr_->is_dense = true;
-        voxel_centroids_ptr_->points.clear();
-        voxel_centroids_ptr_->points.reserve(leaves_.size ());
-        for (const auto & element: leaves_)
-        {
-          leaf_indices_.push_back(element.first);
-          voxel_centroids_ptr_->push_back (PointT ());
-          voxel_centroids_ptr_->points.back ().x = element.second.centroid[0];
-          voxel_centroids_ptr_->points.back ().y = element.second.centroid[1];
-          voxel_centroids_ptr_->points.back ().z = element.second.centroid[2];
-        }
-        voxel_centroids_ptr_->width = static_cast<uint32_t> (voxel_centroids_ptr_->points.size ());
-
-        if (voxel_centroids_ptr_->size() > 0)
-        {
-          kdtree_.setInputCloud (voxel_centroids_ptr_);
-        }
-      }
-
-      /** \brief Search for all the nearest occupied voxels of the query point in a given radius.
-       * \note Only voxels containing a sufficient number of points are used.
-       * \param[in] point the given query point
-       * \param[in] radius the radius of the sphere bounding all of p_q's neighbors
-       * \param[out] k_leaves the resultant leaves of the neighboring points
-       * \param[out] k_sqr_distances the resultant squared distances to the neighboring points
-       * \param[in] max_nn
-       * \return number of neighbors found
-       */
-      int
-      radiusSearch (const PointT &point, double radius, std::vector<LeafConstPtr> &k_leaves,
-                    std::vector<float> &k_sqr_distances, unsigned int max_nn = 0) const
-      {
-        k_leaves.clear ();
-
-        // Find neighbors within radius in the occupied voxel centroid cloud
-        std::vector<int> k_indices;
-        int k = kdtree_.radiusSearch (point, radius, k_indices, k_sqr_distances, max_nn);
-
-        // Find leaves corresponding to neighbors
-        k_leaves.reserve (k);
-        for (std::vector<int>::iterator iter = k_indices.begin (); iter != k_indices.end (); iter++)
-        {
-          auto leaf = leaves_.find(leaf_indices_[*iter]);
-          if (leaf == leaves_.end()) {
-            std::cerr << "error : could not find the leaf corresponding to the voxel" << std::endl;
-            std::cin.ignore(1);
-          }
-          k_leaves.push_back (&(leaf->second));
-        }
-        return k;
-      }
-
-      /** \brief Search for all the nearest occupied voxels of the query point in a given radius.
-       * \note Only voxels containing a sufficient number of points are used.
-       * \param[in] cloud the given query point
-       * \param[in] index a valid index in cloud representing a valid (i.e., finite) query point
-       * \param[in] radius the radius of the sphere bounding all of p_q's neighbors
-       * \param[out] k_leaves the resultant leaves of the neighboring points
-       * \param[out] k_sqr_distances the resultant squared distances to the neighboring points
-       * \param[in] max_nn
-       * \return number of neighbors found
-       */
-      inline int
-      radiusSearch (const PointCloud &cloud, int index, double radius,
-                    std::vector<LeafConstPtr> &k_leaves, std::vector<float> &k_sqr_distances,
-                    unsigned int max_nn = 0) const
-      {
-        if (index >= static_cast<int> (cloud.points.size ()) || index < 0)
-          return (0);
-        return (radiusSearch (cloud.points[index], radius, k_leaves, k_sqr_distances, max_nn));
-      }
-
-      PointCloud getVoxelPCD () const
-      {
-        return *voxel_centroids_ptr_;
-      }
-
-  		std::vector<std::string> getCurrentMapIDs() const
-      {
-        std::vector<std::string> output{};
-        for (const auto &element: grid_leaves_) {
-          output.push_back(element.first);
-        }
-        return output;
-      }
-
-    protected:
-
-      /** \brief Filter cloud and initializes voxel structure.
-       * \param[out] output cloud containing centroids of voxels containing a sufficient number of points
-       */
-      void applyFilter (const PointCloudConstPtr &input, const std::string &grid_id, LeafDict &leaves) const;
-
-      void updateVoxelCentroids (const Leaf &leaf, PointCloud &voxel_centroids) const;
-
-      void updateLeaf (const PointT &point, const int &centroid_size, Leaf &leaf) const;
-
-      void computeLeafParams (const Eigen::Vector3d &pt_sum,
-        Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> &eigensolver,
-        Leaf &leaf) const;
-
-      LeafID getLeafID (const std::string &grid_id, const PointT &point, const BoundingBox &bbox) const;
-
-      /** \brief Minimum points contained with in a voxel to allow it to be usable. */
-      int min_points_per_voxel_;
-
-      /** \brief Minimum allowable ratio between eigenvalues to prevent singular covariance matrices. */
-      double min_covar_eigvalue_mult_;
-
-      /** \brief Voxel structure containing all leaf nodes (includes voxels with less than a sufficient number of points). */
-	    LeafDict leaves_;
-
-      /** \brief Point cloud containing centroids of voxels containing at least minimum number of points. */
-      std::map<std::string, LeafDict> grid_leaves_;
-
-      /** \brief Indices of leaf structures associated with each point in \ref voxel_centroids_ (used for searching). */
-      std::vector<LeafID> leaf_indices_;
-
-      /** \brief KdTree generated using \ref voxel_centroids_ (used for searching). */
-      pcl::KdTreeFLANN<PointT> kdtree_;
-
-      PointCloudPtr voxel_centroids_ptr_;
+    /** \brief Eigen values of voxel covariance matrix */
+    Eigen::Vector3d evals_;
   };
-}
 
-#endif  //#ifndef PCL_MULTI_VOXEL_GRID_COVARIANCE_H_
+  struct LeafID {
+    std::string parent_grid_id;
+    int leaf_index;
+    bool operator<(const LeafID &rhs) const {
+      if(parent_grid_id < rhs.parent_grid_id) {
+        return true;
+      }
+      if(parent_grid_id > rhs.parent_grid_id) {
+        return false;
+      }
+      if(leaf_index < rhs.leaf_index) {
+        return true;
+      }
+      if(leaf_index > rhs.leaf_index) {
+        return false;
+      }
+      return false;
+    }
+  };
+
+  /** \brief Pointer to MultiVoxelGridCovariance leaf structure */
+  typedef Leaf *LeafPtr;
+
+  /** \brief Const pointer to MultiVoxelGridCovariance leaf structure */
+  typedef const Leaf *LeafConstPtr;
+
+  typedef std::map<LeafID, Leaf> LeafDict;
+
+  struct BoundingBox {
+    Eigen::Vector4i max;
+    Eigen::Vector4i min;
+    Eigen::Vector4i div_mul;
+  };
+
+public:
+  /** \brief Constructor.
+   * Sets \ref leaf_size_ to 0
+   */
+  MultiVoxelGridCovariance() : min_points_per_voxel_(6), min_covar_eigvalue_mult_(0.01), leaves_(), grid_leaves_(), leaf_indices_(), kdtree_() {
+    leaf_size_.setZero();
+    min_b_.setZero();
+    max_b_.setZero();
+    filter_name_ = "MultiVoxelGridCovariance";
+  }
+
+  /** \brief Initializes voxel structure.
+   */
+  inline void setInputCloudAndFilter(const PointCloudConstPtr &cloud, const std::string &grid_id) {
+    LeafDict leaves;
+    applyFilter(cloud, grid_id, leaves);
+
+    grid_leaves_[grid_id] = leaves;
+  }
+
+  inline void removeCloud(const std::string &grid_id) {
+    grid_leaves_.erase(grid_id);
+  }
+
+  inline void createKdtree() {
+    leaves_.clear();
+    for(const auto &kv : grid_leaves_) {
+      leaves_.insert(kv.second.begin(), kv.second.end());
+    }
+
+    leaf_indices_.clear();
+    voxel_centroids_ptr_.reset(new PointCloud);
+    voxel_centroids_ptr_->height = 1;
+    voxel_centroids_ptr_->is_dense = true;
+    voxel_centroids_ptr_->points.clear();
+    voxel_centroids_ptr_->points.reserve(leaves_.size());
+    for(const auto &element : leaves_) {
+      leaf_indices_.push_back(element.first);
+      voxel_centroids_ptr_->push_back(PointT());
+      voxel_centroids_ptr_->points.back().x = element.second.centroid[0];
+      voxel_centroids_ptr_->points.back().y = element.second.centroid[1];
+      voxel_centroids_ptr_->points.back().z = element.second.centroid[2];
+    }
+    voxel_centroids_ptr_->width = static_cast<uint32_t>(voxel_centroids_ptr_->points.size());
+
+    if(voxel_centroids_ptr_->size() > 0) {
+      kdtree_.setInputCloud(voxel_centroids_ptr_);
+    }
+  }
+
+  /** \brief Search for all the nearest occupied voxels of the query point in a given radius.
+   * \note Only voxels containing a sufficient number of points are used.
+   * \param[in] point the given query point
+   * \param[in] radius the radius of the sphere bounding all of p_q's neighbors
+   * \param[out] k_leaves the resultant leaves of the neighboring points
+   * \param[out] k_sqr_distances the resultant squared distances to the neighboring points
+   * \param[in] max_nn
+   * \return number of neighbors found
+   */
+  int radiusSearch(const PointT &point, double radius, std::vector<LeafConstPtr> &k_leaves, std::vector<float> &k_sqr_distances, unsigned int max_nn = 0) const {
+    k_leaves.clear();
+
+    // Find neighbors within radius in the occupied voxel centroid cloud
+    std::vector<int> k_indices;
+    int k = kdtree_.radiusSearch(point, radius, k_indices, k_sqr_distances, max_nn);
+
+    // Find leaves corresponding to neighbors
+    k_leaves.reserve(k);
+    for(std::vector<int>::iterator iter = k_indices.begin(); iter != k_indices.end(); iter++) {
+      auto leaf = leaves_.find(leaf_indices_[*iter]);
+      if(leaf == leaves_.end()) {
+        std::cerr << "error : could not find the leaf corresponding to the voxel" << std::endl;
+        std::cin.ignore(1);
+      }
+      k_leaves.push_back(&(leaf->second));
+    }
+    return k;
+  }
+
+  /** \brief Search for all the nearest occupied voxels of the query point in a given radius.
+   * \note Only voxels containing a sufficient number of points are used.
+   * \param[in] cloud the given query point
+   * \param[in] index a valid index in cloud representing a valid (i.e., finite) query point
+   * \param[in] radius the radius of the sphere bounding all of p_q's neighbors
+   * \param[out] k_leaves the resultant leaves of the neighboring points
+   * \param[out] k_sqr_distances the resultant squared distances to the neighboring points
+   * \param[in] max_nn
+   * \return number of neighbors found
+   */
+  inline int radiusSearch(const PointCloud &cloud, int index, double radius, std::vector<LeafConstPtr> &k_leaves, std::vector<float> &k_sqr_distances, unsigned int max_nn = 0) const {
+    if(index >= static_cast<int>(cloud.points.size()) || index < 0) return (0);
+    return (radiusSearch(cloud.points[index], radius, k_leaves, k_sqr_distances, max_nn));
+  }
+
+  PointCloud getVoxelPCD() const {
+    return *voxel_centroids_ptr_;
+  }
+
+  std::vector<std::string> getCurrentMapIDs() const {
+    std::vector<std::string> output{};
+    for(const auto &element : grid_leaves_) {
+      output.push_back(element.first);
+    }
+    return output;
+  }
+
+protected:
+  /** \brief Filter cloud and initializes voxel structure.
+   * \param[out] output cloud containing centroids of voxels containing a sufficient number of points
+   */
+  void applyFilter(const PointCloudConstPtr &input, const std::string &grid_id, LeafDict &leaves) const;
+
+  void updateVoxelCentroids(const Leaf &leaf, PointCloud &voxel_centroids) const;
+
+  void updateLeaf(const PointT &point, const int &centroid_size, Leaf &leaf) const;
+
+  void computeLeafParams(const Eigen::Vector3d &pt_sum, Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> &eigensolver, Leaf &leaf) const;
+
+  LeafID getLeafID(const std::string &grid_id, const PointT &point, const BoundingBox &bbox) const;
+
+  /** \brief Minimum points contained with in a voxel to allow it to be usable. */
+  int min_points_per_voxel_;
+
+  /** \brief Minimum allowable ratio between eigenvalues to prevent singular covariance matrices. */
+  double min_covar_eigvalue_mult_;
+
+  /** \brief Voxel structure containing all leaf nodes (includes voxels with less than a sufficient number of points). */
+  LeafDict leaves_;
+
+  /** \brief Point cloud containing centroids of voxels containing at least minimum number of points. */
+  std::map<std::string, LeafDict> grid_leaves_;
+
+  /** \brief Indices of leaf structures associated with each point in \ref voxel_centroids_ (used for searching). */
+  std::vector<LeafID> leaf_indices_;
+
+  /** \brief KdTree generated using \ref voxel_centroids_ (used for searching). */
+  pcl::KdTreeFLANN<PointT> kdtree_;
+
+  PointCloudPtr voxel_centroids_ptr_;
+};
+}  // namespace pclomp
+
+#endif  // #ifndef PCL_MULTI_VOXEL_GRID_COVARIANCE_H_

--- a/include/multigrid_pclomp/multi_voxel_grid_covariance_omp_impl.hpp
+++ b/include/multigrid_pclomp/multi_voxel_grid_covariance_omp_impl.hpp
@@ -58,62 +58,56 @@
 
 //////////////////////////////////////////////////////////////////////////////////////////
 template<typename PointT>
-void pclomp::MultiVoxelGridCovariance<PointT>::applyFilter (
-  const PointCloudConstPtr &input, const std::string &grid_id, LeafDict &leaves) const
-{
+void pclomp::MultiVoxelGridCovariance<PointT>::applyFilter(const PointCloudConstPtr &input, const std::string &grid_id, LeafDict &leaves) const {
   // Has the input dataset been set already?
-  if (!input)
-  {
-    PCL_WARN ("[pcl::%s::applyFilter] No input dataset given!\n", getClassName ().c_str ());
+  if(!input) {
+    PCL_WARN("[pcl::%s::applyFilter] No input dataset given!\n", getClassName().c_str());
     return;
   }
 
   Eigen::Vector4f min_p, max_p;
-  pcl::getMinMax3D<PointT> (*input, min_p, max_p);
+  pcl::getMinMax3D<PointT>(*input, min_p, max_p);
 
   // Check that the leaf size is not too small, given the size of the data
-  int64_t dx = static_cast<int64_t>((max_p[0] - min_p[0]) * inverse_leaf_size_[0])+1;
-  int64_t dy = static_cast<int64_t>((max_p[1] - min_p[1]) * inverse_leaf_size_[1])+1;
-  int64_t dz = static_cast<int64_t>((max_p[2] - min_p[2]) * inverse_leaf_size_[2])+1;
+  int64_t dx = static_cast<int64_t>((max_p[0] - min_p[0]) * inverse_leaf_size_[0]) + 1;
+  int64_t dy = static_cast<int64_t>((max_p[1] - min_p[1]) * inverse_leaf_size_[1]) + 1;
+  int64_t dz = static_cast<int64_t>((max_p[2] - min_p[2]) * inverse_leaf_size_[2]) + 1;
 
-  if((dx*dy*dz) > std::numeric_limits<int32_t>::max())
-  {
+  if((dx * dy * dz) > std::numeric_limits<int32_t>::max()) {
     PCL_WARN("[pcl::%s::applyFilter] Leaf size is too small for the input dataset. Integer indices would overflow.", getClassName().c_str());
     return;
   }
 
   // Compute the minimum and maximum bounding box values
   BoundingBox bbox;
-  bbox.min[0] = static_cast<int> (floor (min_p[0] * inverse_leaf_size_[0]));
-  bbox.max[0] = static_cast<int> (floor (max_p[0] * inverse_leaf_size_[0]));
-  bbox.min[1] = static_cast<int> (floor (min_p[1] * inverse_leaf_size_[1]));
-  bbox.max[1] = static_cast<int> (floor (max_p[1] * inverse_leaf_size_[1]));
-  bbox.min[2] = static_cast<int> (floor (min_p[2] * inverse_leaf_size_[2]));
-  bbox.max[2] = static_cast<int> (floor (max_p[2] * inverse_leaf_size_[2]));
+  bbox.min[0] = static_cast<int>(floor(min_p[0] * inverse_leaf_size_[0]));
+  bbox.max[0] = static_cast<int>(floor(max_p[0] * inverse_leaf_size_[0]));
+  bbox.min[1] = static_cast<int>(floor(min_p[1] * inverse_leaf_size_[1]));
+  bbox.max[1] = static_cast<int>(floor(max_p[1] * inverse_leaf_size_[1]));
+  bbox.min[2] = static_cast<int>(floor(min_p[2] * inverse_leaf_size_[2]));
+  bbox.max[2] = static_cast<int>(floor(max_p[2] * inverse_leaf_size_[2]));
 
   // Compute the number of divisions needed along all axis
-  Eigen::Vector4i div_b = bbox.max - bbox.min + Eigen::Vector4i::Ones ();
+  Eigen::Vector4i div_b = bbox.max - bbox.min + Eigen::Vector4i::Ones();
   div_b[3] = 0;
 
   // Clear the leaves
-  leaves.clear ();
+  leaves.clear();
   // leaves.reserve(8192);
 
   // Set up the division multiplier
-  bbox.div_mul = Eigen::Vector4i (1, div_b[0], div_b[0] * div_b[1], 0);
+  bbox.div_mul = Eigen::Vector4i(1, div_b[0], div_b[0] * div_b[1], 0);
 
   int centroid_size = 4;
 
   // First pass: go over all points and insert them into the right leaf
-  for (size_t cp = 0; cp < input->points.size (); ++cp)
-  {
-    if (!input->is_dense)
+  for(size_t cp = 0; cp < input->points.size(); ++cp) {
+    if(!input->is_dense)
       // Check if the point is invalid
-      if (!std::isfinite (input->points[cp].x) || !std::isfinite (input->points[cp].y) || !std::isfinite (input->points[cp].z))
-        continue;
+      if(!std::isfinite(input->points[cp].x) || !std::isfinite(input->points[cp].y) || !std::isfinite(input->points[cp].z)) continue;
 
     LeafID leaf_id = getLeafID(grid_id, input->points[cp], bbox);
-    Leaf& leaf = leaves[leaf_id];
+    Leaf &leaf = leaves[leaf_id];
     updateLeaf(input->points[cp], centroid_size, leaf);
   }
 
@@ -125,13 +119,12 @@ void pclomp::MultiVoxelGridCovariance<PointT>::applyFilter (
 
   // Eigen values less than a threshold of max eigen value are inflated to a set fraction of the max eigen value.
   std::vector<LeafID> leaf_ids_to_remove;
-  for (auto it = leaves.begin (); it != leaves.end (); ++it)
-  {
+  for(auto it = leaves.begin(); it != leaves.end(); ++it) {
     // Normalize the centroid
-    Leaf& leaf = it->second;
+    Leaf &leaf = it->second;
 
     // Normalize the centroid
-    leaf.centroid /= static_cast<float> (leaf.nr_points);
+    leaf.centroid /= static_cast<float>(leaf.nr_points);
     // Point sum used for single pass covariance calculation
     pt_sum = leaf.mean_;
     // Normalize mean
@@ -139,40 +132,32 @@ void pclomp::MultiVoxelGridCovariance<PointT>::applyFilter (
 
     // If the voxel contains sufficient points, its covariance is calculated and is added to the voxel centroids and voxel_grid_info.voxel_centroids clouds.
     // Points with less than the minimum points will have a can not be accurately approximated using a normal distribution.
-    if (leaf.nr_points >= min_points_per_voxel_)
-    {
-      computeLeafParams (pt_sum, eigensolver, leaf);
-    }
-    else
-    {
+    if(leaf.nr_points >= min_points_per_voxel_) {
+      computeLeafParams(pt_sum, eigensolver, leaf);
+    } else {
       leaf_ids_to_remove.push_back(it->first);
     }
   }
 
   // Remove leaves that do not have sufficient points
-  for (const LeafID & leaf_id: leaf_ids_to_remove)
-  {
+  for(const LeafID &leaf_id : leaf_ids_to_remove) {
     leaves.erase(leaf_id);
   }
 }
 
 template<typename PointT>
-void pclomp::MultiVoxelGridCovariance<PointT>::updateVoxelCentroids (
-  const Leaf &leaf, PointCloud &voxel_centroids) const
-{
-  voxel_centroids.push_back (PointT ());
-  voxel_centroids.points.back ().x = leaf.centroid[0];
-  voxel_centroids.points.back ().y = leaf.centroid[1];
-  voxel_centroids.points.back ().z = leaf.centroid[2];
+void pclomp::MultiVoxelGridCovariance<PointT>::updateVoxelCentroids(const Leaf &leaf, PointCloud &voxel_centroids) const {
+  voxel_centroids.push_back(PointT());
+  voxel_centroids.points.back().x = leaf.centroid[0];
+  voxel_centroids.points.back().y = leaf.centroid[1];
+  voxel_centroids.points.back().z = leaf.centroid[2];
 }
 
 template<typename PointT>
-typename pclomp::MultiVoxelGridCovariance<PointT>::LeafID pclomp::MultiVoxelGridCovariance<PointT>::getLeafID (
-  const std::string &grid_id, const PointT &point, const BoundingBox &bbox) const
-{
-  int ijk0 = static_cast<int> (floor (point.x * inverse_leaf_size_[0]) - static_cast<float> (bbox.min[0]));
-  int ijk1 = static_cast<int> (floor (point.y * inverse_leaf_size_[1]) - static_cast<float> (bbox.min[1]));
-  int ijk2 = static_cast<int> (floor (point.z * inverse_leaf_size_[2]) - static_cast<float> (bbox.min[2]));
+typename pclomp::MultiVoxelGridCovariance<PointT>::LeafID pclomp::MultiVoxelGridCovariance<PointT>::getLeafID(const std::string &grid_id, const PointT &point, const BoundingBox &bbox) const {
+  int ijk0 = static_cast<int>(floor(point.x * inverse_leaf_size_[0]) - static_cast<float>(bbox.min[0]));
+  int ijk1 = static_cast<int>(floor(point.y * inverse_leaf_size_[1]) - static_cast<float>(bbox.min[1]));
+  int ijk2 = static_cast<int>(floor(point.z * inverse_leaf_size_[2]) - static_cast<float>(bbox.min[2]));
   int idx = ijk0 * bbox.div_mul[0] + ijk1 * bbox.div_mul[1] + ijk2 * bbox.div_mul[2];
   LeafID leaf_id;
   leaf_id.parent_grid_id = grid_id;
@@ -181,71 +166,58 @@ typename pclomp::MultiVoxelGridCovariance<PointT>::LeafID pclomp::MultiVoxelGrid
 }
 
 template<typename PointT>
-void pclomp::MultiVoxelGridCovariance<PointT>::updateLeaf (
-  const PointT &point, const int &centroid_size, Leaf &leaf) const
-{
-  if (leaf.nr_points == 0)
-  {
-    leaf.centroid.resize (centroid_size);
-    leaf.centroid.setZero ();
+void pclomp::MultiVoxelGridCovariance<PointT>::updateLeaf(const PointT &point, const int &centroid_size, Leaf &leaf) const {
+  if(leaf.nr_points == 0) {
+    leaf.centroid.resize(centroid_size);
+    leaf.centroid.setZero();
   }
 
-  Eigen::Vector3d pt3d (point.x, point.y, point.z);
+  Eigen::Vector3d pt3d(point.x, point.y, point.z);
   // Accumulate point sum for centroid calculation
   leaf.mean_ += pt3d;
   // Accumulate x*xT for single pass covariance calculation
-  leaf.cov_ += pt3d * pt3d.transpose ();
+  leaf.cov_ += pt3d * pt3d.transpose();
 
-  Eigen::Vector4f pt (point.x, point.y, point.z, 0);
-  leaf.centroid.template head<4> () += pt;
+  Eigen::Vector4f pt(point.x, point.y, point.z, 0);
+  leaf.centroid.template head<4>() += pt;
   ++leaf.nr_points;
 }
 
 template<typename PointT>
-void pclomp::MultiVoxelGridCovariance<PointT>::computeLeafParams (
-  const Eigen::Vector3d &pt_sum,
-  Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> &eigensolver,
-  Leaf &leaf) const
-{
+void pclomp::MultiVoxelGridCovariance<PointT>::computeLeafParams(const Eigen::Vector3d &pt_sum, Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> &eigensolver, Leaf &leaf) const {
   // Single pass covariance calculation
-  leaf.cov_ = (leaf.cov_ - 2 * (pt_sum * leaf.mean_.transpose ())) / 
-    leaf.nr_points + leaf.mean_ * leaf.mean_.transpose ();
+  leaf.cov_ = (leaf.cov_ - 2 * (pt_sum * leaf.mean_.transpose())) / leaf.nr_points + leaf.mean_ * leaf.mean_.transpose();
   leaf.cov_ *= (leaf.nr_points - 1.0) / leaf.nr_points;
 
-  //Normalize Eigen Val such that max no more than 100x min.
-  eigensolver.compute (leaf.cov_);
-  Eigen::Matrix3d eigen_val = eigensolver.eigenvalues ().asDiagonal ();
-  leaf.evecs_ = eigensolver.eigenvectors ();
+  // Normalize Eigen Val such that max no more than 100x min.
+  eigensolver.compute(leaf.cov_);
+  Eigen::Matrix3d eigen_val = eigensolver.eigenvalues().asDiagonal();
+  leaf.evecs_ = eigensolver.eigenvectors();
 
-  if (eigen_val (0, 0) < 0 || eigen_val (1, 1) < 0 || eigen_val (2, 2) <= 0)
-  {
+  if(eigen_val(0, 0) < 0 || eigen_val(1, 1) < 0 || eigen_val(2, 2) <= 0) {
     leaf.nr_points = -1;
     return;
   }
 
   // Avoids matrices near singularities (eq 6.11)[Magnusson 2009]
-  double min_covar_eigvalue = min_covar_eigvalue_mult_ * eigen_val (2, 2);
-  if (eigen_val (0, 0) < min_covar_eigvalue)
-  {
-    eigen_val (0, 0) = min_covar_eigvalue;
+  double min_covar_eigvalue = min_covar_eigvalue_mult_ * eigen_val(2, 2);
+  if(eigen_val(0, 0) < min_covar_eigvalue) {
+    eigen_val(0, 0) = min_covar_eigvalue;
 
-    if (eigen_val (1, 1) < min_covar_eigvalue)
-    {
-      eigen_val (1, 1) = min_covar_eigvalue;
+    if(eigen_val(1, 1) < min_covar_eigvalue) {
+      eigen_val(1, 1) = min_covar_eigvalue;
     }
 
-    leaf.cov_ = leaf.evecs_ * eigen_val * leaf.evecs_.inverse ();
+    leaf.cov_ = leaf.evecs_ * eigen_val * leaf.evecs_.inverse();
   }
-  leaf.evals_ = eigen_val.diagonal ();
+  leaf.evals_ = eigen_val.diagonal();
 
-  leaf.icov_ = leaf.cov_.inverse ();
-  if (leaf.icov_.maxCoeff () == std::numeric_limits<float>::infinity ( )
-      || leaf.icov_.minCoeff () == -std::numeric_limits<float>::infinity ( ) )
-  {
+  leaf.icov_ = leaf.cov_.inverse();
+  if(leaf.icov_.maxCoeff() == std::numeric_limits<float>::infinity() || leaf.icov_.minCoeff() == -std::numeric_limits<float>::infinity()) {
     leaf.nr_points = -1;
   }
 }
 
 #define PCL_INSTANTIATE_VoxelGridCovariance(T) template class PCL_EXPORTS pcl::VoxelGridCovariance<T>;
 
-#endif    // PCL_MULTI_VOXEL_GRID_COVARIANCE_IMPL_H_
+#endif  // PCL_MULTI_VOXEL_GRID_COVARIANCE_IMPL_H_

--- a/include/multigrid_pclomp/multigrid_ndt_omp.h
+++ b/include/multigrid_pclomp/multigrid_ndt_omp.h
@@ -63,584 +63,472 @@
 
 #include <unsupported/Eigen/NonLinearOptimization>
 
-namespace pclomp
-{
-	struct NdtResult
-	{
-		Eigen::Matrix4f pose;
-		float transform_probability;
-		float nearest_voxel_transformation_likelihood;
-		int iteration_num;
-		Eigen::Matrix<double, 6, 6> hessian;
-		std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f>> transformation_array;
-		EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-	};
+namespace pclomp {
+struct NdtResult {
+  Eigen::Matrix4f pose;
+  float transform_probability;
+  float nearest_voxel_transformation_likelihood;
+  int iteration_num;
+  Eigen::Matrix<double, 6, 6> hessian;
+  std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f>> transformation_array;
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
 
-	struct NdtParams
-	{
-		double trans_epsilon;
-		double step_size;
-		double resolution;
-		int max_iterations;
-		int num_threads;
-		float regularization_scale_factor;
-	};
+struct NdtParams {
+  double trans_epsilon;
+  double step_size;
+  double resolution;
+  int max_iterations;
+  int num_threads;
+  float regularization_scale_factor;
+};
 
-	/** \brief A 3D Normal Distribution Transform registration implementation for point cloud data.
-	  * \note For more information please see
-	  * <b>Magnusson, M. (2009). The Three-Dimensional Normal-Distributions Transform —
-	  * an Efficient Representation for Registration, Surface Analysis, and Loop Detection.
-	  * PhD thesis, Orebro University. Orebro Studies in Technology 36.</b>,
-	  * <b>More, J., and Thuente, D. (1994). Line Search Algorithm with Guaranteed Sufficient Decrease
-	  * In ACM Transactions on Mathematical Software.</b> and
-	  * Sun, W. and Yuan, Y, (2006) Optimization Theory and Methods: Nonlinear Programming. 89-100
-	  * \note Math refactored by Todor Stoyanov.
-	  * \author Brian Okorn (Space and Naval Warfare Systems Center Pacific)
-	  */
-	template<typename PointSource, typename PointTarget>
-	class MultiGridNormalDistributionsTransform : public pcl::Registration<PointSource, PointTarget>
-	{
-	protected:
+/** \brief A 3D Normal Distribution Transform registration implementation for point cloud data.
+ * \note For more information please see
+ * <b>Magnusson, M. (2009). The Three-Dimensional Normal-Distributions Transform —
+ * an Efficient Representation for Registration, Surface Analysis, and Loop Detection.
+ * PhD thesis, Orebro University. Orebro Studies in Technology 36.</b>,
+ * <b>More, J., and Thuente, D. (1994). Line Search Algorithm with Guaranteed Sufficient Decrease
+ * In ACM Transactions on Mathematical Software.</b> and
+ * Sun, W. and Yuan, Y, (2006) Optimization Theory and Methods: Nonlinear Programming. 89-100
+ * \note Math refactored by Todor Stoyanov.
+ * \author Brian Okorn (Space and Naval Warfare Systems Center Pacific)
+ */
+template<typename PointSource, typename PointTarget>
+class MultiGridNormalDistributionsTransform : public pcl::Registration<PointSource, PointTarget> {
+protected:
+  typedef typename pcl::Registration<PointSource, PointTarget>::PointCloudSource PointCloudSource;
+  typedef typename PointCloudSource::Ptr PointCloudSourcePtr;
+  typedef typename PointCloudSource::ConstPtr PointCloudSourceConstPtr;
 
-		typedef typename pcl::Registration<PointSource, PointTarget>::PointCloudSource PointCloudSource;
-		typedef typename PointCloudSource::Ptr PointCloudSourcePtr;
-		typedef typename PointCloudSource::ConstPtr PointCloudSourceConstPtr;
+  typedef typename pcl::Registration<PointSource, PointTarget>::PointCloudTarget PointCloudTarget;
+  typedef typename PointCloudTarget::Ptr PointCloudTargetPtr;
+  typedef typename PointCloudTarget::ConstPtr PointCloudTargetConstPtr;
 
-		typedef typename pcl::Registration<PointSource, PointTarget>::PointCloudTarget PointCloudTarget;
-		typedef typename PointCloudTarget::Ptr PointCloudTargetPtr;
-		typedef typename PointCloudTarget::ConstPtr PointCloudTargetConstPtr;
+  typedef pcl::PointIndices::Ptr PointIndicesPtr;
+  typedef pcl::PointIndices::ConstPtr PointIndicesConstPtr;
 
-		typedef pcl::PointIndices::Ptr PointIndicesPtr;
-		typedef pcl::PointIndices::ConstPtr PointIndicesConstPtr;
+  /** \brief Typename of searchable voxel grid containing mean and covariance. */
+  typedef pclomp::MultiVoxelGridCovariance<PointTarget> TargetGrid;
+  /** \brief Typename of pointer to searchable voxel grid. */
+  typedef TargetGrid *TargetGridPtr;
+  /** \brief Typename of const pointer to searchable voxel grid. */
+  typedef const TargetGrid *TargetGridConstPtr;
+  /** \brief Typename of const pointer to searchable voxel grid leaf. */
+  typedef typename TargetGrid::LeafConstPtr TargetGridLeafConstPtr;
 
-		/** \brief Typename of searchable voxel grid containing mean and covariance. */
-		typedef pclomp::MultiVoxelGridCovariance<PointTarget> TargetGrid;
-		/** \brief Typename of pointer to searchable voxel grid. */
-		typedef TargetGrid* TargetGridPtr;
-		/** \brief Typename of const pointer to searchable voxel grid. */
-		typedef const TargetGrid* TargetGridConstPtr;
-		/** \brief Typename of const pointer to searchable voxel grid leaf. */
-		typedef typename TargetGrid::LeafConstPtr TargetGridLeafConstPtr;
-
-
-	public:
-
+public:
 #if PCL_VERSION >= PCL_VERSION_CALC(1, 10, 0)
-		typedef pcl::shared_ptr< MultiGridNormalDistributionsTransform<PointSource, PointTarget> > Ptr;
-		typedef pcl::shared_ptr< const MultiGridNormalDistributionsTransform<PointSource, PointTarget> > ConstPtr;
+  typedef pcl::shared_ptr<MultiGridNormalDistributionsTransform<PointSource, PointTarget>> Ptr;
+  typedef pcl::shared_ptr<const MultiGridNormalDistributionsTransform<PointSource, PointTarget>> ConstPtr;
 #else
-		typedef boost::shared_ptr< MultiGridNormalDistributionsTransform<PointSource, PointTarget> > Ptr;
-		typedef boost::shared_ptr< const MultiGridNormalDistributionsTransform<PointSource, PointTarget> > ConstPtr;
+  typedef boost::shared_ptr<MultiGridNormalDistributionsTransform<PointSource, PointTarget>> Ptr;
+  typedef boost::shared_ptr<const MultiGridNormalDistributionsTransform<PointSource, PointTarget>> ConstPtr;
 #endif
 
+  /** \brief Constructor.
+   * Sets \ref outlier_ratio_ to 0.35, \ref step_size_ to 0.05 and \ref resolution_ to 1.0
+   */
+  MultiGridNormalDistributionsTransform();
 
-		/** \brief Constructor.
-		  * Sets \ref outlier_ratio_ to 0.35, \ref step_size_ to 0.05 and \ref resolution_ to 1.0
-		  */
-		MultiGridNormalDistributionsTransform();
+  /** \brief Empty destructor */
+  virtual ~MultiGridNormalDistributionsTransform() {}
 
-		/** \brief Empty destructor */
-		virtual ~MultiGridNormalDistributionsTransform() {}
+  void setNumThreads(int n) {
+    num_threads_ = n;
+  }
 
-		void setNumThreads(int n)
-		{
-			num_threads_ = n;
-		}
+  inline int getNumThreads() const {
+    return num_threads_;
+  }
 
-		inline int getNumThreads() const
-		{
-			return num_threads_;
-		}
+  inline void setInputTarget(const PointCloudTargetConstPtr &cloud) {
+    const std::string default_target_id = "default";
+    addTarget(cloud, default_target_id);
+    createVoxelKdtree();
+  }
 
-		inline void
-			setInputTarget(const PointCloudTargetConstPtr &cloud)
-		{
-			const std::string default_target_id = "default";
-			addTarget(cloud, default_target_id);
-			createVoxelKdtree();
-		}
+  /** \brief Provide a pointer to the input target (e.g., the point cloud that we want to align the input source to).
+   * \param[in] cloud the input point cloud target
+   */
+  inline void addTarget(const PointCloudTargetConstPtr &cloud, const std::string target_id) {
+    pcl::Registration<PointSource, PointTarget>::setInputTarget(cloud);
+    target_cells_.setLeafSize(resolution_, resolution_, resolution_);
+    target_cells_.setInputCloudAndFilter(cloud, target_id);
+  }
 
-		/** \brief Provide a pointer to the input target (e.g., the point cloud that we want to align the input source to).
-		  * \param[in] cloud the input point cloud target
-		  */
-		inline void
-			addTarget(const PointCloudTargetConstPtr &cloud, const std::string target_id)
-		{
-			pcl::Registration<PointSource, PointTarget>::setInputTarget(cloud);
-			target_cells_.setLeafSize(resolution_, resolution_, resolution_);
-			target_cells_.setInputCloudAndFilter(cloud, target_id);
-		}
+  inline void removeTarget(const std::string target_id) {
+    target_cells_.removeCloud(target_id);
+  }
 
-		inline void
-			removeTarget(const std::string target_id)
-		{
-			target_cells_.removeCloud(target_id);
-		}
+  inline void createVoxelKdtree() {
+    target_cells_.createKdtree();
+  }
 
-		inline void
-			createVoxelKdtree()
-		{
-			target_cells_.createKdtree();
-		}
+  /** \brief Set/change the voxel grid resolution.
+   * \param[in] resolution side length of voxels
+   */
+  inline void setResolution(float resolution) {
+    // Prevents unnecessary voxel initiations
+    if(resolution_ != resolution) {
+      resolution_ = resolution;
+      if(input_) init();
+    }
+  }
 
+  /** \brief Get voxel grid resolution.
+   * \return side length of voxels
+   */
+  inline float getResolution() const {
+    return (resolution_);
+  }
 
-		/** \brief Set/change the voxel grid resolution.
-		  * \param[in] resolution side length of voxels
-		  */
-		inline void
-			setResolution(float resolution)
-		{
-			// Prevents unnecessary voxel initiations
-			if (resolution_ != resolution)
-			{
-				resolution_ = resolution;
-				if (input_)
-					init();
-			}
-		}
+  /** \brief Get the newton line search maximum step length.
+   * \return maximum step length
+   */
+  inline double getStepSize() const {
+    return (step_size_);
+  }
 
-		/** \brief Get voxel grid resolution.
-		  * \return side length of voxels
-		  */
-		inline float
-			getResolution() const
-		{
-			return (resolution_);
-		}
+  /** \brief Set/change the newton line search maximum step length.
+   * \param[in] step_size maximum step length
+   */
+  inline void setStepSize(double step_size) {
+    step_size_ = step_size;
+  }
 
-		/** \brief Get the newton line search maximum step length.
-		  * \return maximum step length
-		  */
-		inline double
-			getStepSize() const
-		{
-			return (step_size_);
-		}
+  /** \brief Get the point cloud outlier ratio.
+   * \return outlier ratio
+   */
+  inline double getOutlierRatio() const {
+    return (outlier_ratio_);
+  }
 
-		/** \brief Set/change the newton line search maximum step length.
-		  * \param[in] step_size maximum step length
-		  */
-		inline void
-			setStepSize(double step_size)
-		{
-			step_size_ = step_size;
-		}
+  /** \brief Set/change the point cloud outlier ratio.
+   * \param[in] outlier_ratio outlier ratio
+   */
+  inline void setOutlierRatio(double outlier_ratio) {
+    outlier_ratio_ = outlier_ratio;
+  }
 
-		/** \brief Get the point cloud outlier ratio.
-		  * \return outlier ratio
-		  */
-		inline double
-			getOutlierRatio() const
-		{
-			return (outlier_ratio_);
-		}
+  /** \brief Get the registration alignment probability.
+   * \return transformation probability
+   */
+  inline double getTransformationProbability() const {
+    return (trans_probability_);
+  }
 
-		/** \brief Set/change the point cloud outlier ratio.
-		  * \param[in] outlier_ratio outlier ratio
-		  */
-		inline void
-			setOutlierRatio(double outlier_ratio)
-		{
-			outlier_ratio_ = outlier_ratio;
-		}
+  inline double getNearestVoxelTransformationLikelihood() const {
+    return nearest_voxel_transformation_likelihood_;
+  }
 
-		/** \brief Get the registration alignment probability.
-		  * \return transformation probability
-		  */
-		inline double
-			getTransformationProbability() const
-		{
-			return (trans_probability_);
-		}
+  /** \brief Get the number of iterations required to calculate alignment.
+   * \return final number of iterations
+   */
+  inline int getFinalNumIteration() const {
+    return (nr_iterations_);
+  }
 
-		inline double
-			getNearestVoxelTransformationLikelihood() const
-		{
-			return nearest_voxel_transformation_likelihood_;
-		}
+  /** \brief Return the hessian matrix */
+  inline Eigen::Matrix<double, 6, 6> getHessian() const {
+    return hessian_;
+  }
 
-		/** \brief Get the number of iterations required to calculate alignment.
-		  * \return final number of iterations
-		  */
-		inline int
-			getFinalNumIteration() const
-		{
-			return (nr_iterations_);
-		}
+  /** \brief Return the transformation array */
+  inline const std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f>> getFinalTransformationArray() const {
+    return transformation_array_;
+  }
 
-		/** \brief Return the hessian matrix */
-		inline Eigen::Matrix<double, 6, 6>
-			getHessian() const
-		{
-			return hessian_;
-		}
+  /** \brief Convert 6 element transformation vector to affine transformation.
+   * \param[in] x transformation vector of the form [x, y, z, roll, pitch, yaw]
+   * \param[out] trans affine transform corresponding to given transformation vector
+   */
+  static void convertTransform(const Eigen::Matrix<double, 6, 1> &x, Eigen::Affine3f &trans) {
+    trans = Eigen::Translation<float, 3>(float(x(0)), float(x(1)), float(x(2))) * Eigen::AngleAxis<float>(float(x(3)), Eigen::Vector3f::UnitX()) * Eigen::AngleAxis<float>(float(x(4)), Eigen::Vector3f::UnitY()) * Eigen::AngleAxis<float>(float(x(5)), Eigen::Vector3f::UnitZ());
+  }
 
-		/** \brief Return the transformation array */
-		inline const std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f>>
-			getFinalTransformationArray() const
-		{
-			return transformation_array_;
-		}
+  /** \brief Convert 6 element transformation vector to transformation matrix.
+   * \param[in] x transformation vector of the form [x, y, z, roll, pitch, yaw]
+   * \param[out] trans 4x4 transformation matrix corresponding to given transformation vector
+   */
+  static void convertTransform(const Eigen::Matrix<double, 6, 1> &x, Eigen::Matrix4f &trans) {
+    Eigen::Affine3f _affine;
+    convertTransform(x, _affine);
+    trans = _affine.matrix();
+  }
 
-		/** \brief Convert 6 element transformation vector to affine transformation.
-		  * \param[in] x transformation vector of the form [x, y, z, roll, pitch, yaw]
-		  * \param[out] trans affine transform corresponding to given transformation vector
-		  */
-		static void
-			convertTransform(const Eigen::Matrix<double, 6, 1> &x, Eigen::Affine3f &trans)
-		{
-			trans = Eigen::Translation<float, 3>(float(x(0)), float(x(1)), float(x(2))) *
-				Eigen::AngleAxis<float>(float(x(3)), Eigen::Vector3f::UnitX()) *
-				Eigen::AngleAxis<float>(float(x(4)), Eigen::Vector3f::UnitY()) *
-				Eigen::AngleAxis<float>(float(x(5)), Eigen::Vector3f::UnitZ());
-		}
+  // negative log likelihood function
+  // lower is better
+  double calculateScore(const PointCloudSource &cloud) const;
+  double calculateTransformationProbability(const PointCloudSource &cloud) const;
+  double calculateNearestVoxelTransformationLikelihood(const PointCloudSource &cloud) const;
 
-		/** \brief Convert 6 element transformation vector to transformation matrix.
-		  * \param[in] x transformation vector of the form [x, y, z, roll, pitch, yaw]
-		  * \param[out] trans 4x4 transformation matrix corresponding to given transformation vector
-		  */
-		static void
-			convertTransform(const Eigen::Matrix<double, 6, 1> &x, Eigen::Matrix4f &trans)
-		{
-			Eigen::Affine3f _affine;
-			convertTransform(x, _affine);
-			trans = _affine.matrix();
-		}
+  inline void setRegularizationScaleFactor(float regularization_scale_factor) {
+    regularization_scale_factor_ = regularization_scale_factor;
+  }
 
-		// negative log likelihood function
-		// lower is better
-		double calculateScore(const PointCloudSource& cloud) const;
-		double calculateTransformationProbability(const PointCloudSource& cloud) const;
-		double calculateNearestVoxelTransformationLikelihood(const PointCloudSource& cloud) const;
+  inline void setRegularizationPose(Eigen::Matrix4f regularization_pose) {
+    regularization_pose_ = regularization_pose;
+  }
 
-		inline void setRegularizationScaleFactor(float regularization_scale_factor)
-		{
-			regularization_scale_factor_ = regularization_scale_factor;
-		}
+  inline void unsetRegularizationPose() {
+    regularization_pose_ = boost::none;
+  }
 
-		inline void setRegularizationPose(Eigen::Matrix4f regularization_pose)
-		{
-			regularization_pose_ = regularization_pose;
-		}
+  NdtResult getResult() {
+    NdtResult ndt_result;
+    ndt_result.pose = this->getFinalTransformation();
+    ndt_result.transformation_array = getFinalTransformationArray();
+    ndt_result.transform_probability = getTransformationProbability();
+    ndt_result.nearest_voxel_transformation_likelihood = getNearestVoxelTransformationLikelihood();
+    ndt_result.iteration_num = getFinalNumIteration();
+    ndt_result.hessian = getHessian();
+    return ndt_result;
+  }
 
-		inline void unsetRegularizationPose()
-		{
-			regularization_pose_ = boost::none;
-		}
+  void setParams(const NdtParams &ndt_params) {
+    this->setTransformationEpsilon(ndt_params.trans_epsilon);
+    this->setStepSize(ndt_params.step_size);
+    this->setResolution(ndt_params.resolution);
+    this->setMaximumIterations(ndt_params.max_iterations);
+    setRegularizationScaleFactor(ndt_params.regularization_scale_factor);
+    setNumThreads(ndt_params.num_threads);
+  }
 
-		NdtResult getResult()
-		{
-			NdtResult ndt_result;
-			ndt_result.pose = this->getFinalTransformation();
-			ndt_result.transformation_array = getFinalTransformationArray();
-			ndt_result.transform_probability = getTransformationProbability();
-			ndt_result.nearest_voxel_transformation_likelihood =
-				getNearestVoxelTransformationLikelihood();
-			ndt_result.iteration_num = getFinalNumIteration();
-			ndt_result.hessian = getHessian();
-			return ndt_result;
-		}
+  NdtParams getParams() const {
+    NdtParams ndt_params;
+    ndt_params.trans_epsilon = transformation_epsilon_;
+    ndt_params.step_size = getStepSize();
+    ndt_params.resolution = getResolution();
+    ndt_params.max_iterations = max_iterations_;
+    ndt_params.regularization_scale_factor = regularization_scale_factor_;
+    ndt_params.num_threads = num_threads_;
+    return ndt_params;
+  }
 
-		void setParams(const NdtParams & ndt_params)
-		{
-			this->setTransformationEpsilon(ndt_params.trans_epsilon);
-			this->setStepSize(ndt_params.step_size);
-			this->setResolution(ndt_params.resolution);
-			this->setMaximumIterations(ndt_params.max_iterations);
-			setRegularizationScaleFactor(ndt_params.regularization_scale_factor);
-			setNumThreads(ndt_params.num_threads);
-		}
+  pcl::PointCloud<PointTarget> getVoxelPCD() const {
+    return target_cells_.getVoxelPCD();
+  }
 
-		NdtParams getParams() const
-		{
-			NdtParams ndt_params;
-			ndt_params.trans_epsilon = transformation_epsilon_;
-			ndt_params.step_size = getStepSize();
-			ndt_params.resolution = getResolution();
-			ndt_params.max_iterations = max_iterations_;
-			ndt_params.regularization_scale_factor = regularization_scale_factor_;
-			ndt_params.num_threads = num_threads_;
-			return ndt_params;
-		}
+  std::vector<std::string> getCurrentMapIDs() const {
+    return target_cells_.getCurrentMapIDs();
+  }
 
-		pcl::PointCloud<PointTarget> getVoxelPCD() const
-		{
-			return target_cells_.getVoxelPCD();
-		}
+protected:
+  using pcl::Registration<PointSource, PointTarget>::reg_name_;
+  using pcl::Registration<PointSource, PointTarget>::getClassName;
+  using pcl::Registration<PointSource, PointTarget>::input_;
+  using pcl::Registration<PointSource, PointTarget>::indices_;
+  using pcl::Registration<PointSource, PointTarget>::target_;
+  using pcl::Registration<PointSource, PointTarget>::nr_iterations_;
+  using pcl::Registration<PointSource, PointTarget>::max_iterations_;
+  using pcl::Registration<PointSource, PointTarget>::previous_transformation_;
+  using pcl::Registration<PointSource, PointTarget>::final_transformation_;
+  using pcl::Registration<PointSource, PointTarget>::transformation_;
+  using pcl::Registration<PointSource, PointTarget>::transformation_epsilon_;
+  using pcl::Registration<PointSource, PointTarget>::converged_;
+  using pcl::Registration<PointSource, PointTarget>::corr_dist_threshold_;
+  using pcl::Registration<PointSource, PointTarget>::inlier_threshold_;
 
-		std::vector<std::string> getCurrentMapIDs() const
-		{
-			return target_cells_.getCurrentMapIDs();
-		}
+  using pcl::Registration<PointSource, PointTarget>::update_visualizer_;
 
-		
+  /** \brief Estimate the transformation and returns the transformed source (input) as output.
+   * \param[out] output the resultant input transformed point cloud dataset
+   */
+  virtual void computeTransformation(PointCloudSource &output) {
+    computeTransformation(output, Eigen::Matrix4f::Identity());
+  }
 
-	protected:
+  /** \brief Estimate the transformation and returns the transformed source (input) as output.
+   * \param[out] output the resultant input transformed point cloud dataset
+   * \param[in] guess the initial gross estimation of the transformation
+   */
+  virtual void computeTransformation(PointCloudSource &output, const Eigen::Matrix4f &guess);
 
-		using pcl::Registration<PointSource, PointTarget>::reg_name_;
-		using pcl::Registration<PointSource, PointTarget>::getClassName;
-		using pcl::Registration<PointSource, PointTarget>::input_;
-		using pcl::Registration<PointSource, PointTarget>::indices_;
-		using pcl::Registration<PointSource, PointTarget>::target_;
-		using pcl::Registration<PointSource, PointTarget>::nr_iterations_;
-		using pcl::Registration<PointSource, PointTarget>::max_iterations_;
-		using pcl::Registration<PointSource, PointTarget>::previous_transformation_;
-		using pcl::Registration<PointSource, PointTarget>::final_transformation_;
-		using pcl::Registration<PointSource, PointTarget>::transformation_;
-		using pcl::Registration<PointSource, PointTarget>::transformation_epsilon_;
-		using pcl::Registration<PointSource, PointTarget>::converged_;
-		using pcl::Registration<PointSource, PointTarget>::corr_dist_threshold_;
-		using pcl::Registration<PointSource, PointTarget>::inlier_threshold_;
+  /** \brief Initiate covariance voxel structure. */
+  void inline init() {}
 
-		using pcl::Registration<PointSource, PointTarget>::update_visualizer_;
+  /** \brief Compute derivatives of probability function w.r.t. the transformation vector.
+   * \note Equation 6.10, 6.12 and 6.13 [Magnusson 2009].
+   * \param[out] score_gradient the gradient vector of the probability function w.r.t. the transformation vector
+   * \param[out] hessian the hessian matrix of the probability function w.r.t. the transformation vector
+   * \param[in] trans_cloud transformed point cloud
+   * \param[in] p the current transform vector
+   * \param[in] compute_hessian flag to calculate hessian, unnecessary for step calculation.
+   */
+  double computeDerivatives(Eigen::Matrix<double, 6, 1> &score_gradient, Eigen::Matrix<double, 6, 6> &hessian, PointCloudSource &trans_cloud, Eigen::Matrix<double, 6, 1> &p, bool compute_hessian = true);
 
-		/** \brief Estimate the transformation and returns the transformed source (input) as output.
-		  * \param[out] output the resultant input transformed point cloud dataset
-		  */
-		virtual void
-			computeTransformation(PointCloudSource &output)
-		{
-			computeTransformation(output, Eigen::Matrix4f::Identity());
-		}
+  /** \brief Compute individual point contributions to derivatives of probability function w.r.t. the transformation vector.
+   * \note Equation 6.10, 6.12 and 6.13 [Magnusson 2009].
+   * \param[in,out] score_gradient the gradient vector of the probability function w.r.t. the transformation vector
+   * \param[in,out] hessian the hessian matrix of the probability function w.r.t. the transformation vector
+   * \param[in] x_trans transformed point minus mean of occupied covariance voxel
+   * \param[in] c_inv covariance of occupied covariance voxel
+   * \param[in] compute_hessian flag to calculate hessian, unnecessary for step calculation.
+   */
+  double updateDerivatives(Eigen::Matrix<double, 6, 1> &score_gradient, Eigen::Matrix<double, 6, 6> &hessian, const Eigen::Matrix<float, 4, 6> &point_gradient_, const Eigen::Matrix<float, 24, 6> &point_hessian_, const Eigen::Vector3d &x_trans, const Eigen::Matrix3d &c_inv, bool compute_hessian = true) const;
 
-		/** \brief Estimate the transformation and returns the transformed source (input) as output.
-		  * \param[out] output the resultant input transformed point cloud dataset
-		  * \param[in] guess the initial gross estimation of the transformation
-		  */
-		virtual void
-			computeTransformation(PointCloudSource &output, const Eigen::Matrix4f &guess);
+  /** \brief Precompute angular components of derivatives.
+   * \note Equation 6.19 and 6.21 [Magnusson 2009].
+   * \param[in] p the current transform vector
+   * \param[in] compute_hessian flag to calculate hessian, unnecessary for step calculation.
+   */
+  void computeAngleDerivatives(Eigen::Matrix<double, 6, 1> &p, bool compute_hessian = true);
 
-		/** \brief Initiate covariance voxel structure. */
-		void inline
-			init()
-		{
-		}
+  /** \brief Compute point derivatives.
+   * \note Equation 6.18-21 [Magnusson 2009].
+   * \param[in] x point from the input cloud
+   * \param[in] compute_hessian flag to calculate hessian, unnecessary for step calculation.
+   */
+  void computePointDerivatives(Eigen::Vector3d &x, Eigen::Matrix<double, 3, 6> &point_gradient_, Eigen::Matrix<double, 18, 6> &point_hessian_, bool compute_hessian = true) const;
 
-		/** \brief Compute derivatives of probability function w.r.t. the transformation vector.
-		  * \note Equation 6.10, 6.12 and 6.13 [Magnusson 2009].
-		  * \param[out] score_gradient the gradient vector of the probability function w.r.t. the transformation vector
-		  * \param[out] hessian the hessian matrix of the probability function w.r.t. the transformation vector
-		  * \param[in] trans_cloud transformed point cloud
-		  * \param[in] p the current transform vector
-		  * \param[in] compute_hessian flag to calculate hessian, unnecessary for step calculation.
-		  */
-		double
-			computeDerivatives(Eigen::Matrix<double, 6, 1> &score_gradient,
-				Eigen::Matrix<double, 6, 6> &hessian,
-				PointCloudSource &trans_cloud,
-				Eigen::Matrix<double, 6, 1> &p,
-				bool compute_hessian = true);
+  void computePointDerivatives(Eigen::Vector3d &x, Eigen::Matrix<float, 4, 6> &point_gradient_, Eigen::Matrix<float, 24, 6> &point_hessian_, bool compute_hessian = true) const;
 
-		/** \brief Compute individual point contributions to derivatives of probability function w.r.t. the transformation vector.
-		  * \note Equation 6.10, 6.12 and 6.13 [Magnusson 2009].
-		  * \param[in,out] score_gradient the gradient vector of the probability function w.r.t. the transformation vector
-		  * \param[in,out] hessian the hessian matrix of the probability function w.r.t. the transformation vector
-		  * \param[in] x_trans transformed point minus mean of occupied covariance voxel
-		  * \param[in] c_inv covariance of occupied covariance voxel
-		  * \param[in] compute_hessian flag to calculate hessian, unnecessary for step calculation.
-		  */
-		double
-			updateDerivatives(Eigen::Matrix<double, 6, 1> &score_gradient,
-				Eigen::Matrix<double, 6, 6> &hessian,
-				const Eigen::Matrix<float, 4, 6> &point_gradient_,
-				const Eigen::Matrix<float, 24, 6> &point_hessian_,
-				const Eigen::Vector3d &x_trans, const Eigen::Matrix3d &c_inv,
-				bool compute_hessian = true) const;
+  /** \brief Compute hessian of probability function w.r.t. the transformation vector.
+   * \note Equation 6.13 [Magnusson 2009].
+   * \param[out] hessian the hessian matrix of the probability function w.r.t. the transformation vector
+   * \param[in] trans_cloud transformed point cloud
+   * \param[in] p the current transform vector
+   */
+  void computeHessian(Eigen::Matrix<double, 6, 6> &hessian, PointCloudSource &trans_cloud, Eigen::Matrix<double, 6, 1> &p);
 
-		/** \brief Precompute angular components of derivatives.
-		  * \note Equation 6.19 and 6.21 [Magnusson 2009].
-		  * \param[in] p the current transform vector
-		  * \param[in] compute_hessian flag to calculate hessian, unnecessary for step calculation.
-		  */
-		void
-			computeAngleDerivatives(Eigen::Matrix<double, 6, 1> &p, bool compute_hessian = true);
+  /** \brief Compute individual point contributions to hessian of probability function w.r.t. the transformation vector.
+   * \note Equation 6.13 [Magnusson 2009].
+   * \param[in,out] hessian the hessian matrix of the probability function w.r.t. the transformation vector
+   * \param[in] x_trans transformed point minus mean of occupied covariance voxel
+   * \param[in] c_inv covariance of occupied covariance voxel
+   */
+  void updateHessian(Eigen::Matrix<double, 6, 6> &hessian, const Eigen::Matrix<double, 3, 6> &point_gradient_, const Eigen::Matrix<double, 18, 6> &point_hessian_, const Eigen::Vector3d &x_trans, const Eigen::Matrix3d &c_inv) const;
 
-		/** \brief Compute point derivatives.
-		  * \note Equation 6.18-21 [Magnusson 2009].
-		  * \param[in] x point from the input cloud
-		  * \param[in] compute_hessian flag to calculate hessian, unnecessary for step calculation.
-		  */
-		void
-			computePointDerivatives(Eigen::Vector3d &x, Eigen::Matrix<double, 3, 6>& point_gradient_, Eigen::Matrix<double, 18, 6>& point_hessian_, bool compute_hessian = true) const;
+  /** \brief Compute line search step length and update transform and probability derivatives using More-Thuente method.
+   * \note Search Algorithm [More, Thuente 1994]
+   * \param[in] x initial transformation vector, \f$ x \f$ in Equation 1.3 (Moore, Thuente 1994) and \f$ \vec{p} \f$ in Algorithm 2 [Magnusson 2009]
+   * \param[in] step_dir descent direction, \f$ p \f$ in Equation 1.3 (Moore, Thuente 1994) and \f$ \delta \vec{p} \f$ normalized in Algorithm 2 [Magnusson 2009]
+   * \param[in] step_init initial step length estimate, \f$ \alpha_0 \f$ in Moore-Thuente (1994) and the normal of \f$ \delta \vec{p} \f$ in Algorithm 2 [Magnusson 2009]
+   * \param[in] step_max maximum step length, \f$ \alpha_max \f$ in Moore-Thuente (1994)
+   * \param[in] step_min minimum step length, \f$ \alpha_min \f$ in Moore-Thuente (1994)
+   * \param[out] score final score function value, \f$ f(x + \alpha p) \f$ in Equation 1.3 (Moore, Thuente 1994) and \f$ score \f$ in Algorithm 2 [Magnusson 2009]
+   * \param[in,out] score_gradient gradient of score function w.r.t. transformation vector, \f$ f'(x + \alpha p) \f$ in Moore-Thuente (1994) and \f$ \vec{g} \f$ in Algorithm 2 [Magnusson 2009]
+   * \param[out] hessian hessian of score function w.r.t. transformation vector, \f$ f''(x + \alpha p) \f$ in Moore-Thuente (1994) and \f$ H \f$ in Algorithm 2 [Magnusson 2009]
+   * \param[in,out] trans_cloud transformed point cloud, \f$ X \f$ transformed by \f$ T(\vec{p},\vec{x}) \f$ in Algorithm 2 [Magnusson 2009]
+   * \return final step length
+   */
+  double computeStepLengthMT(const Eigen::Matrix<double, 6, 1> &x, Eigen::Matrix<double, 6, 1> &step_dir, double step_init, double step_max, double step_min, double &score, Eigen::Matrix<double, 6, 1> &score_gradient, Eigen::Matrix<double, 6, 6> &hessian, PointCloudSource &trans_cloud);
 
-		void
-			computePointDerivatives(Eigen::Vector3d &x, Eigen::Matrix<float, 4, 6>& point_gradient_, Eigen::Matrix<float, 24, 6>& point_hessian_, bool compute_hessian = true) const;
+  /** \brief Update interval of possible step lengths for More-Thuente method, \f$ I \f$ in More-Thuente (1994)
+   * \note Updating Algorithm until some value satisfies \f$ \psi(\alpha_k) \leq 0 \f$ and \f$ \phi'(\alpha_k) \geq 0 \f$
+   * and Modified Updating Algorithm from then on [More, Thuente 1994].
+   * \param[in,out] a_l first endpoint of interval \f$ I \f$, \f$ \alpha_l \f$ in Moore-Thuente (1994)
+   * \param[in,out] f_l value at first endpoint, \f$ f_l \f$ in Moore-Thuente (1994), \f$ \psi(\alpha_l) \f$ for Update Algorithm and \f$ \phi(\alpha_l) \f$ for Modified Update Algorithm
+   * \param[in,out] g_l derivative at first endpoint, \f$ g_l \f$ in Moore-Thuente (1994), \f$ \psi'(\alpha_l) \f$ for Update Algorithm and \f$ \phi'(\alpha_l) \f$ for Modified Update Algorithm
+   * \param[in,out] a_u second endpoint of interval \f$ I \f$, \f$ \alpha_u \f$ in Moore-Thuente (1994)
+   * \param[in,out] f_u value at second endpoint, \f$ f_u \f$ in Moore-Thuente (1994), \f$ \psi(\alpha_u) \f$ for Update Algorithm and \f$ \phi(\alpha_u) \f$ for Modified Update Algorithm
+   * \param[in,out] g_u derivative at second endpoint, \f$ g_u \f$ in Moore-Thuente (1994), \f$ \psi'(\alpha_u) \f$ for Update Algorithm and \f$ \phi'(\alpha_u) \f$ for Modified Update Algorithm
+   * \param[in] a_t trial value, \f$ \alpha_t \f$ in Moore-Thuente (1994)
+   * \param[in] f_t value at trial value, \f$ f_t \f$ in Moore-Thuente (1994), \f$ \psi(\alpha_t) \f$ for Update Algorithm and \f$ \phi(\alpha_t) \f$ for Modified Update Algorithm
+   * \param[in] g_t derivative at trial value, \f$ g_t \f$ in Moore-Thuente (1994), \f$ \psi'(\alpha_t) \f$ for Update Algorithm and \f$ \phi'(\alpha_t) \f$ for Modified Update Algorithm
+   * \return if interval converges
+   */
+  bool updateIntervalMT(double &a_l, double &f_l, double &g_l, double &a_u, double &f_u, double &g_u, double a_t, double f_t, double g_t);
 
-		/** \brief Compute hessian of probability function w.r.t. the transformation vector.
-		  * \note Equation 6.13 [Magnusson 2009].
-		  * \param[out] hessian the hessian matrix of the probability function w.r.t. the transformation vector
-		  * \param[in] trans_cloud transformed point cloud
-		  * \param[in] p the current transform vector
-		  */
-		void
-			computeHessian(Eigen::Matrix<double, 6, 6> &hessian,
-				PointCloudSource &trans_cloud,
-				Eigen::Matrix<double, 6, 1> &p);
+  /** \brief Select new trial value for More-Thuente method.
+   * \note Trial Value Selection [More, Thuente 1994], \f$ \psi(\alpha_k) \f$ is used for \f$ f_k \f$ and \f$ g_k \f$
+   * until some value satisfies the test \f$ \psi(\alpha_k) \leq 0 \f$ and \f$ \phi'(\alpha_k) \geq 0 \f$
+   * then \f$ \phi(\alpha_k) \f$ is used from then on.
+   * \note Interpolation Minimizer equations from Optimization Theory and Methods: Nonlinear Programming By Wenyu Sun, Ya-xiang Yuan (89-100).
+   * \param[in] a_l first endpoint of interval \f$ I \f$, \f$ \alpha_l \f$ in Moore-Thuente (1994)
+   * \param[in] f_l value at first endpoint, \f$ f_l \f$ in Moore-Thuente (1994)
+   * \param[in] g_l derivative at first endpoint, \f$ g_l \f$ in Moore-Thuente (1994)
+   * \param[in] a_u second endpoint of interval \f$ I \f$, \f$ \alpha_u \f$ in Moore-Thuente (1994)
+   * \param[in] f_u value at second endpoint, \f$ f_u \f$ in Moore-Thuente (1994)
+   * \param[in] g_u derivative at second endpoint, \f$ g_u \f$ in Moore-Thuente (1994)
+   * \param[in] a_t previous trial value, \f$ \alpha_t \f$ in Moore-Thuente (1994)
+   * \param[in] f_t value at previous trial value, \f$ f_t \f$ in Moore-Thuente (1994)
+   * \param[in] g_t derivative at previous trial value, \f$ g_t \f$ in Moore-Thuente (1994)
+   * \return new trial value
+   */
+  double trialValueSelectionMT(double a_l, double f_l, double g_l, double a_u, double f_u, double g_u, double a_t, double f_t, double g_t);
 
-		/** \brief Compute individual point contributions to hessian of probability function w.r.t. the transformation vector.
-		  * \note Equation 6.13 [Magnusson 2009].
-		  * \param[in,out] hessian the hessian matrix of the probability function w.r.t. the transformation vector
-		  * \param[in] x_trans transformed point minus mean of occupied covariance voxel
-		  * \param[in] c_inv covariance of occupied covariance voxel
-		  */
-		void
-			updateHessian(Eigen::Matrix<double, 6, 6> &hessian,
-				const Eigen::Matrix<double, 3, 6> &point_gradient_,
-				const Eigen::Matrix<double, 18, 6> &point_hessian_,
-				const Eigen::Vector3d &x_trans, const Eigen::Matrix3d &c_inv) const;
+  /** \brief Auxiliary function used to determine endpoints of More-Thuente interval.
+   * \note \f$ \psi(\alpha) \f$ in Equation 1.6 (Moore, Thuente 1994)
+   * \param[in] a the step length, \f$ \alpha \f$ in More-Thuente (1994)
+   * \param[in] f_a function value at step length a, \f$ \phi(\alpha) \f$ in More-Thuente (1994)
+   * \param[in] f_0 initial function value, \f$ \phi(0) \f$ in Moore-Thuente (1994)
+   * \param[in] g_0 initial function gradiant, \f$ \phi'(0) \f$ in More-Thuente (1994)
+   * \param[in] mu the step length, constant \f$ \mu \f$ in Equation 1.1 [More, Thuente 1994]
+   * \return sufficient decrease value
+   */
+  inline double auxiliaryFunction_PsiMT(double a, double f_a, double f_0, double g_0, double mu = 1.e-4) {
+    return (f_a - f_0 - mu * g_0 * a);
+  }
 
-		/** \brief Compute line search step length and update transform and probability derivatives using More-Thuente method.
-		  * \note Search Algorithm [More, Thuente 1994]
-		  * \param[in] x initial transformation vector, \f$ x \f$ in Equation 1.3 (Moore, Thuente 1994) and \f$ \vec{p} \f$ in Algorithm 2 [Magnusson 2009]
-		  * \param[in] step_dir descent direction, \f$ p \f$ in Equation 1.3 (Moore, Thuente 1994) and \f$ \delta \vec{p} \f$ normalized in Algorithm 2 [Magnusson 2009]
-		  * \param[in] step_init initial step length estimate, \f$ \alpha_0 \f$ in Moore-Thuente (1994) and the normal of \f$ \delta \vec{p} \f$ in Algorithm 2 [Magnusson 2009]
-		  * \param[in] step_max maximum step length, \f$ \alpha_max \f$ in Moore-Thuente (1994)
-		  * \param[in] step_min minimum step length, \f$ \alpha_min \f$ in Moore-Thuente (1994)
-		  * \param[out] score final score function value, \f$ f(x + \alpha p) \f$ in Equation 1.3 (Moore, Thuente 1994) and \f$ score \f$ in Algorithm 2 [Magnusson 2009]
-		  * \param[in,out] score_gradient gradient of score function w.r.t. transformation vector, \f$ f'(x + \alpha p) \f$ in Moore-Thuente (1994) and \f$ \vec{g} \f$ in Algorithm 2 [Magnusson 2009]
-		  * \param[out] hessian hessian of score function w.r.t. transformation vector, \f$ f''(x + \alpha p) \f$ in Moore-Thuente (1994) and \f$ H \f$ in Algorithm 2 [Magnusson 2009]
-		  * \param[in,out] trans_cloud transformed point cloud, \f$ X \f$ transformed by \f$ T(\vec{p},\vec{x}) \f$ in Algorithm 2 [Magnusson 2009]
-		  * \return final step length
-		  */
-		double
-			computeStepLengthMT(const Eigen::Matrix<double, 6, 1> &x,
-				Eigen::Matrix<double, 6, 1> &step_dir,
-				double step_init,
-				double step_max, double step_min,
-				double &score,
-				Eigen::Matrix<double, 6, 1> &score_gradient,
-				Eigen::Matrix<double, 6, 6> &hessian,
-				PointCloudSource &trans_cloud);
+  /** \brief Auxiliary function derivative used to determine endpoints of More-Thuente interval.
+   * \note \f$ \psi'(\alpha) \f$, derivative of Equation 1.6 (Moore, Thuente 1994)
+   * \param[in] g_a function gradient at step length a, \f$ \phi'(\alpha) \f$ in More-Thuente (1994)
+   * \param[in] g_0 initial function gradiant, \f$ \phi'(0) \f$ in More-Thuente (1994)
+   * \param[in] mu the step length, constant \f$ \mu \f$ in Equation 1.1 [More, Thuente 1994]
+   * \return sufficient decrease derivative
+   */
+  inline double auxiliaryFunction_dPsiMT(double g_a, double g_0, double mu = 1.e-4) {
+    return (g_a - mu * g_0);
+  }
 
-		/** \brief Update interval of possible step lengths for More-Thuente method, \f$ I \f$ in More-Thuente (1994)
-		  * \note Updating Algorithm until some value satisfies \f$ \psi(\alpha_k) \leq 0 \f$ and \f$ \phi'(\alpha_k) \geq 0 \f$
-		  * and Modified Updating Algorithm from then on [More, Thuente 1994].
-		  * \param[in,out] a_l first endpoint of interval \f$ I \f$, \f$ \alpha_l \f$ in Moore-Thuente (1994)
-		  * \param[in,out] f_l value at first endpoint, \f$ f_l \f$ in Moore-Thuente (1994), \f$ \psi(\alpha_l) \f$ for Update Algorithm and \f$ \phi(\alpha_l) \f$ for Modified Update Algorithm
-		  * \param[in,out] g_l derivative at first endpoint, \f$ g_l \f$ in Moore-Thuente (1994), \f$ \psi'(\alpha_l) \f$ for Update Algorithm and \f$ \phi'(\alpha_l) \f$ for Modified Update Algorithm
-		  * \param[in,out] a_u second endpoint of interval \f$ I \f$, \f$ \alpha_u \f$ in Moore-Thuente (1994)
-		  * \param[in,out] f_u value at second endpoint, \f$ f_u \f$ in Moore-Thuente (1994), \f$ \psi(\alpha_u) \f$ for Update Algorithm and \f$ \phi(\alpha_u) \f$ for Modified Update Algorithm
-		  * \param[in,out] g_u derivative at second endpoint, \f$ g_u \f$ in Moore-Thuente (1994), \f$ \psi'(\alpha_u) \f$ for Update Algorithm and \f$ \phi'(\alpha_u) \f$ for Modified Update Algorithm
-		  * \param[in] a_t trial value, \f$ \alpha_t \f$ in Moore-Thuente (1994)
-		  * \param[in] f_t value at trial value, \f$ f_t \f$ in Moore-Thuente (1994), \f$ \psi(\alpha_t) \f$ for Update Algorithm and \f$ \phi(\alpha_t) \f$ for Modified Update Algorithm
-		  * \param[in] g_t derivative at trial value, \f$ g_t \f$ in Moore-Thuente (1994), \f$ \psi'(\alpha_t) \f$ for Update Algorithm and \f$ \phi'(\alpha_t) \f$ for Modified Update Algorithm
-		  * \return if interval converges
-		  */
-		bool
-			updateIntervalMT(double &a_l, double &f_l, double &g_l,
-				double &a_u, double &f_u, double &g_u,
-				double a_t, double f_t, double g_t);
+  /** \brief The voxel grid generated from target cloud containing point means and covariances. */
+  TargetGrid target_cells_;
 
-		/** \brief Select new trial value for More-Thuente method.
-		  * \note Trial Value Selection [More, Thuente 1994], \f$ \psi(\alpha_k) \f$ is used for \f$ f_k \f$ and \f$ g_k \f$
-		  * until some value satisfies the test \f$ \psi(\alpha_k) \leq 0 \f$ and \f$ \phi'(\alpha_k) \geq 0 \f$
-		  * then \f$ \phi(\alpha_k) \f$ is used from then on.
-		  * \note Interpolation Minimizer equations from Optimization Theory and Methods: Nonlinear Programming By Wenyu Sun, Ya-xiang Yuan (89-100).
-		  * \param[in] a_l first endpoint of interval \f$ I \f$, \f$ \alpha_l \f$ in Moore-Thuente (1994)
-		  * \param[in] f_l value at first endpoint, \f$ f_l \f$ in Moore-Thuente (1994)
-		  * \param[in] g_l derivative at first endpoint, \f$ g_l \f$ in Moore-Thuente (1994)
-		  * \param[in] a_u second endpoint of interval \f$ I \f$, \f$ \alpha_u \f$ in Moore-Thuente (1994)
-		  * \param[in] f_u value at second endpoint, \f$ f_u \f$ in Moore-Thuente (1994)
-		  * \param[in] g_u derivative at second endpoint, \f$ g_u \f$ in Moore-Thuente (1994)
-		  * \param[in] a_t previous trial value, \f$ \alpha_t \f$ in Moore-Thuente (1994)
-		  * \param[in] f_t value at previous trial value, \f$ f_t \f$ in Moore-Thuente (1994)
-		  * \param[in] g_t derivative at previous trial value, \f$ g_t \f$ in Moore-Thuente (1994)
-		  * \return new trial value
-		  */
-		double
-			trialValueSelectionMT(double a_l, double f_l, double g_l,
-				double a_u, double f_u, double g_u,
-				double a_t, double f_t, double g_t);
+  // double fitness_epsilon_;
 
-		/** \brief Auxiliary function used to determine endpoints of More-Thuente interval.
-		  * \note \f$ \psi(\alpha) \f$ in Equation 1.6 (Moore, Thuente 1994)
-		  * \param[in] a the step length, \f$ \alpha \f$ in More-Thuente (1994)
-		  * \param[in] f_a function value at step length a, \f$ \phi(\alpha) \f$ in More-Thuente (1994)
-		  * \param[in] f_0 initial function value, \f$ \phi(0) \f$ in Moore-Thuente (1994)
-		  * \param[in] g_0 initial function gradiant, \f$ \phi'(0) \f$ in More-Thuente (1994)
-		  * \param[in] mu the step length, constant \f$ \mu \f$ in Equation 1.1 [More, Thuente 1994]
-		  * \return sufficient decrease value
-		  */
-		inline double
-			auxiliaryFunction_PsiMT(double a, double f_a, double f_0, double g_0, double mu = 1.e-4)
-		{
-			return (f_a - f_0 - mu * g_0 * a);
-		}
+  /** \brief The side length of voxels. */
+  float resolution_;
 
-		/** \brief Auxiliary function derivative used to determine endpoints of More-Thuente interval.
-		  * \note \f$ \psi'(\alpha) \f$, derivative of Equation 1.6 (Moore, Thuente 1994)
-		  * \param[in] g_a function gradient at step length a, \f$ \phi'(\alpha) \f$ in More-Thuente (1994)
-		  * \param[in] g_0 initial function gradiant, \f$ \phi'(0) \f$ in More-Thuente (1994)
-		  * \param[in] mu the step length, constant \f$ \mu \f$ in Equation 1.1 [More, Thuente 1994]
-		  * \return sufficient decrease derivative
-		  */
-		inline double
-			auxiliaryFunction_dPsiMT(double g_a, double g_0, double mu = 1.e-4)
-		{
-			return (g_a - mu * g_0);
-		}
+  /** \brief The maximum step length. */
+  double step_size_;
 
-		/** \brief The voxel grid generated from target cloud containing point means and covariances. */
-		TargetGrid target_cells_;
+  /** \brief The ratio of outliers of points w.r.t. a normal distribution, Equation 6.7 [Magnusson 2009]. */
+  double outlier_ratio_;
 
-		//double fitness_epsilon_;
+  /** \brief The normalization constants used fit the point distribution to a normal distribution, Equation 6.8 [Magnusson 2009]. */
+  double gauss_d1_, gauss_d2_, gauss_d3_;
 
-		/** \brief The side length of voxels. */
-		float resolution_;
+  /** \brief The probability score of the transform applied to the input cloud, Equation 6.9 and 6.10 [Magnusson 2009]. */
+  double trans_probability_;
 
-		/** \brief The maximum step length. */
-		double step_size_;
+  /** \brief Precomputed Angular Gradient
+   *
+   * The precomputed angular derivatives for the jacobian of a transformation vector, Equation 6.19 [Magnusson 2009].
+   */
+  Eigen::Vector3d j_ang_a_, j_ang_b_, j_ang_c_, j_ang_d_, j_ang_e_, j_ang_f_, j_ang_g_, j_ang_h_;
 
-		/** \brief The ratio of outliers of points w.r.t. a normal distribution, Equation 6.7 [Magnusson 2009]. */
-		double outlier_ratio_;
+  Eigen::Matrix<float, 8, 4> j_ang;
 
-		/** \brief The normalization constants used fit the point distribution to a normal distribution, Equation 6.8 [Magnusson 2009]. */
-		double gauss_d1_, gauss_d2_, gauss_d3_;
+  /** \brief Precomputed Angular Hessian
+   *
+   * The precomputed angular derivatives for the hessian of a transformation vector, Equation 6.19 [Magnusson 2009].
+   */
+  Eigen::Vector3d h_ang_a2_, h_ang_a3_, h_ang_b2_, h_ang_b3_, h_ang_c2_, h_ang_c3_, h_ang_d1_, h_ang_d2_, h_ang_d3_, h_ang_e1_, h_ang_e2_, h_ang_e3_, h_ang_f1_, h_ang_f2_, h_ang_f3_;
 
-		/** \brief The probability score of the transform applied to the input cloud, Equation 6.9 and 6.10 [Magnusson 2009]. */
-		double trans_probability_;
+  Eigen::Matrix<float, 16, 4> h_ang;
 
-		/** \brief Precomputed Angular Gradient
-		  *
-		  * The precomputed angular derivatives for the jacobian of a transformation vector, Equation 6.19 [Magnusson 2009].
-		  */
-		Eigen::Vector3d j_ang_a_, j_ang_b_, j_ang_c_, j_ang_d_, j_ang_e_, j_ang_f_, j_ang_g_, j_ang_h_;
-
-		Eigen::Matrix<float, 8, 4> j_ang;
-
-		/** \brief Precomputed Angular Hessian
-		  *
-		  * The precomputed angular derivatives for the hessian of a transformation vector, Equation 6.19 [Magnusson 2009].
-		  */
-		Eigen::Vector3d h_ang_a2_, h_ang_a3_,
-			h_ang_b2_, h_ang_b3_,
-			h_ang_c2_, h_ang_c3_,
-			h_ang_d1_, h_ang_d2_, h_ang_d3_,
-			h_ang_e1_, h_ang_e2_, h_ang_e3_,
-			h_ang_f1_, h_ang_f2_, h_ang_f3_;
-
-		Eigen::Matrix<float, 16, 4> h_ang;
-
-		/** \brief The first order derivative of the transformation of a point w.r.t. the transform vector, \f$ J_E \f$ in Equation 6.18 [Magnusson 2009]. */
+  /** \brief The first order derivative of the transformation of a point w.r.t. the transform vector, \f$ J_E \f$ in Equation 6.18 [Magnusson 2009]. */
   //      Eigen::Matrix<double, 3, 6> point_gradient_;
 
-		/** \brief The second order derivative of the transformation of a point w.r.t. the transform vector, \f$ H_E \f$ in Equation 6.20 [Magnusson 2009]. */
+  /** \brief The second order derivative of the transformation of a point w.r.t. the transform vector, \f$ H_E \f$ in Equation 6.20 [Magnusson 2009]. */
   //      Eigen::Matrix<double, 18, 6> point_hessian_;
 
-    int num_threads_;
+  int num_threads_;
 
-	Eigen::Matrix<double, 6, 6> hessian_;
-	std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f>> transformation_array_;
-	double nearest_voxel_transformation_likelihood_;
+  Eigen::Matrix<double, 6, 6> hessian_;
+  std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f>> transformation_array_;
+  double nearest_voxel_transformation_likelihood_;
 
-	float regularization_scale_factor_;
-	boost::optional<Eigen::Matrix4f> regularization_pose_;
-	Eigen::Vector3f regularization_pose_translation_;
+  float regularization_scale_factor_;
+  boost::optional<Eigen::Matrix4f> regularization_pose_;
+  Eigen::Vector3f regularization_pose_translation_;
 
-	public:
-		EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-	};
+public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
 
-}
+}  // namespace pclomp
 
-#endif // PCL_REGISTRATION_NDT_MULTI_VOXEL_H_
+#endif  // PCL_REGISTRATION_NDT_MULTI_VOXEL_H_

--- a/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp
+++ b/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp
@@ -58,30 +58,18 @@
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template<typename PointSource, typename PointTarget>
-pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::MultiGridNormalDistributionsTransform ()
-  : target_cells_ ()
-  , resolution_ (1.0f)
-  , step_size_ (0.1)
-  , outlier_ratio_ (0.55)
-  , gauss_d1_ ()
-  , gauss_d2_ ()
-  , gauss_d3_ ()
-  , trans_probability_ ()
-  , regularization_pose_ (boost::none)
-  , j_ang_a_ (), j_ang_b_ (), j_ang_c_ (), j_ang_d_ (), j_ang_e_ (), j_ang_f_ (), j_ang_g_ (), j_ang_h_ ()
-  , h_ang_a2_ (), h_ang_a3_ (), h_ang_b2_ (), h_ang_b3_ (), h_ang_c2_ (), h_ang_c3_ (), h_ang_d1_ (), h_ang_d2_ ()
-  , h_ang_d3_ (), h_ang_e1_ (), h_ang_e2_ (), h_ang_e3_ (), h_ang_f1_ (), h_ang_f2_ (), h_ang_f3_ ()
-{
+pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::MultiGridNormalDistributionsTransform()
+    : target_cells_(), resolution_(1.0f), step_size_(0.1), outlier_ratio_(0.55), gauss_d1_(), gauss_d2_(), gauss_d3_(), trans_probability_(), regularization_pose_(boost::none), j_ang_a_(), j_ang_b_(), j_ang_c_(), j_ang_d_(), j_ang_e_(), j_ang_f_(), j_ang_g_(), j_ang_h_(), h_ang_a2_(), h_ang_a3_(), h_ang_b2_(), h_ang_b3_(), h_ang_c2_(), h_ang_c3_(), h_ang_d1_(), h_ang_d2_(), h_ang_d3_(), h_ang_e1_(), h_ang_e2_(), h_ang_e3_(), h_ang_f1_(), h_ang_f2_(), h_ang_f3_() {
   reg_name_ = "MultiGridNormalDistributionsTransform";
 
   double gauss_c1, gauss_c2;
 
   // Initializes the gaussian fitting parameters (eq. 6.8) [Magnusson 2009]
   gauss_c1 = 10.0 * (1 - outlier_ratio_);
-  gauss_c2 = outlier_ratio_ / pow (resolution_, 3);
-  gauss_d3_ = -log (gauss_c2);
-  gauss_d1_ = -log ( gauss_c1 + gauss_c2 ) - gauss_d3_;
-  gauss_d2_ = -2 * log ((-log ( gauss_c1 * exp ( -0.5 ) + gauss_c2 ) - gauss_d3_) / gauss_d1_);
+  gauss_c2 = outlier_ratio_ / pow(resolution_, 3);
+  gauss_d3_ = -log(gauss_c2);
+  gauss_d1_ = -log(gauss_c1 + gauss_c2) - gauss_d3_;
+  gauss_d2_ = -2 * log((-log(gauss_c1 * exp(-0.5) + gauss_c2) - gauss_d3_) / gauss_d1_);
 
   transformation_epsilon_ = 0.1;
   max_iterations_ = 35;
@@ -89,11 +77,9 @@ pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::MultiGr
   num_threads_ = omp_get_max_threads();
 }
 
-
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget> void
-pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeTransformation (PointCloudSource &output, const Eigen::Matrix4f &guess)
-{
+template<typename PointSource, typename PointTarget>
+void pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeTransformation(PointCloudSource &output, const Eigen::Matrix4f &guess) {
   nr_iterations_ = 0;
   converged_ = false;
 
@@ -101,128 +87,114 @@ pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::compute
 
   // Initializes the gaussian fitting parameters (eq. 6.8) [Magnusson 2009]
   gauss_c1 = 10 * (1 - outlier_ratio_);
-  gauss_c2 = outlier_ratio_ / pow (resolution_, 3);
-  gauss_d3_ = -log (gauss_c2);
-  gauss_d1_ = -log ( gauss_c1 + gauss_c2 ) - gauss_d3_;
-  gauss_d2_ = -2 * log ((-log ( gauss_c1 * exp ( -0.5 ) + gauss_c2 ) - gauss_d3_) / gauss_d1_);
+  gauss_c2 = outlier_ratio_ / pow(resolution_, 3);
+  gauss_d3_ = -log(gauss_c2);
+  gauss_d1_ = -log(gauss_c1 + gauss_c2) - gauss_d3_;
+  gauss_d2_ = -2 * log((-log(gauss_c1 * exp(-0.5) + gauss_c2) - gauss_d3_) / gauss_d1_);
 
-  if (guess != Eigen::Matrix4f::Identity ())
-  {
+  if(guess != Eigen::Matrix4f::Identity()) {
     // Initialise final transformation to the guessed one
     final_transformation_ = guess;
     // Apply guessed transformation prior to search for neighbours
-    transformPointCloud (output, output, guess);
+    transformPointCloud(output, output, guess);
   }
 
   Eigen::Transform<float, 3, Eigen::Affine, Eigen::ColMajor> eig_transformation;
-  eig_transformation.matrix () = final_transformation_;
+  eig_transformation.matrix() = final_transformation_;
   transformation_array_.clear();
   transformation_array_.push_back(final_transformation_);
 
   // Convert initial guess matrix to 6 element transformation vector
   Eigen::Matrix<double, 6, 1> p, delta_p, score_gradient;
-  Eigen::Vector3f init_translation = eig_transformation.translation ();
-  Eigen::Vector3f init_rotation = eig_transformation.rotation ().eulerAngles (0, 1, 2);
-  p << init_translation (0), init_translation (1), init_translation (2),
-  init_rotation (0), init_rotation (1), init_rotation (2);
+  Eigen::Vector3f init_translation = eig_transformation.translation();
+  Eigen::Vector3f init_rotation = eig_transformation.rotation().eulerAngles(0, 1, 2);
+  p << init_translation(0), init_translation(1), init_translation(2), init_rotation(0), init_rotation(1), init_rotation(2);
 
   Eigen::Matrix<double, 6, 6> hessian;
 
   double score = 0;
   double delta_p_norm;
 
-  if (regularization_pose_)
-  {
+  if(regularization_pose_) {
     Eigen::Transform<float, 3, Eigen::Affine, Eigen::ColMajor> regularization_pose_transformation;
     regularization_pose_transformation.matrix() = regularization_pose_.get();
     regularization_pose_translation_ = regularization_pose_transformation.translation();
   }
 
   // Calculate derivatives of initial transform vector, subsequent derivative calculations are done in the step length determination.
-  score = computeDerivatives (score_gradient, hessian, output, p);
+  score = computeDerivatives(score_gradient, hessian, output, p);
 
-  while (!converged_)
-  {
+  while(!converged_) {
     // Store previous transformation
     previous_transformation_ = transformation_;
 
     // Solve for decent direction using newton method, line 23 in Algorithm 2 [Magnusson 2009]
-    Eigen::JacobiSVD<Eigen::Matrix<double, 6, 6> > sv (hessian, Eigen::ComputeFullU | Eigen::ComputeFullV);
+    Eigen::JacobiSVD<Eigen::Matrix<double, 6, 6>> sv(hessian, Eigen::ComputeFullU | Eigen::ComputeFullV);
     // Negative for maximization as opposed to minimization
-    delta_p = sv.solve (-score_gradient);
+    delta_p = sv.solve(-score_gradient);
 
-    //Calculate step length with guaranteed sufficient decrease [More, Thuente 1994]
-    delta_p_norm = delta_p.norm ();
+    // Calculate step length with guaranteed sufficient decrease [More, Thuente 1994]
+    delta_p_norm = delta_p.norm();
 
-    if (delta_p_norm == 0 || delta_p_norm != delta_p_norm)
-    {
-      if (input_->points.empty()) {
+    if(delta_p_norm == 0 || delta_p_norm != delta_p_norm) {
+      if(input_->points.empty()) {
         trans_probability_ = 0.0f;
-      }
-      else {
-        trans_probability_ = score / static_cast<double> (input_->points.size ());
+      } else {
+        trans_probability_ = score / static_cast<double>(input_->points.size());
       }
 
       converged_ = delta_p_norm == delta_p_norm;
       return;
     }
 
-    delta_p.normalize ();
-    delta_p_norm = computeStepLengthMT (p, delta_p, delta_p_norm, step_size_, transformation_epsilon_ / 2, score, score_gradient, hessian, output);
+    delta_p.normalize();
+    delta_p_norm = computeStepLengthMT(p, delta_p, delta_p_norm, step_size_, transformation_epsilon_ / 2, score, score_gradient, hessian, output);
     delta_p *= delta_p_norm;
 
-
-    transformation_ = (Eigen::Translation<float, 3> (static_cast<float> (delta_p (0)), static_cast<float> (delta_p (1)), static_cast<float> (delta_p (2))) *
-                       Eigen::AngleAxis<float> (static_cast<float> (delta_p (3)), Eigen::Vector3f::UnitX ()) *
-                       Eigen::AngleAxis<float> (static_cast<float> (delta_p (4)), Eigen::Vector3f::UnitY ()) *
-                       Eigen::AngleAxis<float> (static_cast<float> (delta_p (5)), Eigen::Vector3f::UnitZ ())).matrix ();
+    transformation_ = (Eigen::Translation<float, 3>(static_cast<float>(delta_p(0)), static_cast<float>(delta_p(1)), static_cast<float>(delta_p(2))) * Eigen::AngleAxis<float>(static_cast<float>(delta_p(3)), Eigen::Vector3f::UnitX()) * Eigen::AngleAxis<float>(static_cast<float>(delta_p(4)), Eigen::Vector3f::UnitY()) * Eigen::AngleAxis<float>(static_cast<float>(delta_p(5)), Eigen::Vector3f::UnitZ()))
+                          .matrix();
 
     transformation_array_.push_back(final_transformation_);
 
     p = p + delta_p;
 
     // Update Visualizer (untested)
-    if (update_visualizer_ != 0)
-      update_visualizer_ (output, std::vector<int>(), *target_, std::vector<int>() );
+    if(update_visualizer_ != 0) update_visualizer_(output, std::vector<int>(), *target_, std::vector<int>());
 
     nr_iterations_++;
 
-    if (nr_iterations_ >= max_iterations_ ||
-        (nr_iterations_ && (std::fabs (delta_p_norm) < transformation_epsilon_)))
-    {
+    if(nr_iterations_ >= max_iterations_ || (nr_iterations_ && (std::fabs(delta_p_norm) < transformation_epsilon_))) {
       converged_ = true;
     }
   }
 
   // Store transformation probability. The relative differences within each scan registration are accurate
   // but the normalization constants need to be modified for it to be globally accurate
-  if (input_->points.empty()) {
+  if(input_->points.empty()) {
     trans_probability_ = 0.0f;
-  }
-  else {
-    trans_probability_ = score / static_cast<double> (input_->points.size ());
+  } else {
+    trans_probability_ = score / static_cast<double>(input_->points.size());
   }
 
   hessian_ = hessian;
 }
 
 #ifndef _OPENMP
-int omp_get_max_threads() { return 1; }
-int omp_get_thread_num() { return 0; }
+int omp_get_max_threads() {
+  return 1;
+}
+int omp_get_thread_num() {
+  return 0;
+}
 #endif
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget> double
-pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeDerivatives(Eigen::Matrix<double, 6, 1> &score_gradient,
-	Eigen::Matrix<double, 6, 6> &hessian,
-	PointCloudSource &trans_cloud,
-	Eigen::Matrix<double, 6, 1> &p,
-	bool compute_hessian)
-{
-	score_gradient.setZero();
-	hessian.setZero();
-	double score = 0;
-	int total_neighborhood_count = 0;
+template<typename PointSource, typename PointTarget>
+double pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeDerivatives(Eigen::Matrix<double, 6, 1> &score_gradient, Eigen::Matrix<double, 6, 6> &hessian, PointCloudSource &trans_cloud, Eigen::Matrix<double, 6, 1> &p, bool compute_hessian) {
+  score_gradient.setZero();
+  hessian.setZero();
+  double score = 0;
+  int total_neighborhood_count = 0;
   double nearest_voxel_score = 0;
   size_t found_neigborhood_voxel_num = 0;
 
@@ -232,395 +204,366 @@ pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::compute
   std::vector<Eigen::Matrix<double, 6, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 6, 1>>> score_gradients(input_->points.size());
   std::vector<Eigen::Matrix<double, 6, 6>, Eigen::aligned_allocator<Eigen::Matrix<double, 6, 6>>> hessians(input_->points.size());
   std::vector<int> neighborhood_counts(input_->points.size());
-  for (std::size_t i = 0; i < input_->points.size(); i++) {
-		scores[i] = 0;
+  for(std::size_t i = 0; i < input_->points.size(); i++) {
+    scores[i] = 0;
     nearest_voxel_scores[i] = 0;
     found_neigborhood_voxel_nums[i] = 0;
-		score_gradients[i].setZero();
-		hessians[i].setZero();
-		neighborhood_counts[i] = 0;
-	}
+    score_gradients[i].setZero();
+    hessians[i].setZero();
+    neighborhood_counts[i] = 0;
+  }
 
-	// Precompute Angular Derivatives (eq. 6.19 and 6.21)[Magnusson 2009]
-	computeAngleDerivatives(p);
+  // Precompute Angular Derivatives (eq. 6.19 and 6.21)[Magnusson 2009]
+  computeAngleDerivatives(p);
 
   std::vector<std::vector<TargetGridLeafConstPtr>> neighborhoods(num_threads_);
   std::vector<std::vector<float>> distancess(num_threads_);
 
   // Update gradient and hessian for each point, line 17 in Algorithm 2 [Magnusson 2009]
 #pragma omp parallel for num_threads(num_threads_) schedule(guided, 8)
-	for (std::size_t idx = 0; idx < input_->points.size(); idx++)
-	{
-		int thread_n = omp_get_thread_num();
+  for(std::size_t idx = 0; idx < input_->points.size(); idx++) {
+    int thread_n = omp_get_thread_num();
 
-		// Original Point and Transformed Point
-		PointSource x_pt, x_trans_pt;
-		// Original Point and Transformed Point (for math)
-		Eigen::Vector3d x, x_trans;
-		// Occupied Voxel
-		TargetGridLeafConstPtr cell;
-		// Inverse Covariance of Occupied Voxel
-		Eigen::Matrix3d c_inv;
+    // Original Point and Transformed Point
+    PointSource x_pt, x_trans_pt;
+    // Original Point and Transformed Point (for math)
+    Eigen::Vector3d x, x_trans;
+    // Occupied Voxel
+    TargetGridLeafConstPtr cell;
+    // Inverse Covariance of Occupied Voxel
+    Eigen::Matrix3d c_inv;
 
-		// Initialize Point Gradient and Hessian
-		Eigen::Matrix<float, 4, 6> point_gradient_;
-		Eigen::Matrix<float, 24, 6> point_hessian_;
-		point_gradient_.setZero();
-		point_gradient_.block<3, 3>(0, 0).setIdentity();
-		point_hessian_.setZero();
+    // Initialize Point Gradient and Hessian
+    Eigen::Matrix<float, 4, 6> point_gradient_;
+    Eigen::Matrix<float, 24, 6> point_hessian_;
+    point_gradient_.setZero();
+    point_gradient_.block<3, 3>(0, 0).setIdentity();
+    point_hessian_.setZero();
 
-		x_trans_pt = trans_cloud.points[idx];
+    x_trans_pt = trans_cloud.points[idx];
 
-		auto& neighborhood = neighborhoods[thread_n];
-		auto& distances = distancess[thread_n];
+    auto &neighborhood = neighborhoods[thread_n];
+    auto &distances = distancess[thread_n];
 
     // Neighborhood search method other than kdtree is disabled in multigrid_ndt_omp
     target_cells_.radiusSearch(x_trans_pt, resolution_, neighborhood, distances);
 
-		double sum_score_pt = 0;
+    double sum_score_pt = 0;
     double nearest_voxel_score_pt = 0;
-		Eigen::Matrix<double, 6, 1> score_gradient_pt = Eigen::Matrix<double, 6, 1>::Zero();
-		Eigen::Matrix<double, 6, 6> hessian_pt = Eigen::Matrix<double, 6, 6>::Zero();
-		int neighborhood_count = 0;
+    Eigen::Matrix<double, 6, 1> score_gradient_pt = Eigen::Matrix<double, 6, 1>::Zero();
+    Eigen::Matrix<double, 6, 6> hessian_pt = Eigen::Matrix<double, 6, 6>::Zero();
+    int neighborhood_count = 0;
 
-		for (typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it = neighborhood.begin(); neighborhood_it != neighborhood.end(); neighborhood_it++)
-		{
-			cell = *neighborhood_it;
-			x_pt = input_->points[idx];
-			x = Eigen::Vector3d(x_pt.x, x_pt.y, x_pt.z);
+    for(typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it = neighborhood.begin(); neighborhood_it != neighborhood.end(); neighborhood_it++) {
+      cell = *neighborhood_it;
+      x_pt = input_->points[idx];
+      x = Eigen::Vector3d(x_pt.x, x_pt.y, x_pt.z);
 
-			x_trans = Eigen::Vector3d(x_trans_pt.x, x_trans_pt.y, x_trans_pt.z);
+      x_trans = Eigen::Vector3d(x_trans_pt.x, x_trans_pt.y, x_trans_pt.z);
 
-			// Denorm point, x_k' in Equations 6.12 and 6.13 [Magnusson 2009]
-			x_trans -= cell->getMean();
-			// Uses precomputed covariance for speed.
-			c_inv = cell->getInverseCov();
+      // Denorm point, x_k' in Equations 6.12 and 6.13 [Magnusson 2009]
+      x_trans -= cell->getMean();
+      // Uses precomputed covariance for speed.
+      c_inv = cell->getInverseCov();
 
-			// Compute derivative of transform function w.r.t. transform vector, J_E and H_E in Equations 6.18 and 6.20 [Magnusson 2009]
-			computePointDerivatives(x, point_gradient_, point_hessian_);
-			// Update score, gradient and hessian, lines 19-21 in Algorithm 2, according to Equations 6.10, 6.12 and 6.13, respectively [Magnusson 2009]
-			double score_pt = updateDerivatives(score_gradient_pt, hessian_pt, point_gradient_, point_hessian_, x_trans, c_inv, compute_hessian);
-			neighborhood_count++;
+      // Compute derivative of transform function w.r.t. transform vector, J_E and H_E in Equations 6.18 and 6.20 [Magnusson 2009]
+      computePointDerivatives(x, point_gradient_, point_hessian_);
+      // Update score, gradient and hessian, lines 19-21 in Algorithm 2, according to Equations 6.10, 6.12 and 6.13, respectively [Magnusson 2009]
+      double score_pt = updateDerivatives(score_gradient_pt, hessian_pt, point_gradient_, point_hessian_, x_trans, c_inv, compute_hessian);
+      neighborhood_count++;
       sum_score_pt += score_pt;
-      if (score_pt > nearest_voxel_score_pt) {
+      if(score_pt > nearest_voxel_score_pt) {
         nearest_voxel_score_pt = score_pt;
       }
-		}
+    }
 
     if(!neighborhood.empty()) {
       ++found_neigborhood_voxel_nums[idx];
     }
 
-		scores[idx] = sum_score_pt;
+    scores[idx] = sum_score_pt;
     nearest_voxel_scores[idx] = nearest_voxel_score_pt;
-		score_gradients[idx].noalias() = score_gradient_pt;
-		hessians[idx].noalias() = hessian_pt;
-		neighborhood_counts[idx] += neighborhood_count;
-	}
+    score_gradients[idx].noalias() = score_gradient_pt;
+    hessians[idx].noalias() = hessian_pt;
+    neighborhood_counts[idx] += neighborhood_count;
+  }
 
   // Ensure that the result is invariant against the summing up order
-  for (std::size_t i = 0; i < input_->points.size(); i++) {
-		score += scores[i];
+  for(std::size_t i = 0; i < input_->points.size(); i++) {
+    score += scores[i];
     nearest_voxel_score += nearest_voxel_scores[i];
     found_neigborhood_voxel_num += found_neigborhood_voxel_nums[i];
-		score_gradient += score_gradients[i];
-		hessian += hessians[i];
-		total_neighborhood_count += neighborhood_counts[i];
-	}
-
-	if (regularization_pose_) {
-		float regularization_score = 0.0f;
-		Eigen::Matrix<double, 6, 1> regularization_gradient = Eigen::Matrix<double, 6, 1>::Zero();
-		Eigen::Matrix<double, 6, 6> regularization_hessian = Eigen::Matrix<double, 6, 6>::Zero();
-
-		const float dx = regularization_pose_translation_(0) - static_cast<float>(p(0, 0));
-		const float dy = regularization_pose_translation_(1) - static_cast<float>(p(1, 0));
-		const auto sin_yaw = static_cast<float>(sin(p(5, 0)));
-		const auto cos_yaw = static_cast<float>(cos(p(5, 0)));
-		const float longitudinal_distance = dy * sin_yaw + dx * cos_yaw;
-		const auto neighborhood_count_weight = static_cast<float>(total_neighborhood_count);
-
-		regularization_score = - regularization_scale_factor_ * neighborhood_count_weight * longitudinal_distance * longitudinal_distance;
-
-		regularization_gradient(0, 0) = regularization_scale_factor_ * neighborhood_count_weight * 2.0f * cos_yaw * longitudinal_distance;
-		regularization_gradient(1, 0) = regularization_scale_factor_ * neighborhood_count_weight * 2.0f * sin_yaw * longitudinal_distance;
-
-		regularization_hessian(0, 0) = - regularization_scale_factor_ * neighborhood_count_weight * 2.0f * cos_yaw * cos_yaw;
-		regularization_hessian(0, 1) = - regularization_scale_factor_ * neighborhood_count_weight * 2.0f * cos_yaw * sin_yaw;
-		regularization_hessian(1, 1) = - regularization_scale_factor_ * neighborhood_count_weight * 2.0f * sin_yaw * sin_yaw;
-		regularization_hessian(1, 0) = regularization_hessian(0, 1);
-
-		score += regularization_score;
-		score_gradient += regularization_gradient;
-		hessian += regularization_hessian;
-	}
-
-  if (found_neigborhood_voxel_num != 0) {
-    nearest_voxel_transformation_likelihood_ = nearest_voxel_score / static_cast<double>(found_neigborhood_voxel_num);
+    score_gradient += score_gradients[i];
+    hessian += hessians[i];
+    total_neighborhood_count += neighborhood_counts[i];
   }
-  else {
+
+  if(regularization_pose_) {
+    float regularization_score = 0.0f;
+    Eigen::Matrix<double, 6, 1> regularization_gradient = Eigen::Matrix<double, 6, 1>::Zero();
+    Eigen::Matrix<double, 6, 6> regularization_hessian = Eigen::Matrix<double, 6, 6>::Zero();
+
+    const float dx = regularization_pose_translation_(0) - static_cast<float>(p(0, 0));
+    const float dy = regularization_pose_translation_(1) - static_cast<float>(p(1, 0));
+    const auto sin_yaw = static_cast<float>(sin(p(5, 0)));
+    const auto cos_yaw = static_cast<float>(cos(p(5, 0)));
+    const float longitudinal_distance = dy * sin_yaw + dx * cos_yaw;
+    const auto neighborhood_count_weight = static_cast<float>(total_neighborhood_count);
+
+    regularization_score = -regularization_scale_factor_ * neighborhood_count_weight * longitudinal_distance * longitudinal_distance;
+
+    regularization_gradient(0, 0) = regularization_scale_factor_ * neighborhood_count_weight * 2.0f * cos_yaw * longitudinal_distance;
+    regularization_gradient(1, 0) = regularization_scale_factor_ * neighborhood_count_weight * 2.0f * sin_yaw * longitudinal_distance;
+
+    regularization_hessian(0, 0) = -regularization_scale_factor_ * neighborhood_count_weight * 2.0f * cos_yaw * cos_yaw;
+    regularization_hessian(0, 1) = -regularization_scale_factor_ * neighborhood_count_weight * 2.0f * cos_yaw * sin_yaw;
+    regularization_hessian(1, 1) = -regularization_scale_factor_ * neighborhood_count_weight * 2.0f * sin_yaw * sin_yaw;
+    regularization_hessian(1, 0) = regularization_hessian(0, 1);
+
+    score += regularization_score;
+    score_gradient += regularization_gradient;
+    hessian += regularization_hessian;
+  }
+
+  if(found_neigborhood_voxel_num != 0) {
+    nearest_voxel_transformation_likelihood_ = nearest_voxel_score / static_cast<double>(found_neigborhood_voxel_num);
+  } else {
     nearest_voxel_transformation_likelihood_ = 0.0;
   }
 
-	return (score);
+  return (score);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget> void
-pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeAngleDerivatives(Eigen::Matrix<double, 6, 1> &p, bool compute_hessian)
-{
-	// Simplified math for near 0 angles
-	double cx, cy, cz, sx, sy, sz;
-	if (fabs(p(3)) < 10e-5)
-	{
-		//p(3) = 0;
-		cx = 1.0;
-		sx = 0.0;
-	}
-	else
-	{
-		cx = cos(p(3));
-		sx = sin(p(3));
-	}
-	if (fabs(p(4)) < 10e-5)
-	{
-		//p(4) = 0;
-		cy = 1.0;
-		sy = 0.0;
-	}
-	else
-	{
-		cy = cos(p(4));
-		sy = sin(p(4));
-	}
+template<typename PointSource, typename PointTarget>
+void pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeAngleDerivatives(Eigen::Matrix<double, 6, 1> &p, bool compute_hessian) {
+  // Simplified math for near 0 angles
+  double cx, cy, cz, sx, sy, sz;
+  if(fabs(p(3)) < 10e-5) {
+    // p(3) = 0;
+    cx = 1.0;
+    sx = 0.0;
+  } else {
+    cx = cos(p(3));
+    sx = sin(p(3));
+  }
+  if(fabs(p(4)) < 10e-5) {
+    // p(4) = 0;
+    cy = 1.0;
+    sy = 0.0;
+  } else {
+    cy = cos(p(4));
+    sy = sin(p(4));
+  }
 
-	if (fabs(p(5)) < 10e-5)
-	{
-		//p(5) = 0;
-		cz = 1.0;
-		sz = 0.0;
-	}
-	else
-	{
-		cz = cos(p(5));
-		sz = sin(p(5));
-	}
+  if(fabs(p(5)) < 10e-5) {
+    // p(5) = 0;
+    cz = 1.0;
+    sz = 0.0;
+  } else {
+    cz = cos(p(5));
+    sz = sin(p(5));
+  }
 
-	// Precomputed angular gradiant components. Letters correspond to Equation 6.19 [Magnusson 2009]
-	j_ang_a_ << (-sx * sz + cx * sy * cz), (-sx * cz - cx * sy * sz), (-cx * cy);
-	j_ang_b_ << (cx * sz + sx * sy * cz), (cx * cz - sx * sy * sz), (-sx * cy);
-	j_ang_c_ << (-sy * cz), sy * sz, cy;
-	j_ang_d_ << sx * cy * cz, (-sx * cy * sz), sx * sy;
-	j_ang_e_ << (-cx * cy * cz), cx * cy * sz, (-cx * sy);
-	j_ang_f_ << (-cy * sz), (-cy * cz), 0;
-	j_ang_g_ << (cx * cz - sx * sy * sz), (-cx * sz - sx * sy * cz), 0;
-	j_ang_h_ << (sx * cz + cx * sy * sz), (cx * sy * cz - sx * sz), 0;
+  // Precomputed angular gradiant components. Letters correspond to Equation 6.19 [Magnusson 2009]
+  j_ang_a_ << (-sx * sz + cx * sy * cz), (-sx * cz - cx * sy * sz), (-cx * cy);
+  j_ang_b_ << (cx * sz + sx * sy * cz), (cx * cz - sx * sy * sz), (-sx * cy);
+  j_ang_c_ << (-sy * cz), sy * sz, cy;
+  j_ang_d_ << sx * cy * cz, (-sx * cy * sz), sx * sy;
+  j_ang_e_ << (-cx * cy * cz), cx * cy * sz, (-cx * sy);
+  j_ang_f_ << (-cy * sz), (-cy * cz), 0;
+  j_ang_g_ << (cx * cz - sx * sy * sz), (-cx * sz - sx * sy * cz), 0;
+  j_ang_h_ << (sx * cz + cx * sy * sz), (cx * sy * cz - sx * sz), 0;
 
-	j_ang.setZero();
-	j_ang.row(0).noalias() = Eigen::Vector4f((-sx * sz + cx * sy * cz), (-sx * cz - cx * sy * sz), (-cx * cy), 0.0f);
-	j_ang.row(1).noalias() = Eigen::Vector4f((cx * sz + sx * sy * cz), (cx * cz - sx * sy * sz), (-sx * cy), 0.0f);
-	j_ang.row(2).noalias() = Eigen::Vector4f((-sy * cz), sy * sz, cy, 0.0f);
-	j_ang.row(3).noalias() = Eigen::Vector4f(sx * cy * cz, (-sx * cy * sz), sx * sy, 0.0f);
-	j_ang.row(4).noalias() = Eigen::Vector4f((-cx * cy * cz), cx * cy * sz, (-cx * sy), 0.0f);
-	j_ang.row(5).noalias() = Eigen::Vector4f((-cy * sz), (-cy * cz), 0, 0.0f);
-	j_ang.row(6).noalias() = Eigen::Vector4f((cx * cz - sx * sy * sz), (-cx * sz - sx * sy * cz), 0, 0.0f);
-	j_ang.row(7).noalias() = Eigen::Vector4f((sx * cz + cx * sy * sz), (cx * sy * cz - sx * sz), 0, 0.0f);
+  j_ang.setZero();
+  j_ang.row(0).noalias() = Eigen::Vector4f((-sx * sz + cx * sy * cz), (-sx * cz - cx * sy * sz), (-cx * cy), 0.0f);
+  j_ang.row(1).noalias() = Eigen::Vector4f((cx * sz + sx * sy * cz), (cx * cz - sx * sy * sz), (-sx * cy), 0.0f);
+  j_ang.row(2).noalias() = Eigen::Vector4f((-sy * cz), sy * sz, cy, 0.0f);
+  j_ang.row(3).noalias() = Eigen::Vector4f(sx * cy * cz, (-sx * cy * sz), sx * sy, 0.0f);
+  j_ang.row(4).noalias() = Eigen::Vector4f((-cx * cy * cz), cx * cy * sz, (-cx * sy), 0.0f);
+  j_ang.row(5).noalias() = Eigen::Vector4f((-cy * sz), (-cy * cz), 0, 0.0f);
+  j_ang.row(6).noalias() = Eigen::Vector4f((cx * cz - sx * sy * sz), (-cx * sz - sx * sy * cz), 0, 0.0f);
+  j_ang.row(7).noalias() = Eigen::Vector4f((sx * cz + cx * sy * sz), (cx * sy * cz - sx * sz), 0, 0.0f);
 
-	if (compute_hessian)
-	{
-		// Precomputed angular hessian components. Letters correspond to Equation 6.21 and numbers correspond to row index [Magnusson 2009]
-		h_ang_a2_ << (-cx * sz - sx * sy * cz), (-cx * cz + sx * sy * sz), sx * cy;
-		h_ang_a3_ << (-sx * sz + cx * sy * cz), (-cx * sy * sz - sx * cz), (-cx * cy);
+  if(compute_hessian) {
+    // Precomputed angular hessian components. Letters correspond to Equation 6.21 and numbers correspond to row index [Magnusson 2009]
+    h_ang_a2_ << (-cx * sz - sx * sy * cz), (-cx * cz + sx * sy * sz), sx * cy;
+    h_ang_a3_ << (-sx * sz + cx * sy * cz), (-cx * sy * sz - sx * cz), (-cx * cy);
 
-		h_ang_b2_ << (cx * cy * cz), (-cx * cy * sz), (cx * sy);
-		h_ang_b3_ << (sx * cy * cz), (-sx * cy * sz), (sx * sy);
+    h_ang_b2_ << (cx * cy * cz), (-cx * cy * sz), (cx * sy);
+    h_ang_b3_ << (sx * cy * cz), (-sx * cy * sz), (sx * sy);
 
-		h_ang_c2_ << (-sx * cz - cx * sy * sz), (sx * sz - cx * sy * cz), 0;
-		h_ang_c3_ << (cx * cz - sx * sy * sz), (-sx * sy * cz - cx * sz), 0;
+    h_ang_c2_ << (-sx * cz - cx * sy * sz), (sx * sz - cx * sy * cz), 0;
+    h_ang_c3_ << (cx * cz - sx * sy * sz), (-sx * sy * cz - cx * sz), 0;
 
-		h_ang_d1_ << (-cy * cz), (cy * sz), (sy);
-		h_ang_d2_ << (-sx * sy * cz), (sx * sy * sz), (sx * cy);
-		h_ang_d3_ << (cx * sy * cz), (-cx * sy * sz), (-cx * cy);
+    h_ang_d1_ << (-cy * cz), (cy * sz), (sy);
+    h_ang_d2_ << (-sx * sy * cz), (sx * sy * sz), (sx * cy);
+    h_ang_d3_ << (cx * sy * cz), (-cx * sy * sz), (-cx * cy);
 
-		h_ang_e1_ << (sy * sz), (sy * cz), 0;
-		h_ang_e2_ << (-sx * cy * sz), (-sx * cy * cz), 0;
-		h_ang_e3_ << (cx * cy * sz), (cx * cy * cz), 0;
+    h_ang_e1_ << (sy * sz), (sy * cz), 0;
+    h_ang_e2_ << (-sx * cy * sz), (-sx * cy * cz), 0;
+    h_ang_e3_ << (cx * cy * sz), (cx * cy * cz), 0;
 
-		h_ang_f1_ << (-cy * cz), (cy * sz), 0;
-		h_ang_f2_ << (-cx * sz - sx * sy * cz), (-cx * cz + sx * sy * sz), 0;
-		h_ang_f3_ << (-sx * sz + cx * sy * cz), (-cx * sy * sz - sx * cz), 0;
+    h_ang_f1_ << (-cy * cz), (cy * sz), 0;
+    h_ang_f2_ << (-cx * sz - sx * sy * cz), (-cx * cz + sx * sy * sz), 0;
+    h_ang_f3_ << (-sx * sz + cx * sy * cz), (-cx * sy * sz - sx * cz), 0;
 
-		h_ang.setZero();
-		h_ang.row(0).noalias() = Eigen::Vector4f((-cx * sz - sx * sy * cz), (-cx * cz + sx * sy * sz), sx * cy, 0.0f);		// a2
-		h_ang.row(1).noalias() = Eigen::Vector4f((-sx * sz + cx * sy * cz), (-cx * sy * sz - sx * cz), (-cx * cy), 0.0f);	// a3
+    h_ang.setZero();
+    h_ang.row(0).noalias() = Eigen::Vector4f((-cx * sz - sx * sy * cz), (-cx * cz + sx * sy * sz), sx * cy, 0.0f);     // a2
+    h_ang.row(1).noalias() = Eigen::Vector4f((-sx * sz + cx * sy * cz), (-cx * sy * sz - sx * cz), (-cx * cy), 0.0f);  // a3
 
-		h_ang.row(2).noalias() = Eigen::Vector4f((cx * cy * cz), (-cx * cy * sz), (cx * sy), 0.0f);							// b2
-		h_ang.row(3).noalias() = Eigen::Vector4f((sx * cy * cz), (-sx * cy * sz), (sx * sy), 0.0f);							// b3
+    h_ang.row(2).noalias() = Eigen::Vector4f((cx * cy * cz), (-cx * cy * sz), (cx * sy), 0.0f);                        // b2
+    h_ang.row(3).noalias() = Eigen::Vector4f((sx * cy * cz), (-sx * cy * sz), (sx * sy), 0.0f);                        // b3
 
-		h_ang.row(4).noalias() = Eigen::Vector4f((-sx * cz - cx * sy * sz), (sx * sz - cx * sy * cz), 0, 0.0f);				// c2
-		h_ang.row(5).noalias() = Eigen::Vector4f((cx * cz - sx * sy * sz), (-sx * sy * cz - cx * sz), 0, 0.0f);				// c3
+    h_ang.row(4).noalias() = Eigen::Vector4f((-sx * cz - cx * sy * sz), (sx * sz - cx * sy * cz), 0, 0.0f);            // c2
+    h_ang.row(5).noalias() = Eigen::Vector4f((cx * cz - sx * sy * sz), (-sx * sy * cz - cx * sz), 0, 0.0f);            // c3
 
-		h_ang.row(6).noalias() = Eigen::Vector4f((-cy * cz), (cy * sz), (sy), 0.0f);										// d1
-		h_ang.row(7).noalias() = Eigen::Vector4f((-sx * sy * cz), (sx * sy * sz), (sx * cy), 0.0f);							// d2
-		h_ang.row(8).noalias() = Eigen::Vector4f((cx * sy * cz), (-cx * sy * sz), (-cx * cy), 0.0f);						// d3
+    h_ang.row(6).noalias() = Eigen::Vector4f((-cy * cz), (cy * sz), (sy), 0.0f);                                       // d1
+    h_ang.row(7).noalias() = Eigen::Vector4f((-sx * sy * cz), (sx * sy * sz), (sx * cy), 0.0f);                        // d2
+    h_ang.row(8).noalias() = Eigen::Vector4f((cx * sy * cz), (-cx * sy * sz), (-cx * cy), 0.0f);                       // d3
 
-		h_ang.row(9).noalias() = Eigen::Vector4f((sy * sz), (sy * cz), 0, 0.0f);											// e1
-		h_ang.row(10).noalias() = Eigen::Vector4f ((-sx * cy * sz), (-sx * cy * cz), 0, 0.0f);								// e2
-		h_ang.row(11).noalias() = Eigen::Vector4f ((cx * cy * sz), (cx * cy * cz), 0, 0.0f);								// e3
+    h_ang.row(9).noalias() = Eigen::Vector4f((sy * sz), (sy * cz), 0, 0.0f);                                           // e1
+    h_ang.row(10).noalias() = Eigen::Vector4f((-sx * cy * sz), (-sx * cy * cz), 0, 0.0f);                              // e2
+    h_ang.row(11).noalias() = Eigen::Vector4f((cx * cy * sz), (cx * cy * cz), 0, 0.0f);                                // e3
 
-		h_ang.row(12).noalias() = Eigen::Vector4f ((-cy * cz), (cy * sz), 0, 0.0f);											// f1
-		h_ang.row(13).noalias() = Eigen::Vector4f ((-cx * sz - sx * sy * cz), (-cx * cz + sx * sy * sz), 0, 0.0f);			// f2
-		h_ang.row(14).noalias() = Eigen::Vector4f ((-sx * sz + cx * sy * cz), (-cx * sy * sz - sx * cz), 0, 0.0f);			// f3
-	}
+    h_ang.row(12).noalias() = Eigen::Vector4f((-cy * cz), (cy * sz), 0, 0.0f);                                         // f1
+    h_ang.row(13).noalias() = Eigen::Vector4f((-cx * sz - sx * sy * cz), (-cx * cz + sx * sy * sz), 0, 0.0f);          // f2
+    h_ang.row(14).noalias() = Eigen::Vector4f((-sx * sz + cx * sy * cz), (-cx * sy * sz - sx * cz), 0, 0.0f);          // f3
+  }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget> void
-pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computePointDerivatives(Eigen::Vector3d &x, Eigen::Matrix<float, 4, 6>& point_gradient_, Eigen::Matrix<float, 24, 6>& point_hessian_, bool compute_hessian) const
-{
-	Eigen::Vector4f x4(x[0], x[1], x[2], 0.0f);
+template<typename PointSource, typename PointTarget>
+void pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computePointDerivatives(Eigen::Vector3d &x, Eigen::Matrix<float, 4, 6> &point_gradient_, Eigen::Matrix<float, 24, 6> &point_hessian_, bool compute_hessian) const {
+  Eigen::Vector4f x4(x[0], x[1], x[2], 0.0f);
 
-	// Calculate first derivative of Transformation Equation 6.17 w.r.t. transform vector p.
-	// Derivative w.r.t. ith element of transform vector corresponds to column i, Equation 6.18 and 6.19 [Magnusson 2009]
-	Eigen::Matrix<float, 8, 1> x_j_ang = j_ang * x4;
+  // Calculate first derivative of Transformation Equation 6.17 w.r.t. transform vector p.
+  // Derivative w.r.t. ith element of transform vector corresponds to column i, Equation 6.18 and 6.19 [Magnusson 2009]
+  Eigen::Matrix<float, 8, 1> x_j_ang = j_ang * x4;
 
-	point_gradient_(1, 3) = x_j_ang[0];
-	point_gradient_(2, 3) = x_j_ang[1];
-	point_gradient_(0, 4) = x_j_ang[2];
-	point_gradient_(1, 4) = x_j_ang[3];
-	point_gradient_(2, 4) = x_j_ang[4];
-	point_gradient_(0, 5) = x_j_ang[5];
-	point_gradient_(1, 5) = x_j_ang[6];
-	point_gradient_(2, 5) = x_j_ang[7];
+  point_gradient_(1, 3) = x_j_ang[0];
+  point_gradient_(2, 3) = x_j_ang[1];
+  point_gradient_(0, 4) = x_j_ang[2];
+  point_gradient_(1, 4) = x_j_ang[3];
+  point_gradient_(2, 4) = x_j_ang[4];
+  point_gradient_(0, 5) = x_j_ang[5];
+  point_gradient_(1, 5) = x_j_ang[6];
+  point_gradient_(2, 5) = x_j_ang[7];
 
-	if (compute_hessian)
-	{
-		Eigen::Matrix<float, 16, 1> x_h_ang = h_ang * x4;
+  if(compute_hessian) {
+    Eigen::Matrix<float, 16, 1> x_h_ang = h_ang * x4;
 
-		// Vectors from Equation 6.21 [Magnusson 2009]
-		Eigen::Vector4f a (0, x_h_ang[0], x_h_ang[1], 0.0f);
-		Eigen::Vector4f b (0, x_h_ang[2], x_h_ang[3], 0.0f);
-		Eigen::Vector4f c (0, x_h_ang[4], x_h_ang[5], 0.0f);
-		Eigen::Vector4f d (x_h_ang[6], x_h_ang[7], x_h_ang[8], 0.0f);
-		Eigen::Vector4f e (x_h_ang[9], x_h_ang[10], x_h_ang[11], 0.0f);
-		Eigen::Vector4f f (x_h_ang[12], x_h_ang[13], x_h_ang[14], 0.0f);
+    // Vectors from Equation 6.21 [Magnusson 2009]
+    Eigen::Vector4f a(0, x_h_ang[0], x_h_ang[1], 0.0f);
+    Eigen::Vector4f b(0, x_h_ang[2], x_h_ang[3], 0.0f);
+    Eigen::Vector4f c(0, x_h_ang[4], x_h_ang[5], 0.0f);
+    Eigen::Vector4f d(x_h_ang[6], x_h_ang[7], x_h_ang[8], 0.0f);
+    Eigen::Vector4f e(x_h_ang[9], x_h_ang[10], x_h_ang[11], 0.0f);
+    Eigen::Vector4f f(x_h_ang[12], x_h_ang[13], x_h_ang[14], 0.0f);
 
-		// Calculate second derivative of Transformation Equation 6.17 w.r.t. transform vector p.
-		// Derivative w.r.t. ith and jth elements of transform vector corresponds to the 3x1 block matrix starting at (3i,j), Equation 6.20 and 6.21 [Magnusson 2009]
-		point_hessian_.block<4, 1>((9/3)*4, 3) = a;
-		point_hessian_.block<4, 1>((12/3)*4, 3) = b;
-		point_hessian_.block<4, 1>((15/3)*4, 3) = c;
-		point_hessian_.block<4, 1>((9/3)*4, 4) = b;
-		point_hessian_.block<4, 1>((12/3)*4, 4) = d;
-		point_hessian_.block<4, 1>((15/3)*4, 4) = e;
-		point_hessian_.block<4, 1>((9/3)*4, 5) = c;
-		point_hessian_.block<4, 1>((12/3)*4, 5) = e;
-		point_hessian_.block<4, 1>((15/3)*4, 5) = f;
-	}
+    // Calculate second derivative of Transformation Equation 6.17 w.r.t. transform vector p.
+    // Derivative w.r.t. ith and jth elements of transform vector corresponds to the 3x1 block matrix starting at (3i,j), Equation 6.20 and 6.21 [Magnusson 2009]
+    point_hessian_.block<4, 1>((9 / 3) * 4, 3) = a;
+    point_hessian_.block<4, 1>((12 / 3) * 4, 3) = b;
+    point_hessian_.block<4, 1>((15 / 3) * 4, 3) = c;
+    point_hessian_.block<4, 1>((9 / 3) * 4, 4) = b;
+    point_hessian_.block<4, 1>((12 / 3) * 4, 4) = d;
+    point_hessian_.block<4, 1>((15 / 3) * 4, 4) = e;
+    point_hessian_.block<4, 1>((9 / 3) * 4, 5) = c;
+    point_hessian_.block<4, 1>((12 / 3) * 4, 5) = e;
+    point_hessian_.block<4, 1>((15 / 3) * 4, 5) = f;
+  }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget> void
-pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computePointDerivatives(Eigen::Vector3d &x, Eigen::Matrix<double, 3, 6>& point_gradient_, Eigen::Matrix<double, 18, 6>& point_hessian_, bool compute_hessian) const
-{
-	// Calculate first derivative of Transformation Equation 6.17 w.r.t. transform vector p.
-	// Derivative w.r.t. ith element of transform vector corresponds to column i, Equation 6.18 and 6.19 [Magnusson 2009]
-	point_gradient_(1, 3) = x.dot(j_ang_a_);
-	point_gradient_(2, 3) = x.dot(j_ang_b_);
-	point_gradient_(0, 4) = x.dot(j_ang_c_);
-	point_gradient_(1, 4) = x.dot(j_ang_d_);
-	point_gradient_(2, 4) = x.dot(j_ang_e_);
-	point_gradient_(0, 5) = x.dot(j_ang_f_);
-	point_gradient_(1, 5) = x.dot(j_ang_g_);
-	point_gradient_(2, 5) = x.dot(j_ang_h_);
+template<typename PointSource, typename PointTarget>
+void pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computePointDerivatives(Eigen::Vector3d &x, Eigen::Matrix<double, 3, 6> &point_gradient_, Eigen::Matrix<double, 18, 6> &point_hessian_, bool compute_hessian) const {
+  // Calculate first derivative of Transformation Equation 6.17 w.r.t. transform vector p.
+  // Derivative w.r.t. ith element of transform vector corresponds to column i, Equation 6.18 and 6.19 [Magnusson 2009]
+  point_gradient_(1, 3) = x.dot(j_ang_a_);
+  point_gradient_(2, 3) = x.dot(j_ang_b_);
+  point_gradient_(0, 4) = x.dot(j_ang_c_);
+  point_gradient_(1, 4) = x.dot(j_ang_d_);
+  point_gradient_(2, 4) = x.dot(j_ang_e_);
+  point_gradient_(0, 5) = x.dot(j_ang_f_);
+  point_gradient_(1, 5) = x.dot(j_ang_g_);
+  point_gradient_(2, 5) = x.dot(j_ang_h_);
 
-	if (compute_hessian)
-	{
-		// Vectors from Equation 6.21 [Magnusson 2009]
-		Eigen::Vector3d a, b, c, d, e, f;
+  if(compute_hessian) {
+    // Vectors from Equation 6.21 [Magnusson 2009]
+    Eigen::Vector3d a, b, c, d, e, f;
 
-		a << 0, x.dot(h_ang_a2_), x.dot(h_ang_a3_);
-		b << 0, x.dot(h_ang_b2_), x.dot(h_ang_b3_);
-		c << 0, x.dot(h_ang_c2_), x.dot(h_ang_c3_);
-		d << x.dot(h_ang_d1_), x.dot(h_ang_d2_), x.dot(h_ang_d3_);
-		e << x.dot(h_ang_e1_), x.dot(h_ang_e2_), x.dot(h_ang_e3_);
-		f << x.dot(h_ang_f1_), x.dot(h_ang_f2_), x.dot(h_ang_f3_);
+    a << 0, x.dot(h_ang_a2_), x.dot(h_ang_a3_);
+    b << 0, x.dot(h_ang_b2_), x.dot(h_ang_b3_);
+    c << 0, x.dot(h_ang_c2_), x.dot(h_ang_c3_);
+    d << x.dot(h_ang_d1_), x.dot(h_ang_d2_), x.dot(h_ang_d3_);
+    e << x.dot(h_ang_e1_), x.dot(h_ang_e2_), x.dot(h_ang_e3_);
+    f << x.dot(h_ang_f1_), x.dot(h_ang_f2_), x.dot(h_ang_f3_);
 
-		// Calculate second derivative of Transformation Equation 6.17 w.r.t. transform vector p.
-		// Derivative w.r.t. ith and jth elements of transform vector corresponds to the 3x1 block matrix starting at (3i,j), Equation 6.20 and 6.21 [Magnusson 2009]
-		point_hessian_.block<3, 1>(9, 3) = a;
-		point_hessian_.block<3, 1>(12, 3) = b;
-		point_hessian_.block<3, 1>(15, 3) = c;
-		point_hessian_.block<3, 1>(9, 4) = b;
-		point_hessian_.block<3, 1>(12, 4) = d;
-		point_hessian_.block<3, 1>(15, 4) = e;
-		point_hessian_.block<3, 1>(9, 5) = c;
-		point_hessian_.block<3, 1>(12, 5) = e;
-		point_hessian_.block<3, 1>(15, 5) = f;
-	}
+    // Calculate second derivative of Transformation Equation 6.17 w.r.t. transform vector p.
+    // Derivative w.r.t. ith and jth elements of transform vector corresponds to the 3x1 block matrix starting at (3i,j), Equation 6.20 and 6.21 [Magnusson 2009]
+    point_hessian_.block<3, 1>(9, 3) = a;
+    point_hessian_.block<3, 1>(12, 3) = b;
+    point_hessian_.block<3, 1>(15, 3) = c;
+    point_hessian_.block<3, 1>(9, 4) = b;
+    point_hessian_.block<3, 1>(12, 4) = d;
+    point_hessian_.block<3, 1>(15, 4) = e;
+    point_hessian_.block<3, 1>(9, 5) = c;
+    point_hessian_.block<3, 1>(12, 5) = e;
+    point_hessian_.block<3, 1>(15, 5) = f;
+  }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget> double
-pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::updateDerivatives(Eigen::Matrix<double, 6, 1> &score_gradient,
-	Eigen::Matrix<double, 6, 6> &hessian,
-	const Eigen::Matrix<float, 4, 6> &point_gradient4,
-	const Eigen::Matrix<float, 24, 6> &point_hessian_,
-	const Eigen::Vector3d &x_trans, const Eigen::Matrix3d &c_inv,
-	bool compute_hessian) const
-{
-	Eigen::Matrix<float, 1, 4> x_trans4( x_trans[0], x_trans[1], x_trans[2], 0.0f );
-	Eigen::Matrix4f c_inv4 = Eigen::Matrix4f::Zero();
-	c_inv4.topLeftCorner(3, 3) = c_inv.cast<float>();
+template<typename PointSource, typename PointTarget>
+double pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::updateDerivatives(Eigen::Matrix<double, 6, 1> &score_gradient, Eigen::Matrix<double, 6, 6> &hessian, const Eigen::Matrix<float, 4, 6> &point_gradient4, const Eigen::Matrix<float, 24, 6> &point_hessian_, const Eigen::Vector3d &x_trans, const Eigen::Matrix3d &c_inv, bool compute_hessian) const {
+  Eigen::Matrix<float, 1, 4> x_trans4(x_trans[0], x_trans[1], x_trans[2], 0.0f);
+  Eigen::Matrix4f c_inv4 = Eigen::Matrix4f::Zero();
+  c_inv4.topLeftCorner(3, 3) = c_inv.cast<float>();
 
-	float gauss_d2 = gauss_d2_;
+  float gauss_d2 = gauss_d2_;
 
-	// e^(-d_2/2 * (x_k - mu_k)^T Sigma_k^-1 (x_k - mu_k)) Equation 6.9 [Magnusson 2009]
-	float e_x_cov_x = exp(-gauss_d2 * x_trans4.dot(x_trans4 * c_inv4) * 0.5f);
-	// Calculate probability of transformed points existence, Equation 6.9 [Magnusson 2009]
-	float score_inc = -gauss_d1_ * e_x_cov_x;
+  // e^(-d_2/2 * (x_k - mu_k)^T Sigma_k^-1 (x_k - mu_k)) Equation 6.9 [Magnusson 2009]
+  float e_x_cov_x = exp(-gauss_d2 * x_trans4.dot(x_trans4 * c_inv4) * 0.5f);
+  // Calculate probability of transformed points existence, Equation 6.9 [Magnusson 2009]
+  float score_inc = -gauss_d1_ * e_x_cov_x;
 
-	e_x_cov_x = gauss_d2 * e_x_cov_x;
+  e_x_cov_x = gauss_d2 * e_x_cov_x;
 
-	// Error checking for invalid values.
-	if (e_x_cov_x > 1 || e_x_cov_x < 0 || e_x_cov_x != e_x_cov_x)
-		return (0);
+  // Error checking for invalid values.
+  if(e_x_cov_x > 1 || e_x_cov_x < 0 || e_x_cov_x != e_x_cov_x) return (0);
 
-	// Reusable portion of Equation 6.12 and 6.13 [Magnusson 2009]
-	e_x_cov_x *= gauss_d1_;
+  // Reusable portion of Equation 6.12 and 6.13 [Magnusson 2009]
+  e_x_cov_x *= gauss_d1_;
 
-	Eigen::Matrix<float, 4, 6> c_inv4_x_point_gradient4 = c_inv4 * point_gradient4;
-	Eigen::Matrix<float, 6, 1> x_trans4_dot_c_inv4_x_point_gradient4 = x_trans4 * c_inv4_x_point_gradient4;
+  Eigen::Matrix<float, 4, 6> c_inv4_x_point_gradient4 = c_inv4 * point_gradient4;
+  Eigen::Matrix<float, 6, 1> x_trans4_dot_c_inv4_x_point_gradient4 = x_trans4 * c_inv4_x_point_gradient4;
 
-	score_gradient.noalias() += (e_x_cov_x * x_trans4_dot_c_inv4_x_point_gradient4).cast<double>();
+  score_gradient.noalias() += (e_x_cov_x * x_trans4_dot_c_inv4_x_point_gradient4).cast<double>();
 
-	if (compute_hessian) {
-		Eigen::Matrix<float, 1, 4> x_trans4_x_c_inv4 = x_trans4 * c_inv4;
-		Eigen::Matrix<float, 6, 6> point_gradient4_colj_dot_c_inv4_x_point_gradient4_col_i = point_gradient4.transpose() * c_inv4_x_point_gradient4;
-		Eigen::Matrix<float, 6, 1> x_trans4_dot_c_inv4_x_ext_point_hessian_4ij;
+  if(compute_hessian) {
+    Eigen::Matrix<float, 1, 4> x_trans4_x_c_inv4 = x_trans4 * c_inv4;
+    Eigen::Matrix<float, 6, 6> point_gradient4_colj_dot_c_inv4_x_point_gradient4_col_i = point_gradient4.transpose() * c_inv4_x_point_gradient4;
+    Eigen::Matrix<float, 6, 1> x_trans4_dot_c_inv4_x_ext_point_hessian_4ij;
 
-		for (int i = 0; i < 6; i++) {
-			// Sigma_k^-1 d(T(x,p))/dpi, Reusable portion of Equation 6.12 and 6.13 [Magnusson 2009]
-			// Update gradient, Equation 6.12 [Magnusson 2009]
-			x_trans4_dot_c_inv4_x_ext_point_hessian_4ij.noalias() = x_trans4_x_c_inv4 * point_hessian_.block<4, 6>(i * 4, 0);
+    for(int i = 0; i < 6; i++) {
+      // Sigma_k^-1 d(T(x,p))/dpi, Reusable portion of Equation 6.12 and 6.13 [Magnusson 2009]
+      // Update gradient, Equation 6.12 [Magnusson 2009]
+      x_trans4_dot_c_inv4_x_ext_point_hessian_4ij.noalias() = x_trans4_x_c_inv4 * point_hessian_.block<4, 6>(i * 4, 0);
 
-			for (int j = 0; j < hessian.cols(); j++) {
-				// Update hessian, Equation 6.13 [Magnusson 2009]
-				hessian(i, j) += e_x_cov_x * (-gauss_d2 * x_trans4_dot_c_inv4_x_point_gradient4(i) * x_trans4_dot_c_inv4_x_point_gradient4(j) +
-					x_trans4_dot_c_inv4_x_ext_point_hessian_4ij(j) +
-					point_gradient4_colj_dot_c_inv4_x_point_gradient4_col_i(j, i));
-			}
-		}
-	}
+      for(int j = 0; j < hessian.cols(); j++) {
+        // Update hessian, Equation 6.13 [Magnusson 2009]
+        hessian(i, j) += e_x_cov_x * (-gauss_d2 * x_trans4_dot_c_inv4_x_point_gradient4(i) * x_trans4_dot_c_inv4_x_point_gradient4(j) + x_trans4_dot_c_inv4_x_ext_point_hessian_4ij(j) + point_gradient4_colj_dot_c_inv4_x_point_gradient4_col_i(j, i));
+      }
+    }
+  }
 
-	return (score_inc);
+  return (score_inc);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget> void
-pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeHessian (Eigen::Matrix<double, 6, 6> &hessian,
-                                                                             PointCloudSource &trans_cloud, Eigen::Matrix<double, 6, 1> &)
-{
+template<typename PointSource, typename PointTarget>
+void pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeHessian(Eigen::Matrix<double, 6, 6> &hessian, PointCloudSource &trans_cloud, Eigen::Matrix<double, 6, 1> &) {
   // Original Point and Transformed Point
   PointSource x_pt, x_trans_pt;
   // Original Point and Transformed Point (for math)
@@ -637,13 +580,12 @@ pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::compute
   point_gradient_.block<3, 3>(0, 0).setIdentity();
   point_hessian_.setZero();
 
-  hessian.setZero ();
+  hessian.setZero();
 
   // Precompute Angular Derivatives unnecessary because only used after regular derivative calculation
 
   // Update hessian for each point, line 17 in Algorithm 2 [Magnusson 2009]
-  for (size_t idx = 0; idx < input_->points.size (); idx++)
-  {
+  for(size_t idx = 0; idx < input_->points.size(); idx++) {
     x_trans_pt = trans_cloud.points[idx];
 
     // Find neighbors (Radius search has been experimentally faster than direct neighbor checking.
@@ -653,92 +595,72 @@ pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::compute
     // Neighborhood search method other than kdtree is disabled in multigrid_ndt_omp
     target_cells_.radiusSearch(x_trans_pt, resolution_, neighborhood, distances);
 
-    for (typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it = neighborhood.begin (); neighborhood_it != neighborhood.end (); neighborhood_it++)
-    {
+    for(typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it = neighborhood.begin(); neighborhood_it != neighborhood.end(); neighborhood_it++) {
       cell = *neighborhood_it;
 
       {
         x_pt = input_->points[idx];
-        x = Eigen::Vector3d (x_pt.x, x_pt.y, x_pt.z);
+        x = Eigen::Vector3d(x_pt.x, x_pt.y, x_pt.z);
 
-        x_trans = Eigen::Vector3d (x_trans_pt.x, x_trans_pt.y, x_trans_pt.z);
+        x_trans = Eigen::Vector3d(x_trans_pt.x, x_trans_pt.y, x_trans_pt.z);
 
         // Denorm point, x_k' in Equations 6.12 and 6.13 [Magnusson 2009]
-        x_trans -= cell->getMean ();
+        x_trans -= cell->getMean();
         // Uses precomputed covariance for speed.
-        c_inv = cell->getInverseCov ();
+        c_inv = cell->getInverseCov();
 
         // Compute derivative of transform function w.r.t. transform vector, J_E and H_E in Equations 6.18 and 6.20 [Magnusson 2009]
-        computePointDerivatives (x, point_gradient_, point_hessian_);
+        computePointDerivatives(x, point_gradient_, point_hessian_);
         // Update hessian, lines 21 in Algorithm 2, according to Equations 6.10, 6.12 and 6.13, respectively [Magnusson 2009]
-        updateHessian (hessian, point_gradient_, point_hessian_, x_trans, c_inv);
+        updateHessian(hessian, point_gradient_, point_hessian_, x_trans, c_inv);
       }
     }
   }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget> void
-pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::updateHessian (Eigen::Matrix<double, 6, 6> &hessian,
-	const Eigen::Matrix<double, 3, 6> &point_gradient_,
-	const Eigen::Matrix<double, 18, 6> &point_hessian_,
-	const Eigen::Vector3d &x_trans,
-	const Eigen::Matrix3d &c_inv) const
-{
+template<typename PointSource, typename PointTarget>
+void pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::updateHessian(Eigen::Matrix<double, 6, 6> &hessian, const Eigen::Matrix<double, 3, 6> &point_gradient_, const Eigen::Matrix<double, 18, 6> &point_hessian_, const Eigen::Vector3d &x_trans, const Eigen::Matrix3d &c_inv) const {
   Eigen::Vector3d cov_dxd_pi;
   // e^(-d_2/2 * (x_k - mu_k)^T Sigma_k^-1 (x_k - mu_k)) Equation 6.9 [Magnusson 2009]
-  double e_x_cov_x = gauss_d2_ * exp (-gauss_d2_ * x_trans.dot (c_inv * x_trans) / 2);
+  double e_x_cov_x = gauss_d2_ * exp(-gauss_d2_ * x_trans.dot(c_inv * x_trans) / 2);
 
   // Error checking for invalid values.
-  if (e_x_cov_x > 1 || e_x_cov_x < 0 || e_x_cov_x != e_x_cov_x)
-    return;
+  if(e_x_cov_x > 1 || e_x_cov_x < 0 || e_x_cov_x != e_x_cov_x) return;
 
   // Reusable portion of Equation 6.12 and 6.13 [Magnusson 2009]
   e_x_cov_x *= gauss_d1_;
 
-  for (int i = 0; i < 6; i++)
-  {
+  for(int i = 0; i < 6; i++) {
     // Sigma_k^-1 d(T(x,p))/dpi, Reusable portion of Equation 6.12 and 6.13 [Magnusson 2009]
-    cov_dxd_pi = c_inv * point_gradient_.col (i);
+    cov_dxd_pi = c_inv * point_gradient_.col(i);
 
-    for (int j = 0; j < hessian.cols (); j++)
-    {
+    for(int j = 0; j < hessian.cols(); j++) {
       // Update hessian, Equation 6.13 [Magnusson 2009]
-      hessian (i, j) += e_x_cov_x * (-gauss_d2_ * x_trans.dot (cov_dxd_pi) * x_trans.dot (c_inv * point_gradient_.col (j)) +
-                                  x_trans.dot (c_inv * point_hessian_.block<3, 1>(3 * i, j)) +
-                                  point_gradient_.col (j).dot (cov_dxd_pi) );
+      hessian(i, j) += e_x_cov_x * (-gauss_d2_ * x_trans.dot(cov_dxd_pi) * x_trans.dot(c_inv * point_gradient_.col(j)) + x_trans.dot(c_inv * point_hessian_.block<3, 1>(3 * i, j)) + point_gradient_.col(j).dot(cov_dxd_pi));
     }
   }
-
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget> bool
-pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::updateIntervalMT (double &a_l, double &f_l, double &g_l,
-                                                                               double &a_u, double &f_u, double &g_u,
-                                                                               double a_t, double f_t, double g_t)
-{
+template<typename PointSource, typename PointTarget>
+bool pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::updateIntervalMT(double &a_l, double &f_l, double &g_l, double &a_u, double &f_u, double &g_u, double a_t, double f_t, double g_t) {
   // Case U1 in Update Algorithm and Case a in Modified Update Algorithm [More, Thuente 1994]
-  if (f_t > f_l)
-  {
+  if(f_t > f_l) {
     a_u = a_t;
     f_u = f_t;
     g_u = g_t;
     return (false);
   }
   // Case U2 in Update Algorithm and Case b in Modified Update Algorithm [More, Thuente 1994]
-  else
-  if (g_t * (a_l - a_t) > 0)
-  {
+  else if(g_t * (a_l - a_t) > 0) {
     a_l = a_t;
     f_l = f_t;
     g_l = g_t;
     return (false);
   }
   // Case U3 in Update Algorithm and Case c in Modified Update Algorithm [More, Thuente 1994]
-  else
-  if (g_t * (a_l - a_t) < 0)
-  {
+  else if(g_t * (a_l - a_t) < 0) {
     a_u = a_l;
     f_u = f_l;
     g_u = g_l;
@@ -754,18 +676,14 @@ pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::updateI
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget> double
-pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::trialValueSelectionMT (double a_l, double f_l, double g_l,
-                                                                                    double a_u, double f_u, double g_u,
-                                                                                    double a_t, double f_t, double g_t)
-{
+template<typename PointSource, typename PointTarget>
+double pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::trialValueSelectionMT(double a_l, double f_l, double g_l, double a_u, double f_u, double g_u, double a_t, double f_t, double g_t) {
   // Case 1 in Trial Value Selection [More, Thuente 1994]
-  if (f_t > f_l)
-  {
+  if(f_t > f_l) {
     // Calculate the minimizer of the cubic that interpolates f_l, f_t, g_l and g_t
     // Equation 2.4.52 [Sun, Yuan 2006]
     double z = 3 * (f_t - f_l) / (a_t - a_l) - g_t - g_l;
-    double w = std::sqrt (z * z - g_t * g_l);
+    double w = std::sqrt(z * z - g_t * g_l);
     // Equation 2.4.56 [Sun, Yuan 2006]
     double a_c = a_l + (a_t - a_l) * (w - g_l - z) / (g_t - g_l + 2 * w);
 
@@ -773,19 +691,17 @@ pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::trialVa
     // Equation 2.4.2 [Sun, Yuan 2006]
     double a_q = a_l - 0.5 * (a_l - a_t) * g_l / (g_l - (f_l - f_t) / (a_l - a_t));
 
-    if (std::fabs (a_c - a_l) < std::fabs (a_q - a_l))
+    if(std::fabs(a_c - a_l) < std::fabs(a_q - a_l))
       return (a_c);
     else
       return (0.5 * (a_q + a_c));
   }
   // Case 2 in Trial Value Selection [More, Thuente 1994]
-  else
-  if (g_t * g_l < 0)
-  {
+  else if(g_t * g_l < 0) {
     // Calculate the minimizer of the cubic that interpolates f_l, f_t, g_l and g_t
     // Equation 2.4.52 [Sun, Yuan 2006]
     double z = 3 * (f_t - f_l) / (a_t - a_l) - g_t - g_l;
-    double w = std::sqrt (z * z - g_t * g_l);
+    double w = std::sqrt(z * z - g_t * g_l);
     // Equation 2.4.56 [Sun, Yuan 2006]
     double a_c = a_l + (a_t - a_l) * (w - g_l - z) / (g_t - g_l + 2 * w);
 
@@ -793,19 +709,17 @@ pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::trialVa
     // Equation 2.4.5 [Sun, Yuan 2006]
     double a_s = a_l - (a_l - a_t) / (g_l - g_t) * g_l;
 
-    if (std::fabs (a_c - a_t) >= std::fabs (a_s - a_t))
+    if(std::fabs(a_c - a_t) >= std::fabs(a_s - a_t))
       return (a_c);
     else
       return (a_s);
   }
   // Case 3 in Trial Value Selection [More, Thuente 1994]
-  else
-  if (std::fabs (g_t) <= std::fabs (g_l))
-  {
+  else if(std::fabs(g_t) <= std::fabs(g_l)) {
     // Calculate the minimizer of the cubic that interpolates f_l, f_t, g_l and g_t
     // Equation 2.4.52 [Sun, Yuan 2006]
     double z = 3 * (f_t - f_l) / (a_t - a_l) - g_t - g_l;
-    double w = std::sqrt (z * z - g_t * g_l);
+    double w = std::sqrt(z * z - g_t * g_l);
     double a_c = a_l + (a_t - a_l) * (w - g_l - z) / (g_t - g_l + 2 * w);
 
     // Calculate the minimizer of the quadratic that interpolates g_l and g_t
@@ -814,52 +728,45 @@ pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::trialVa
 
     double a_t_next;
 
-    if (std::fabs (a_c - a_t) < std::fabs (a_s - a_t))
+    if(std::fabs(a_c - a_t) < std::fabs(a_s - a_t))
       a_t_next = a_c;
     else
       a_t_next = a_s;
 
-    if (a_t > a_l)
-      return (std::min (a_t + 0.66 * (a_u - a_t), a_t_next));
+    if(a_t > a_l)
+      return (std::min(a_t + 0.66 * (a_u - a_t), a_t_next));
     else
-      return (std::max (a_t + 0.66 * (a_u - a_t), a_t_next));
+      return (std::max(a_t + 0.66 * (a_u - a_t), a_t_next));
   }
   // Case 4 in Trial Value Selection [More, Thuente 1994]
-  else
-  {
+  else {
     // Calculate the minimizer of the cubic that interpolates f_u, f_t, g_u and g_t
     // Equation 2.4.52 [Sun, Yuan 2006]
     double z = 3 * (f_t - f_u) / (a_t - a_u) - g_t - g_u;
-    double w = std::sqrt (z * z - g_t * g_u);
+    double w = std::sqrt(z * z - g_t * g_u);
     // Equation 2.4.56 [Sun, Yuan 2006]
     return (a_u + (a_t - a_u) * (w - g_u - z) / (g_t - g_u + 2 * w));
   }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget> double
-pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeStepLengthMT (const Eigen::Matrix<double, 6, 1> &x, Eigen::Matrix<double, 6, 1> &step_dir, double step_init, double step_max,
-                                                                                  double step_min, double &score, Eigen::Matrix<double, 6, 1> &score_gradient, Eigen::Matrix<double, 6, 6> &hessian,
-                                                                                  PointCloudSource &trans_cloud)
-{
+template<typename PointSource, typename PointTarget>
+double pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeStepLengthMT(const Eigen::Matrix<double, 6, 1> &x, Eigen::Matrix<double, 6, 1> &step_dir, double step_init, double step_max, double step_min, double &score, Eigen::Matrix<double, 6, 1> &score_gradient, Eigen::Matrix<double, 6, 6> &hessian, PointCloudSource &trans_cloud) {
   // Set the value of phi(0), Equation 1.3 [More, Thuente 1994]
   double phi_0 = -score;
   // Set the value of phi'(0), Equation 1.3 [More, Thuente 1994]
-  double d_phi_0 = -(score_gradient.dot (step_dir));
+  double d_phi_0 = -(score_gradient.dot(step_dir));
 
-  Eigen::Matrix<double, 6, 1>  x_t;
+  Eigen::Matrix<double, 6, 1> x_t;
 
-  if (d_phi_0 >= 0)
-  {
+  if(d_phi_0 >= 0) {
     // Not a decent direction
-    if (d_phi_0 == 0)
+    if(d_phi_0 == 0)
       return 0;
-    else
-    {
+    else {
       // Reverse step direction and calculate optimal step.
       d_phi_0 *= -1;
       step_dir *= -1;
-
     }
   }
 
@@ -877,32 +784,30 @@ pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::compute
   double a_l = 0, a_u = 0;
 
   // Auxiliary function psi is used until I is determined ot be a closed interval, Equation 2.1 [More, Thuente 1994]
-  double f_l = auxiliaryFunction_PsiMT (a_l, phi_0, phi_0, d_phi_0, mu);
-  double g_l = auxiliaryFunction_dPsiMT (d_phi_0, d_phi_0, mu);
+  double f_l = auxiliaryFunction_PsiMT(a_l, phi_0, phi_0, d_phi_0, mu);
+  double g_l = auxiliaryFunction_dPsiMT(d_phi_0, d_phi_0, mu);
 
-  double f_u = auxiliaryFunction_PsiMT (a_u, phi_0, phi_0, d_phi_0, mu);
-  double g_u = auxiliaryFunction_dPsiMT (d_phi_0, d_phi_0, mu);
+  double f_u = auxiliaryFunction_PsiMT(a_u, phi_0, phi_0, d_phi_0, mu);
+  double g_u = auxiliaryFunction_dPsiMT(d_phi_0, d_phi_0, mu);
 
   // Check used to allow More-Thuente step length calculation to be skipped by making step_min == step_max
   bool interval_converged = (step_max - step_min) < 0, open_interval = true;
 
   double a_t = step_init;
-  a_t = std::min (a_t, step_max);
-  a_t = std::max (a_t, step_min);
+  a_t = std::min(a_t, step_max);
+  a_t = std::max(a_t, step_min);
 
   x_t = x + step_dir * a_t;
 
-  final_transformation_ = (Eigen::Translation<float, 3>(static_cast<float> (x_t (0)), static_cast<float> (x_t (1)), static_cast<float> (x_t (2))) *
-                           Eigen::AngleAxis<float> (static_cast<float> (x_t (3)), Eigen::Vector3f::UnitX ()) *
-                           Eigen::AngleAxis<float> (static_cast<float> (x_t (4)), Eigen::Vector3f::UnitY ()) *
-                           Eigen::AngleAxis<float> (static_cast<float> (x_t (5)), Eigen::Vector3f::UnitZ ())).matrix ();
+  final_transformation_ = (Eigen::Translation<float, 3>(static_cast<float>(x_t(0)), static_cast<float>(x_t(1)), static_cast<float>(x_t(2))) * Eigen::AngleAxis<float>(static_cast<float>(x_t(3)), Eigen::Vector3f::UnitX()) * Eigen::AngleAxis<float>(static_cast<float>(x_t(4)), Eigen::Vector3f::UnitY()) * Eigen::AngleAxis<float>(static_cast<float>(x_t(5)), Eigen::Vector3f::UnitZ()))
+                              .matrix();
 
   // New transformed point cloud
-  transformPointCloud (*input_, trans_cloud, final_transformation_);
+  transformPointCloud(*input_, trans_cloud, final_transformation_);
 
   // Updates score, gradient and hessian.  Hessian calculation is unnecessary but testing showed that most step calculations use the
   // initial step suggestion and recalculation the reusable portions of the hessian would intail more computation time.
-  score = computeDerivatives (score_gradient, hessian, trans_cloud, x_t, true);
+  score = computeDerivatives(score_gradient, hessian, trans_cloud, x_t, true);
 
   // --------------------------------------------------------------------------------------------------------------------------------
   // FIXME(YamatoAndo):
@@ -1002,149 +907,138 @@ pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::compute
   // If inner loop was run then hessian needs to be calculated.
   // Hessian is unnecessary for step length determination but gradients are required
   // so derivative and transform data is stored for the next iteration.
-  if (step_iterations)
-    computeHessian (hessian, trans_cloud, x_t);
+  if(step_iterations) computeHessian(hessian, trans_cloud, x_t);
 
   return (a_t);
 }
 
 template<typename PointSource, typename PointTarget>
-double pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::calculateScore(const PointCloudSource & trans_cloud) const
-{
-	double score = 0;
+double pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::calculateScore(const PointCloudSource &trans_cloud) const {
+  double score = 0;
 
-	for (std::size_t idx = 0; idx < trans_cloud.points.size(); idx++)
-	{
-		PointSource x_trans_pt = trans_cloud.points[idx];
+  for(std::size_t idx = 0; idx < trans_cloud.points.size(); idx++) {
+    PointSource x_trans_pt = trans_cloud.points[idx];
 
-		// Find neighbors (Radius search has been experimentally faster than direct neighbor checking.
-		std::vector<TargetGridLeafConstPtr> neighborhood;
-		std::vector<float> distances;
+    // Find neighbors (Radius search has been experimentally faster than direct neighbor checking.
+    std::vector<TargetGridLeafConstPtr> neighborhood;
+    std::vector<float> distances;
 
     // Neighborhood search method other than kdtree is disabled in multigrid_ndt_omp
     target_cells_.radiusSearch(x_trans_pt, resolution_, neighborhood, distances);
 
-		for (typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it = neighborhood.begin(); neighborhood_it != neighborhood.end(); neighborhood_it++)
-		{
-			TargetGridLeafConstPtr cell = *neighborhood_it;
+    for(typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it = neighborhood.begin(); neighborhood_it != neighborhood.end(); neighborhood_it++) {
+      TargetGridLeafConstPtr cell = *neighborhood_it;
 
-			Eigen::Vector3d x_trans = Eigen::Vector3d(x_trans_pt.x, x_trans_pt.y, x_trans_pt.z);
+      Eigen::Vector3d x_trans = Eigen::Vector3d(x_trans_pt.x, x_trans_pt.y, x_trans_pt.z);
 
-			// Denorm point, x_k' in Equations 6.12 and 6.13 [Magnusson 2009]
-			x_trans -= cell->getMean();
-			// Uses precomputed covariance for speed.
-			Eigen::Matrix3d c_inv = cell->getInverseCov();
+      // Denorm point, x_k' in Equations 6.12 and 6.13 [Magnusson 2009]
+      x_trans -= cell->getMean();
+      // Uses precomputed covariance for speed.
+      Eigen::Matrix3d c_inv = cell->getInverseCov();
 
-			// e^(-d_2/2 * (x_k - mu_k)^T Sigma_k^-1 (x_k - mu_k)) Equation 6.9 [Magnusson 2009]
-			double e_x_cov_x = exp(-gauss_d2_ * x_trans.dot(c_inv * x_trans) / 2);
-			// Calculate probability of transformed points existence, Equation 6.9 [Magnusson 2009]
-			double score_inc = -gauss_d1_ * e_x_cov_x - gauss_d3_;
+      // e^(-d_2/2 * (x_k - mu_k)^T Sigma_k^-1 (x_k - mu_k)) Equation 6.9 [Magnusson 2009]
+      double e_x_cov_x = exp(-gauss_d2_ * x_trans.dot(c_inv * x_trans) / 2);
+      // Calculate probability of transformed points existence, Equation 6.9 [Magnusson 2009]
+      double score_inc = -gauss_d1_ * e_x_cov_x - gauss_d3_;
 
-			score += score_inc / neighborhood.size();
-		}
-	}
-
-  double output_score = 0;
-  if (!trans_cloud.points.empty()) {
-    output_score = (score) / static_cast<double> (trans_cloud.size());
-  }
-	return output_score;
-}
-
-template<typename PointSource, typename PointTarget>
-double pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::calculateTransformationProbability(const PointCloudSource & trans_cloud) const
-{
-	double score = 0;
-
-	for (std::size_t idx = 0; idx < trans_cloud.points.size(); idx++)
-	{
-		PointSource x_trans_pt = trans_cloud.points[idx];
-
-		// Find neighbors (Radius search has been experimentally faster than direct neighbor checking.
-		std::vector<TargetGridLeafConstPtr> neighborhood;
-		std::vector<float> distances;
-
-    // Neighborhood search method other than kdtree is disabled in multigrid_ndt_omp
-    target_cells_.radiusSearch(x_trans_pt, resolution_, neighborhood, distances);
-
-		for (typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it = neighborhood.begin(); neighborhood_it != neighborhood.end(); neighborhood_it++)
-		{
-			TargetGridLeafConstPtr cell = *neighborhood_it;
-
-			Eigen::Vector3d x_trans = Eigen::Vector3d(x_trans_pt.x, x_trans_pt.y, x_trans_pt.z);
-
-			// Denorm point, x_k' in Equations 6.12 and 6.13 [Magnusson 2009]
-			x_trans -= cell->getMean();
-			// Uses precomputed covariance for speed.
-			Eigen::Matrix3d c_inv = cell->getInverseCov();
-
-			// e^(-d_2/2 * (x_k - mu_k)^T Sigma_k^-1 (x_k - mu_k)) Equation 6.9 [Magnusson 2009]
-			double e_x_cov_x = exp(-gauss_d2_ * x_trans.dot(c_inv * x_trans) / 2);
-			// Calculate probability of transformed points existence, Equation 6.9 [Magnusson 2009]
-			double score_inc = -gauss_d1_ * e_x_cov_x;
-
-      score += score_inc;
-		}
-	}
-
-  double output_score = 0;
-  if (!trans_cloud.points.empty()) {
-    output_score = (score) / static_cast<double> (trans_cloud.points.size());
-  }
-	return output_score;
-}
-
-template<typename PointSource, typename PointTarget>
-double pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::calculateNearestVoxelTransformationLikelihood(const PointCloudSource & trans_cloud) const
-{
-  double nearest_voxel_score = 0;
-  size_t found_neigborhood_voxel_num = 0;
-
-	for (std::size_t idx = 0; idx < trans_cloud.points.size(); idx++)
-	{
-    double nearest_voxel_score_pt = 0;
-		PointSource x_trans_pt = trans_cloud.points[idx];
-
-		// Find neighbors (Radius search has been experimentally faster than direct neighbor checking.
-		std::vector<TargetGridLeafConstPtr> neighborhood;
-		std::vector<float> distances;
-
-    // Neighborhood search method other than kdtree is disabled in multigrid_ndt_omp
-    target_cells_.radiusSearch(x_trans_pt, resolution_, neighborhood, distances);
-
-		for (typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it = neighborhood.begin(); neighborhood_it != neighborhood.end(); neighborhood_it++)
-		{
-			TargetGridLeafConstPtr cell = *neighborhood_it;
-
-			Eigen::Vector3d x_trans = Eigen::Vector3d(x_trans_pt.x, x_trans_pt.y, x_trans_pt.z);
-
-			// Denorm point, x_k' in Equations 6.12 and 6.13 [Magnusson 2009]
-			x_trans -= cell->getMean();
-			// Uses precomputed covariance for speed.
-			Eigen::Matrix3d c_inv = cell->getInverseCov();
-
-			// e^(-d_2/2 * (x_k - mu_k)^T Sigma_k^-1 (x_k - mu_k)) Equation 6.9 [Magnusson 2009]
-			double e_x_cov_x = exp(-gauss_d2_ * x_trans.dot(c_inv * x_trans) / 2);
-			// Calculate probability of transformed points existence, Equation 6.9 [Magnusson 2009]
-			double score_inc = -gauss_d1_ * e_x_cov_x;
-
-      if (score_inc > nearest_voxel_score_pt) {
-        nearest_voxel_score_pt = score_inc;
-      }
-		}
-
-    if (!neighborhood.empty()) {
-      ++found_neigborhood_voxel_num;
-      nearest_voxel_score += nearest_voxel_score_pt;
+      score += score_inc / neighborhood.size();
     }
-
-	}
+  }
 
   double output_score = 0;
-  if (found_neigborhood_voxel_num != 0) {
-    output_score =  nearest_voxel_score / static_cast<double> (found_neigborhood_voxel_num);
+  if(!trans_cloud.points.empty()) {
+    output_score = (score) / static_cast<double>(trans_cloud.size());
   }
   return output_score;
 }
 
-#endif // PCL_REGISTRATION_NDT_OMP_MULTI_VOXEL_IMPL_H_
+template<typename PointSource, typename PointTarget>
+double pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::calculateTransformationProbability(const PointCloudSource &trans_cloud) const {
+  double score = 0;
+
+  for(std::size_t idx = 0; idx < trans_cloud.points.size(); idx++) {
+    PointSource x_trans_pt = trans_cloud.points[idx];
+
+    // Find neighbors (Radius search has been experimentally faster than direct neighbor checking.
+    std::vector<TargetGridLeafConstPtr> neighborhood;
+    std::vector<float> distances;
+
+    // Neighborhood search method other than kdtree is disabled in multigrid_ndt_omp
+    target_cells_.radiusSearch(x_trans_pt, resolution_, neighborhood, distances);
+
+    for(typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it = neighborhood.begin(); neighborhood_it != neighborhood.end(); neighborhood_it++) {
+      TargetGridLeafConstPtr cell = *neighborhood_it;
+
+      Eigen::Vector3d x_trans = Eigen::Vector3d(x_trans_pt.x, x_trans_pt.y, x_trans_pt.z);
+
+      // Denorm point, x_k' in Equations 6.12 and 6.13 [Magnusson 2009]
+      x_trans -= cell->getMean();
+      // Uses precomputed covariance for speed.
+      Eigen::Matrix3d c_inv = cell->getInverseCov();
+
+      // e^(-d_2/2 * (x_k - mu_k)^T Sigma_k^-1 (x_k - mu_k)) Equation 6.9 [Magnusson 2009]
+      double e_x_cov_x = exp(-gauss_d2_ * x_trans.dot(c_inv * x_trans) / 2);
+      // Calculate probability of transformed points existence, Equation 6.9 [Magnusson 2009]
+      double score_inc = -gauss_d1_ * e_x_cov_x;
+
+      score += score_inc;
+    }
+  }
+
+  double output_score = 0;
+  if(!trans_cloud.points.empty()) {
+    output_score = (score) / static_cast<double>(trans_cloud.points.size());
+  }
+  return output_score;
+}
+
+template<typename PointSource, typename PointTarget>
+double pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::calculateNearestVoxelTransformationLikelihood(const PointCloudSource &trans_cloud) const {
+  double nearest_voxel_score = 0;
+  size_t found_neigborhood_voxel_num = 0;
+
+  for(std::size_t idx = 0; idx < trans_cloud.points.size(); idx++) {
+    double nearest_voxel_score_pt = 0;
+    PointSource x_trans_pt = trans_cloud.points[idx];
+
+    // Find neighbors (Radius search has been experimentally faster than direct neighbor checking.
+    std::vector<TargetGridLeafConstPtr> neighborhood;
+    std::vector<float> distances;
+
+    // Neighborhood search method other than kdtree is disabled in multigrid_ndt_omp
+    target_cells_.radiusSearch(x_trans_pt, resolution_, neighborhood, distances);
+
+    for(typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it = neighborhood.begin(); neighborhood_it != neighborhood.end(); neighborhood_it++) {
+      TargetGridLeafConstPtr cell = *neighborhood_it;
+
+      Eigen::Vector3d x_trans = Eigen::Vector3d(x_trans_pt.x, x_trans_pt.y, x_trans_pt.z);
+
+      // Denorm point, x_k' in Equations 6.12 and 6.13 [Magnusson 2009]
+      x_trans -= cell->getMean();
+      // Uses precomputed covariance for speed.
+      Eigen::Matrix3d c_inv = cell->getInverseCov();
+
+      // e^(-d_2/2 * (x_k - mu_k)^T Sigma_k^-1 (x_k - mu_k)) Equation 6.9 [Magnusson 2009]
+      double e_x_cov_x = exp(-gauss_d2_ * x_trans.dot(c_inv * x_trans) / 2);
+      // Calculate probability of transformed points existence, Equation 6.9 [Magnusson 2009]
+      double score_inc = -gauss_d1_ * e_x_cov_x;
+
+      if(score_inc > nearest_voxel_score_pt) {
+        nearest_voxel_score_pt = score_inc;
+      }
+    }
+
+    if(!neighborhood.empty()) {
+      ++found_neigborhood_voxel_num;
+      nearest_voxel_score += nearest_voxel_score_pt;
+    }
+  }
+
+  double output_score = 0;
+  if(found_neigborhood_voxel_num != 0) {
+    output_score = nearest_voxel_score / static_cast<double>(found_neigborhood_voxel_num);
+  }
+  return output_score;
+}
+
+#endif  // PCL_REGISTRATION_NDT_OMP_MULTI_VOXEL_IMPL_H_

--- a/include/pclomp/gicp_omp.h
+++ b/include/pclomp/gicp_omp.h
@@ -44,337 +44,294 @@
 #include <pcl/registration/icp.h>
 #include <pcl/registration/bfgs.h>
 
-namespace pclomp
-{
-  /** \brief GeneralizedIterativeClosestPoint is an ICP variant that implements the
-    * generalized iterative closest point algorithm as described by Alex Segal et al. in
-    * http://www.robots.ox.ac.uk/~avsegal/resources/papers/Generalized_ICP.pdf
-    * The approach is based on using anisotropic cost functions to optimize the alignment
-    * after closest point assignments have been made.
-    * The original code uses GSL and ANN while in ours we use an eigen mapped BFGS and
-    * FLANN.
-    * \author Nizar Sallem
-    * \ingroup registration
-    */
-  template <typename PointSource, typename PointTarget>
-  class GeneralizedIterativeClosestPoint : public pcl::IterativeClosestPoint<PointSource, PointTarget>
-  {
-    public:
-      using pcl::IterativeClosestPoint<PointSource, PointTarget>::reg_name_;
-      using pcl::IterativeClosestPoint<PointSource, PointTarget>::getClassName;
-      using pcl::IterativeClosestPoint<PointSource, PointTarget>::indices_;
-      using pcl::IterativeClosestPoint<PointSource, PointTarget>::target_;
-      using pcl::IterativeClosestPoint<PointSource, PointTarget>::input_;
-      using pcl::IterativeClosestPoint<PointSource, PointTarget>::tree_;
-      using pcl::IterativeClosestPoint<PointSource, PointTarget>::tree_reciprocal_;
-      using pcl::IterativeClosestPoint<PointSource, PointTarget>::nr_iterations_;
-      using pcl::IterativeClosestPoint<PointSource, PointTarget>::max_iterations_;
-      using pcl::IterativeClosestPoint<PointSource, PointTarget>::previous_transformation_;
-      using pcl::IterativeClosestPoint<PointSource, PointTarget>::final_transformation_;
-      using pcl::IterativeClosestPoint<PointSource, PointTarget>::transformation_;
-      using pcl::IterativeClosestPoint<PointSource, PointTarget>::transformation_epsilon_;
-      using pcl::IterativeClosestPoint<PointSource, PointTarget>::converged_;
-      using pcl::IterativeClosestPoint<PointSource, PointTarget>::corr_dist_threshold_;
-      using pcl::IterativeClosestPoint<PointSource, PointTarget>::inlier_threshold_;
-      using pcl::IterativeClosestPoint<PointSource, PointTarget>::min_number_correspondences_;
-      using pcl::IterativeClosestPoint<PointSource, PointTarget>::update_visualizer_;
+namespace pclomp {
+/** \brief GeneralizedIterativeClosestPoint is an ICP variant that implements the
+ * generalized iterative closest point algorithm as described by Alex Segal et al. in
+ * http://www.robots.ox.ac.uk/~avsegal/resources/papers/Generalized_ICP.pdf
+ * The approach is based on using anisotropic cost functions to optimize the alignment
+ * after closest point assignments have been made.
+ * The original code uses GSL and ANN while in ours we use an eigen mapped BFGS and
+ * FLANN.
+ * \author Nizar Sallem
+ * \ingroup registration
+ */
+template<typename PointSource, typename PointTarget>
+class GeneralizedIterativeClosestPoint : public pcl::IterativeClosestPoint<PointSource, PointTarget> {
+public:
+  using pcl::IterativeClosestPoint<PointSource, PointTarget>::reg_name_;
+  using pcl::IterativeClosestPoint<PointSource, PointTarget>::getClassName;
+  using pcl::IterativeClosestPoint<PointSource, PointTarget>::indices_;
+  using pcl::IterativeClosestPoint<PointSource, PointTarget>::target_;
+  using pcl::IterativeClosestPoint<PointSource, PointTarget>::input_;
+  using pcl::IterativeClosestPoint<PointSource, PointTarget>::tree_;
+  using pcl::IterativeClosestPoint<PointSource, PointTarget>::tree_reciprocal_;
+  using pcl::IterativeClosestPoint<PointSource, PointTarget>::nr_iterations_;
+  using pcl::IterativeClosestPoint<PointSource, PointTarget>::max_iterations_;
+  using pcl::IterativeClosestPoint<PointSource, PointTarget>::previous_transformation_;
+  using pcl::IterativeClosestPoint<PointSource, PointTarget>::final_transformation_;
+  using pcl::IterativeClosestPoint<PointSource, PointTarget>::transformation_;
+  using pcl::IterativeClosestPoint<PointSource, PointTarget>::transformation_epsilon_;
+  using pcl::IterativeClosestPoint<PointSource, PointTarget>::converged_;
+  using pcl::IterativeClosestPoint<PointSource, PointTarget>::corr_dist_threshold_;
+  using pcl::IterativeClosestPoint<PointSource, PointTarget>::inlier_threshold_;
+  using pcl::IterativeClosestPoint<PointSource, PointTarget>::min_number_correspondences_;
+  using pcl::IterativeClosestPoint<PointSource, PointTarget>::update_visualizer_;
 
-      using PointCloudSource = pcl::PointCloud<PointSource>;
-      using PointCloudSourcePtr = typename PointCloudSource::Ptr;
-      using PointCloudSourceConstPtr = typename PointCloudSource::ConstPtr;
+  using PointCloudSource = pcl::PointCloud<PointSource>;
+  using PointCloudSourcePtr = typename PointCloudSource::Ptr;
+  using PointCloudSourceConstPtr = typename PointCloudSource::ConstPtr;
 
-      using PointCloudTarget = pcl::PointCloud<PointTarget>;
-      using PointCloudTargetPtr = typename PointCloudTarget::Ptr;
-      using PointCloudTargetConstPtr = typename PointCloudTarget::ConstPtr;
+  using PointCloudTarget = pcl::PointCloud<PointTarget>;
+  using PointCloudTargetPtr = typename PointCloudTarget::Ptr;
+  using PointCloudTargetConstPtr = typename PointCloudTarget::ConstPtr;
 
-      using PointIndicesPtr = pcl::PointIndices::Ptr;
-      using PointIndicesConstPtr = pcl::PointIndices::ConstPtr;
+  using PointIndicesPtr = pcl::PointIndices::Ptr;
+  using PointIndicesConstPtr = pcl::PointIndices::ConstPtr;
 
-      using InputKdTree = typename pcl::Registration<PointSource, PointTarget>::KdTree;
-      using InputKdTreePtr = typename pcl::Registration<PointSource, PointTarget>::KdTreePtr;
+  using InputKdTree = typename pcl::Registration<PointSource, PointTarget>::KdTree;
+  using InputKdTreePtr = typename pcl::Registration<PointSource, PointTarget>::KdTreePtr;
 
-      using MatricesVector = std::vector<Eigen::Matrix3d, Eigen::aligned_allocator<Eigen::Matrix3d> >;
+  using MatricesVector = std::vector<Eigen::Matrix3d, Eigen::aligned_allocator<Eigen::Matrix3d> >;
 
 #if PCL_VERSION >= PCL_VERSION_CALC(1, 10, 0)
-      using MatricesVectorPtr = pcl::shared_ptr<MatricesVector>;
-      using MatricesVectorConstPtr = pcl::shared_ptr<const MatricesVector>;
+  using MatricesVectorPtr = pcl::shared_ptr<MatricesVector>;
+  using MatricesVectorConstPtr = pcl::shared_ptr<const MatricesVector>;
 
-      using Ptr = pcl::shared_ptr<GeneralizedIterativeClosestPoint<PointSource, PointTarget> >;
-      using ConstPtr = pcl::shared_ptr<const GeneralizedIterativeClosestPoint<PointSource, PointTarget> >;
+  using Ptr = pcl::shared_ptr<GeneralizedIterativeClosestPoint<PointSource, PointTarget> >;
+  using ConstPtr = pcl::shared_ptr<const GeneralizedIterativeClosestPoint<PointSource, PointTarget> >;
 #else
-      using MatricesVectorPtr = boost::shared_ptr<MatricesVector>;
-      using MatricesVectorConstPtr = boost::shared_ptr<const MatricesVector>;
+  using MatricesVectorPtr = boost::shared_ptr<MatricesVector>;
+  using MatricesVectorConstPtr = boost::shared_ptr<const MatricesVector>;
 
-      using Ptr = boost::shared_ptr<GeneralizedIterativeClosestPoint<PointSource, PointTarget> >;
-      using ConstPtr = boost::shared_ptr<const GeneralizedIterativeClosestPoint<PointSource, PointTarget> >;
+  using Ptr = boost::shared_ptr<GeneralizedIterativeClosestPoint<PointSource, PointTarget> >;
+  using ConstPtr = boost::shared_ptr<const GeneralizedIterativeClosestPoint<PointSource, PointTarget> >;
 #endif
 
+  using Vector6d = Eigen::Matrix<double, 6, 1>;
 
-      using Vector6d = Eigen::Matrix<double, 6, 1>;
+  /** \brief Empty constructor. */
+  GeneralizedIterativeClosestPoint() : k_correspondences_(20), gicp_epsilon_(0.001), rotation_epsilon_(2e-3), mahalanobis_(0), max_inner_iterations_(20) {
+    min_number_correspondences_ = 4;
+    reg_name_ = "GeneralizedIterativeClosestPoint";
+    max_iterations_ = 200;
+    transformation_epsilon_ = 5e-4;
+    corr_dist_threshold_ = 5.;
+    rigid_transformation_estimation_ = [this](const PointCloudSource &cloud_src, const std::vector<int> &indices_src, const PointCloudTarget &cloud_tgt, const std::vector<int> &indices_tgt, Eigen::Matrix4f &transformation_matrix) {
+      estimateRigidTransformationBFGS(cloud_src, indices_src, cloud_tgt, indices_tgt, transformation_matrix);
+    };
+  }
 
-      /** \brief Empty constructor. */
-      GeneralizedIterativeClosestPoint ()
-        : k_correspondences_(20)
-        , gicp_epsilon_(0.001)
-        , rotation_epsilon_(2e-3)
-        , mahalanobis_(0)
-        , max_inner_iterations_(20)
-      {
-        min_number_correspondences_ = 4;
-        reg_name_ = "GeneralizedIterativeClosestPoint";
-        max_iterations_ = 200;
-        transformation_epsilon_ = 5e-4;
-        corr_dist_threshold_ = 5.;
-        rigid_transformation_estimation_ = [this] (const PointCloudSource& cloud_src,
-                                                   const std::vector<int>& indices_src,
-                                                   const PointCloudTarget& cloud_tgt,
-                                                   const std::vector<int>& indices_tgt,
-                                                   Eigen::Matrix4f& transformation_matrix)
-        {
-          estimateRigidTransformationBFGS (cloud_src, indices_src, cloud_tgt, indices_tgt, transformation_matrix);
-        };
-      }
+  /** \brief Provide a pointer to the input dataset
+   * \param cloud the const boost shared pointer to a PointCloud message
+   */
+  inline void setInputSource(const PointCloudSourceConstPtr &cloud) override {
+    if(cloud->points.empty()) {
+      PCL_ERROR("[pcl::%s::setInputSource] Invalid or empty point cloud dataset given!\n", getClassName().c_str());
+      return;
+    }
+    PointCloudSource input = *cloud;
+    // Set all the point.data[3] values to 1 to aid the rigid transformation
+    for(size_t i = 0; i < input.size(); ++i) input[i].data[3] = 1.0;
 
-      /** \brief Provide a pointer to the input dataset
-        * \param cloud the const boost shared pointer to a PointCloud message
-        */
-      inline void
-      setInputSource (const PointCloudSourceConstPtr &cloud) override
-      {
+    pcl::IterativeClosestPoint<PointSource, PointTarget>::setInputSource(cloud);
+    input_covariances_.reset();
+  }
 
-        if (cloud->points.empty ())
-        {
-          PCL_ERROR ("[pcl::%s::setInputSource] Invalid or empty point cloud dataset given!\n", getClassName ().c_str ());
-          return;
-        }
-        PointCloudSource input = *cloud;
-        // Set all the point.data[3] values to 1 to aid the rigid transformation
-        for (size_t i = 0; i < input.size (); ++i)
-          input[i].data[3] = 1.0;
+  /** \brief Provide a pointer to the covariances of the input source (if computed externally!).
+   * If not set, GeneralizedIterativeClosestPoint will compute the covariances itself.
+   * Make sure to set the covariances AFTER setting the input source point cloud (setting the input source point cloud will reset the covariances).
+   * \param[in] target the input point cloud target
+   */
+  inline void setSourceCovariances(const MatricesVectorPtr &covariances) {
+    input_covariances_ = covariances;
+  }
 
-        pcl::IterativeClosestPoint<PointSource, PointTarget>::setInputSource (cloud);
-        input_covariances_.reset ();
-      }
+  /** \brief Provide a pointer to the input target (e.g., the point cloud that we want to align the input source to)
+   * \param[in] target the input point cloud target
+   */
+  inline void setInputTarget(const PointCloudTargetConstPtr &target) override {
+    pcl::IterativeClosestPoint<PointSource, PointTarget>::setInputTarget(target);
+    target_covariances_.reset();
+  }
 
-      /** \brief Provide a pointer to the covariances of the input source (if computed externally!).
-        * If not set, GeneralizedIterativeClosestPoint will compute the covariances itself.
-        * Make sure to set the covariances AFTER setting the input source point cloud (setting the input source point cloud will reset the covariances).
-        * \param[in] target the input point cloud target
-        */
-      inline void
-      setSourceCovariances (const MatricesVectorPtr& covariances)
-      {
-        input_covariances_ = covariances;
-      }
+  /** \brief Provide a pointer to the covariances of the input target (if computed externally!).
+   * If not set, GeneralizedIterativeClosestPoint will compute the covariances itself.
+   * Make sure to set the covariances AFTER setting the input source point cloud (setting the input source point cloud will reset the covariances).
+   * \param[in] target the input point cloud target
+   */
+  inline void setTargetCovariances(const MatricesVectorPtr &covariances) {
+    target_covariances_ = covariances;
+  }
 
-      /** \brief Provide a pointer to the input target (e.g., the point cloud that we want to align the input source to)
-        * \param[in] target the input point cloud target
-        */
-      inline void
-      setInputTarget (const PointCloudTargetConstPtr &target) override
-      {
-        pcl::IterativeClosestPoint<PointSource, PointTarget>::setInputTarget(target);
-        target_covariances_.reset ();
-      }
+  /** \brief Estimate a rigid rotation transformation between a source and a target point cloud using an iterative
+   * non-linear Levenberg-Marquardt approach.
+   * \param[in] cloud_src the source point cloud dataset
+   * \param[in] indices_src the vector of indices describing the points of interest in \a cloud_src
+   * \param[in] cloud_tgt the target point cloud dataset
+   * \param[in] indices_tgt the vector of indices describing the correspondences of the interest points from \a indices_src
+   * \param[out] transformation_matrix the resultant transformation matrix
+   */
+  void estimateRigidTransformationBFGS(const PointCloudSource &cloud_src, const std::vector<int> &indices_src, const PointCloudTarget &cloud_tgt, const std::vector<int> &indices_tgt, Eigen::Matrix4f &transformation_matrix);
 
-      /** \brief Provide a pointer to the covariances of the input target (if computed externally!).
-        * If not set, GeneralizedIterativeClosestPoint will compute the covariances itself.
-        * Make sure to set the covariances AFTER setting the input source point cloud (setting the input source point cloud will reset the covariances).
-        * \param[in] target the input point cloud target
-        */
-	    inline void
-      setTargetCovariances (const MatricesVectorPtr& covariances)
-      {
-        target_covariances_ = covariances;
-      }
+  /** \brief \return Mahalanobis distance matrix for the given point index */
+  inline const Eigen::Matrix4f &mahalanobis(size_t index) const {
+    assert(index < mahalanobis_.size());
+    return mahalanobis_[index];
+  }
 
-      /** \brief Estimate a rigid rotation transformation between a source and a target point cloud using an iterative
-        * non-linear Levenberg-Marquardt approach.
-        * \param[in] cloud_src the source point cloud dataset
-        * \param[in] indices_src the vector of indices describing the points of interest in \a cloud_src
-        * \param[in] cloud_tgt the target point cloud dataset
-        * \param[in] indices_tgt the vector of indices describing the correspondences of the interest points from \a indices_src
-        * \param[out] transformation_matrix the resultant transformation matrix
-        */
-      void
-      estimateRigidTransformationBFGS (const PointCloudSource &cloud_src,
-                                       const std::vector<int> &indices_src,
-                                       const PointCloudTarget &cloud_tgt,
-                                       const std::vector<int> &indices_tgt,
-                                       Eigen::Matrix4f &transformation_matrix);
+  /** \brief Computes rotation matrix derivative.
+   * rotation matrix is obtained from rotation angles x[3], x[4] and x[5]
+   * \return d/d_rx, d/d_ry and d/d_rz respectively in g[3], g[4] and g[5]
+   * param x array representing 3D transformation
+   * param R rotation matrix
+   * param g gradient vector
+   */
+  void computeRDerivative(const Vector6d &x, const Eigen::Matrix3d &R, Vector6d &g) const;
 
-      /** \brief \return Mahalanobis distance matrix for the given point index */
-      inline const Eigen::Matrix4f& mahalanobis(size_t index) const
-      {
-        assert(index < mahalanobis_.size());
-        return mahalanobis_[index];
-      }
+  /** \brief Set the rotation epsilon (maximum allowable difference between two
+   * consecutive rotations) in order for an optimization to be considered as having
+   * converged to the final solution.
+   * \param epsilon the rotation epsilon
+   */
+  inline void setRotationEpsilon(double epsilon) {
+    rotation_epsilon_ = epsilon;
+  }
 
-      /** \brief Computes rotation matrix derivative.
-        * rotation matrix is obtained from rotation angles x[3], x[4] and x[5]
-        * \return d/d_rx, d/d_ry and d/d_rz respectively in g[3], g[4] and g[5]
-        * param x array representing 3D transformation
-        * param R rotation matrix
-        * param g gradient vector
-        */
-      void
-      computeRDerivative(const Vector6d &x, const Eigen::Matrix3d &R, Vector6d &g) const;
+  /** \brief Get the rotation epsilon (maximum allowable difference between two
+   * consecutive rotations) as set by the user.
+   */
+  inline double getRotationEpsilon() {
+    return (rotation_epsilon_);
+  }
 
-      /** \brief Set the rotation epsilon (maximum allowable difference between two
-        * consecutive rotations) in order for an optimization to be considered as having
-        * converged to the final solution.
-        * \param epsilon the rotation epsilon
-        */
-      inline void
-      setRotationEpsilon (double epsilon) { rotation_epsilon_ = epsilon; }
+  /** \brief Set the number of neighbors used when selecting a point neighbourhood
+   * to compute covariances.
+   * A higher value will bring more accurate covariance matrix but will make
+   * covariances computation slower.
+   * \param k the number of neighbors to use when computing covariances
+   */
+  void setCorrespondenceRandomness(int k) {
+    k_correspondences_ = k;
+  }
 
-      /** \brief Get the rotation epsilon (maximum allowable difference between two
-        * consecutive rotations) as set by the user.
-        */
-      inline double
-      getRotationEpsilon () { return (rotation_epsilon_); }
+  /** \brief Get the number of neighbors used when computing covariances as set by
+   * the user
+   */
+  int getCorrespondenceRandomness() {
+    return (k_correspondences_);
+  }
 
-      /** \brief Set the number of neighbors used when selecting a point neighbourhood
-        * to compute covariances.
-        * A higher value will bring more accurate covariance matrix but will make
-        * covariances computation slower.
-        * \param k the number of neighbors to use when computing covariances
-        */
-      void
-      setCorrespondenceRandomness (int k) { k_correspondences_ = k; }
+  /** set maximum number of iterations at the optimization step
+   * \param[in] max maximum number of iterations for the optimizer
+   */
+  void setMaximumOptimizerIterations(int max) {
+    max_inner_iterations_ = max;
+  }
 
-      /** \brief Get the number of neighbors used when computing covariances as set by
-        * the user
-        */
-      int
-      getCorrespondenceRandomness () { return (k_correspondences_); }
+  ///\return maximum number of iterations at the optimization step
+  int getMaximumOptimizerIterations() {
+    return (max_inner_iterations_);
+  }
 
-      /** set maximum number of iterations at the optimization step
-        * \param[in] max maximum number of iterations for the optimizer
-        */
-      void
-      setMaximumOptimizerIterations (int max) { max_inner_iterations_ = max; }
+protected:
+  /** \brief The number of neighbors used for covariances computation.
+   * default: 20
+   */
+  int k_correspondences_;
 
-      ///\return maximum number of iterations at the optimization step
-      int
-      getMaximumOptimizerIterations () { return (max_inner_iterations_); }
+  /** \brief The epsilon constant for gicp paper; this is NOT the convergence
+   * tolerance
+   * default: 0.001
+   */
+  double gicp_epsilon_;
 
-    protected:
+  /** The epsilon constant for rotation error. (In GICP the transformation epsilon
+   * is split in rotation part and translation part).
+   * default: 2e-3
+   */
+  double rotation_epsilon_;
 
-      /** \brief The number of neighbors used for covariances computation.
-        * default: 20
-        */
-      int k_correspondences_;
+  /** \brief base transformation */
+  Eigen::Matrix4f base_transformation_;
 
-      /** \brief The epsilon constant for gicp paper; this is NOT the convergence
-        * tolerance
-        * default: 0.001
-        */
-      double gicp_epsilon_;
+  /** \brief Temporary pointer to the source dataset. */
+  const PointCloudSource *tmp_src_;
 
-      /** The epsilon constant for rotation error. (In GICP the transformation epsilon
-        * is split in rotation part and translation part).
-        * default: 2e-3
-        */
-      double rotation_epsilon_;
+  /** \brief Temporary pointer to the target dataset. */
+  const PointCloudTarget *tmp_tgt_;
 
-      /** \brief base transformation */
-      Eigen::Matrix4f base_transformation_;
+  /** \brief Temporary pointer to the source dataset indices. */
+  const std::vector<int> *tmp_idx_src_;
 
-      /** \brief Temporary pointer to the source dataset. */
-      const PointCloudSource *tmp_src_;
+  /** \brief Temporary pointer to the target dataset indices. */
+  const std::vector<int> *tmp_idx_tgt_;
 
-      /** \brief Temporary pointer to the target dataset. */
-      const PointCloudTarget  *tmp_tgt_;
+  /** \brief Input cloud points covariances. */
+  MatricesVectorPtr input_covariances_;
 
-      /** \brief Temporary pointer to the source dataset indices. */
-      const std::vector<int> *tmp_idx_src_;
+  /** \brief Target cloud points covariances. */
+  MatricesVectorPtr target_covariances_;
 
-      /** \brief Temporary pointer to the target dataset indices. */
-      const std::vector<int> *tmp_idx_tgt_;
+  /** \brief Mahalanobis matrices holder. */
+  std::vector<Eigen::Matrix4f> mahalanobis_;
 
+  /** \brief maximum number of optimizations */
+  int max_inner_iterations_;
 
-      /** \brief Input cloud points covariances. */
-      MatricesVectorPtr input_covariances_;
+  /** \brief compute points covariances matrices according to the K nearest
+   * neighbors. K is set via setCorrespondenceRandomness() method.
+   * \param cloud pointer to point cloud
+   * \param tree KD tree performer for nearest neighbors search
+   * \param[out] cloud_covariances covariances matrices for each point in the cloud
+   */
+  template<typename PointT>
+  void computeCovariances(typename pcl::PointCloud<PointT>::ConstPtr cloud, const typename pcl::search::KdTree<PointT>::ConstPtr tree, MatricesVector &cloud_covariances);
 
-      /** \brief Target cloud points covariances. */
-      MatricesVectorPtr target_covariances_;
+  /** \return trace of mat1^t . mat2
+   * \param mat1 matrix of dimension nxm
+   * \param mat2 matrix of dimension nxp
+   */
+  inline double matricesInnerProd(const Eigen::MatrixXd &mat1, const Eigen::MatrixXd &mat2) const {
+    double r = 0.;
+    size_t n = mat1.rows();
+    // tr(mat1^t.mat2)
+    for(size_t i = 0; i < n; i++)
+      for(size_t j = 0; j < n; j++) r += mat1(j, i) * mat2(i, j);
+    return r;
+  }
 
-      /** \brief Mahalanobis matrices holder. */
-      std::vector<Eigen::Matrix4f> mahalanobis_;
+  /** \brief Rigid transformation computation method  with initial guess.
+   * \param output the transformed input point cloud dataset using the rigid transformation found
+   * \param guess the initial guess of the transformation to compute
+   */
+  void computeTransformation(PointCloudSource &output, const Eigen::Matrix4f &guess) override;
 
-      /** \brief maximum number of optimizations */
-      int max_inner_iterations_;
+  /** \brief Search for the closest nearest neighbor of a given point.
+   * \param query the point to search a nearest neighbour for
+   * \param index vector of size 1 to store the index of the nearest neighbour found
+   * \param distance vector of size 1 to store the distance to nearest neighbour found
+   */
+  inline bool searchForNeighbors(const PointSource &query, std::vector<int> &index, std::vector<float> &distance) const {
+    int k = tree_->nearestKSearch(query, 1, index, distance);
+    if(k == 0) return (false);
+    return (true);
+  }
 
-      /** \brief compute points covariances matrices according to the K nearest
-        * neighbors. K is set via setCorrespondenceRandomness() method.
-        * \param cloud pointer to point cloud
-        * \param tree KD tree performer for nearest neighbors search
-        * \param[out] cloud_covariances covariances matrices for each point in the cloud
-        */
-      template<typename PointT>
-      void computeCovariances(typename pcl::PointCloud<PointT>::ConstPtr cloud,
-                              const typename pcl::search::KdTree<PointT>::ConstPtr tree,
-                              MatricesVector& cloud_covariances);
+  /// \brief compute transformation matrix from transformation matrix
+  void applyState(Eigen::Matrix4f &t, const Vector6d &x) const;
 
-      /** \return trace of mat1^t . mat2
-        * \param mat1 matrix of dimension nxm
-        * \param mat2 matrix of dimension nxp
-        */
-      inline double
-      matricesInnerProd(const Eigen::MatrixXd& mat1, const Eigen::MatrixXd& mat2) const
-      {
-        double r = 0.;
-        size_t n = mat1.rows();
-        // tr(mat1^t.mat2)
-        for(size_t i = 0; i < n; i++)
-          for(size_t j = 0; j < n; j++)
-            r += mat1 (j, i) * mat2 (i,j);
-        return r;
-      }
+  /// \brief optimization functor structure
+  struct OptimizationFunctorWithIndices : public BFGSDummyFunctor<double, 6> {
+    OptimizationFunctorWithIndices(const GeneralizedIterativeClosestPoint *gicp) : BFGSDummyFunctor<double, 6>(), gicp_(gicp) {}
+    double operator()(const Vector6d &x) override;
+    void df(const Vector6d &x, Vector6d &df) override;
+    void fdf(const Vector6d &x, double &f, Vector6d &df) override;
 
-      /** \brief Rigid transformation computation method  with initial guess.
-        * \param output the transformed input point cloud dataset using the rigid transformation found
-        * \param guess the initial guess of the transformation to compute
-        */
-      void
-      computeTransformation (PointCloudSource &output, const Eigen::Matrix4f &guess) override;
-
-      /** \brief Search for the closest nearest neighbor of a given point.
-        * \param query the point to search a nearest neighbour for
-        * \param index vector of size 1 to store the index of the nearest neighbour found
-        * \param distance vector of size 1 to store the distance to nearest neighbour found
-        */
-      inline bool
-      searchForNeighbors (const PointSource &query, std::vector<int>& index, std::vector<float>& distance) const
-      {
-        int k = tree_->nearestKSearch (query, 1, index, distance);
-        if (k == 0)
-          return (false);
-        return (true);
-      }
-
-      /// \brief compute transformation matrix from transformation matrix
-      void applyState(Eigen::Matrix4f &t, const Vector6d& x) const;
-
-      /// \brief optimization functor structure
-      struct OptimizationFunctorWithIndices : public BFGSDummyFunctor<double,6>
-      {
-        OptimizationFunctorWithIndices (const GeneralizedIterativeClosestPoint* gicp)
-          : BFGSDummyFunctor<double,6> (), gicp_(gicp) {}
-        double operator() (const Vector6d& x) override;
-        void  df(const Vector6d &x, Vector6d &df) override;
-        void fdf(const Vector6d &x, double &f, Vector6d &df) override;
-
-        const GeneralizedIterativeClosestPoint *gicp_;
-      };
-
-      std::function<void(const pcl::PointCloud<PointSource> &cloud_src,
-                           const std::vector<int> &src_indices,
-                           const pcl::PointCloud<PointTarget> &cloud_tgt,
-                           const std::vector<int> &tgt_indices,
-                           Eigen::Matrix4f &transformation_matrix)> rigid_transformation_estimation_;
+    const GeneralizedIterativeClosestPoint *gicp_;
   };
-}
 
-#endif  //#ifndef PCL_GICP_H_
+  std::function<void(const pcl::PointCloud<PointSource> &cloud_src, const std::vector<int> &src_indices, const pcl::PointCloud<PointTarget> &cloud_tgt, const std::vector<int> &tgt_indices, Eigen::Matrix4f &transformation_matrix)> rigid_transformation_estimation_;
+};
+}  // namespace pclomp
+
+#endif  // #ifndef PCL_GICP_H_

--- a/include/pclomp/gicp_omp_impl.hpp
+++ b/include/pclomp/gicp_omp_impl.hpp
@@ -45,86 +45,79 @@
 #include <pcl/registration/exceptions.h>
 
 ////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointSource, typename PointTarget>
-template<typename PointT> void
-pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeCovariances(typename pcl::PointCloud<PointT>::ConstPtr cloud,
-                                                                                    const typename pcl::search::KdTree<PointT>::ConstPtr kdtree,
-                                                                                    MatricesVector& cloud_covariances)
-{
-  if (k_correspondences_ > int (cloud->size ()))
-  {
-    PCL_ERROR ("[pcl::GeneralizedIterativeClosestPoint::computeCovariances] Number of points in cloud (%lu) is less than k_correspondences_ (%lu)!\n", cloud->size (), k_correspondences_);
+template<typename PointSource, typename PointTarget>
+template<typename PointT>
+void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeCovariances(typename pcl::PointCloud<PointT>::ConstPtr cloud, const typename pcl::search::KdTree<PointT>::ConstPtr kdtree, MatricesVector& cloud_covariances) {
+  if(k_correspondences_ > int(cloud->size())) {
+    PCL_ERROR("[pcl::GeneralizedIterativeClosestPoint::computeCovariances] Number of points in cloud (%lu) is less than k_correspondences_ (%lu)!\n", cloud->size(), k_correspondences_);
     return;
   }
 
   // We should never get there but who knows
-  if(cloud_covariances.size () < cloud->size ())
-    cloud_covariances.resize (cloud->size ());
+  if(cloud_covariances.size() < cloud->size()) cloud_covariances.resize(cloud->size());
 
   std::vector<std::vector<int>> nn_indices_array(omp_get_max_threads());
   std::vector<std::vector<float>> nn_dist_sq_array(omp_get_max_threads());
 
-  #pragma omp parallel for
-  for(std::size_t i=0; i < cloud->size(); i++) {
+#pragma omp parallel for
+  for(std::size_t i = 0; i < cloud->size(); i++) {
     auto& nn_indices = nn_indices_array[omp_get_thread_num()];
     auto& nn_dist_sq = nn_dist_sq_array[omp_get_thread_num()];
 
-    const PointT &query_point = cloud->at(i);
+    const PointT& query_point = cloud->at(i);
     Eigen::Vector3d mean = Eigen::Vector3d::Zero();
-    Eigen::Matrix3d &cov = cloud_covariances[i];
+    Eigen::Matrix3d& cov = cloud_covariances[i];
     // Zero out the cov and mean
-    cov.setZero ();
+    cov.setZero();
 
     // Search for the K nearest neighbours
     kdtree->nearestKSearch(query_point, k_correspondences_, nn_indices, nn_dist_sq);
 
     // Find the covariance matrix
     for(int j = 0; j < k_correspondences_; j++) {
-      const PointT &pt = (*cloud)[nn_indices[j]];
+      const PointT& pt = (*cloud)[nn_indices[j]];
 
       mean[0] += pt.x;
       mean[1] += pt.y;
       mean[2] += pt.z;
 
-      cov(0,0) += pt.x*pt.x;
+      cov(0, 0) += pt.x * pt.x;
 
-      cov(1,0) += pt.y*pt.x;
-      cov(1,1) += pt.y*pt.y;
+      cov(1, 0) += pt.y * pt.x;
+      cov(1, 1) += pt.y * pt.y;
 
-      cov(2,0) += pt.z*pt.x;
-      cov(2,1) += pt.z*pt.y;
-      cov(2,2) += pt.z*pt.z;
+      cov(2, 0) += pt.z * pt.x;
+      cov(2, 1) += pt.z * pt.y;
+      cov(2, 2) += pt.z * pt.z;
     }
 
-    mean /= static_cast<double> (k_correspondences_);
+    mean /= static_cast<double>(k_correspondences_);
     // Get the actual covariance
-    for (int k = 0; k < 3; k++)
-      for (int l = 0; l <= k; l++)
-      {
-        cov(k,l) /= static_cast<double> (k_correspondences_);
-        cov(k,l) -= mean[k]*mean[l];
-        cov(l,k) = cov(k,l);
+    for(int k = 0; k < 3; k++)
+      for(int l = 0; l <= k; l++) {
+        cov(k, l) /= static_cast<double>(k_correspondences_);
+        cov(k, l) -= mean[k] * mean[l];
+        cov(l, k) = cov(k, l);
       }
 
     // Compute the SVD (covariance matrix is symmetric so U = V')
     Eigen::JacobiSVD<Eigen::Matrix3d> svd(cov, Eigen::ComputeFullU);
-    cov.setZero ();
-    Eigen::Matrix3d U = svd.matrixU ();
+    cov.setZero();
+    Eigen::Matrix3d U = svd.matrixU();
     // Reconstitute the covariance matrix with modified singular values using the column     // vectors in V.
     for(int k = 0; k < 3; k++) {
       Eigen::Vector3d col = U.col(k);
-      double v = 1.; // biggest 2 singular values replaced by 1
-      if(k == 2)   // smallest singular value replaced by gicp_epsilon
+      double v = 1.;  // biggest 2 singular values replaced by 1
+      if(k == 2)      // smallest singular value replaced by gicp_epsilon
         v = gicp_epsilon_;
-      cov+= v * col * col.transpose();
+      cov += v * col * col.transpose();
     }
   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointSource, typename PointTarget> void
-pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeRDerivative(const Vector6d &x, const Eigen::Matrix3d &R, Vector6d& g) const
-{
+template<typename PointSource, typename PointTarget>
+void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeRDerivative(const Vector6d& x, const Eigen::Matrix3d& R, Vector6d& g) const {
   Eigen::Matrix3d dR_dPhi;
   Eigen::Matrix3d dR_dTheta;
   Eigen::Matrix3d dR_dPsi;
@@ -135,41 +128,41 @@ pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeRDeri
   double ctheta = std::cos(theta), stheta = sin(theta);
   double cpsi = std::cos(psi), spsi = sin(psi);
 
-  dR_dPhi(0,0) = 0.;
-  dR_dPhi(1,0) = 0.;
-  dR_dPhi(2,0) = 0.;
+  dR_dPhi(0, 0) = 0.;
+  dR_dPhi(1, 0) = 0.;
+  dR_dPhi(2, 0) = 0.;
 
-  dR_dPhi(0,1) = sphi*spsi + cphi*cpsi*stheta;
-  dR_dPhi(1,1) = -cpsi*sphi + cphi*spsi*stheta;
-  dR_dPhi(2,1) = cphi*ctheta;
+  dR_dPhi(0, 1) = sphi * spsi + cphi * cpsi * stheta;
+  dR_dPhi(1, 1) = -cpsi * sphi + cphi * spsi * stheta;
+  dR_dPhi(2, 1) = cphi * ctheta;
 
-  dR_dPhi(0,2) = cphi*spsi - cpsi*sphi*stheta;
-  dR_dPhi(1,2) = -cphi*cpsi - sphi*spsi*stheta;
-  dR_dPhi(2,2) = -ctheta*sphi;
+  dR_dPhi(0, 2) = cphi * spsi - cpsi * sphi * stheta;
+  dR_dPhi(1, 2) = -cphi * cpsi - sphi * spsi * stheta;
+  dR_dPhi(2, 2) = -ctheta * sphi;
 
-  dR_dTheta(0,0) = -cpsi*stheta;
-  dR_dTheta(1,0) = -spsi*stheta;
-  dR_dTheta(2,0) = -ctheta;
+  dR_dTheta(0, 0) = -cpsi * stheta;
+  dR_dTheta(1, 0) = -spsi * stheta;
+  dR_dTheta(2, 0) = -ctheta;
 
-  dR_dTheta(0,1) = cpsi*ctheta*sphi;
-  dR_dTheta(1,1) = ctheta*sphi*spsi;
-  dR_dTheta(2,1) = -sphi*stheta;
+  dR_dTheta(0, 1) = cpsi * ctheta * sphi;
+  dR_dTheta(1, 1) = ctheta * sphi * spsi;
+  dR_dTheta(2, 1) = -sphi * stheta;
 
-  dR_dTheta(0,2) = cphi*cpsi*ctheta;
-  dR_dTheta(1,2) = cphi*ctheta*spsi;
-  dR_dTheta(2,2) = -cphi*stheta;
+  dR_dTheta(0, 2) = cphi * cpsi * ctheta;
+  dR_dTheta(1, 2) = cphi * ctheta * spsi;
+  dR_dTheta(2, 2) = -cphi * stheta;
 
-  dR_dPsi(0,0) = -ctheta*spsi;
-  dR_dPsi(1,0) = cpsi*ctheta;
-  dR_dPsi(2,0) = 0.;
+  dR_dPsi(0, 0) = -ctheta * spsi;
+  dR_dPsi(1, 0) = cpsi * ctheta;
+  dR_dPsi(2, 0) = 0.;
 
-  dR_dPsi(0,1) = -cphi*cpsi - sphi*spsi*stheta;
-  dR_dPsi(1,1) = -cphi*spsi + cpsi*sphi*stheta;
-  dR_dPsi(2,1) = 0.;
+  dR_dPsi(0, 1) = -cphi * cpsi - sphi * spsi * stheta;
+  dR_dPsi(1, 1) = -cphi * spsi + cpsi * sphi * stheta;
+  dR_dPsi(2, 1) = 0.;
 
-  dR_dPsi(0,2) = cpsi*sphi - cphi*spsi*stheta;
-  dR_dPsi(1,2) = sphi*spsi + cphi*cpsi*stheta;
-  dR_dPsi(2,2) = 0.;
+  dR_dPsi(0, 2) = cpsi * sphi - cphi * spsi * stheta;
+  dR_dPsi(1, 2) = sphi * spsi + cphi * cpsi * stheta;
+  dR_dPsi(2, 2) = 0.;
 
   g[3] = matricesInnerProd(dR_dPhi, R);
   g[4] = matricesInnerProd(dR_dTheta, R);
@@ -177,27 +170,21 @@ pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeRDeri
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointSource, typename PointTarget> void
-pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::estimateRigidTransformationBFGS (const PointCloudSource &cloud_src,
-                                                                                                  const std::vector<int> &indices_src,
-                                                                                                  const PointCloudTarget &cloud_tgt,
-                                                                                                  const std::vector<int> &indices_tgt,
-                                                                                                  Eigen::Matrix4f &transformation_matrix)
-{
-  if (indices_src.size () < 4)     // need at least 4 samples
+template<typename PointSource, typename PointTarget>
+void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::estimateRigidTransformationBFGS(const PointCloudSource& cloud_src, const std::vector<int>& indices_src, const PointCloudTarget& cloud_tgt, const std::vector<int>& indices_tgt, Eigen::Matrix4f& transformation_matrix) {
+  if(indices_src.size() < 4)  // need at least 4 samples
   {
-    PCL_THROW_EXCEPTION (pcl::NotEnoughPointsException,
-                         "[pcl::GeneralizedIterativeClosestPoint::estimateRigidTransformationBFGS] Need at least 4 points to estimate a transform! Source and target have " << indices_src.size () << " points!");
+    PCL_THROW_EXCEPTION(pcl::NotEnoughPointsException, "[pcl::GeneralizedIterativeClosestPoint::estimateRigidTransformationBFGS] Need at least 4 points to estimate a transform! Source and target have " << indices_src.size() << " points!");
     return;
   }
   // Set the initial solution
-  Vector6d x = Vector6d::Zero ();
-  x[0] = transformation_matrix (0,3);
-  x[1] = transformation_matrix (1,3);
-  x[2] = transformation_matrix (2,3);
-  x[3] = std::atan2 (transformation_matrix (2,1), transformation_matrix (2,2));
-  x[4] = asin (-transformation_matrix (2,0));
-  x[5] = std::atan2 (transformation_matrix (1,0), transformation_matrix (0,0));
+  Vector6d x = Vector6d::Zero();
+  x[0] = transformation_matrix(0, 3);
+  x[1] = transformation_matrix(1, 3);
+  x[2] = transformation_matrix(2, 3);
+  x[3] = std::atan2(transformation_matrix(2, 1), transformation_matrix(2, 2));
+  x[4] = asin(-transformation_matrix(2, 0));
+  x[5] = std::atan2(transformation_matrix(1, 0), transformation_matrix(0, 0));
 
   // Set temporary pointers
   tmp_src_ = &cloud_src;
@@ -208,7 +195,7 @@ pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::estimateRigi
   // Optimize using forward-difference approximation LM
   const double gradient_tol = 1e-2;
   OptimizationFunctorWithIndices functor(this);
-  BFGS<OptimizationFunctorWithIndices> bfgs (functor);
+  BFGS<OptimizationFunctorWithIndices> bfgs(functor);
   bfgs.parameters.sigma = 0.01;
   bfgs.parameters.rho = 0.01;
   bfgs.parameters.tau1 = 9;
@@ -217,43 +204,36 @@ pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::estimateRigi
   bfgs.parameters.order = 3;
 
   int inner_iterations_ = 0;
-  int result = bfgs.minimizeInit (x);
+  int result = bfgs.minimizeInit(x);
   result = BFGSSpace::Running;
-  do
-  {
+  do {
     inner_iterations_++;
-    result = bfgs.minimizeOneStep (x);
-    if(result)
-    {
+    result = bfgs.minimizeOneStep(x);
+    if(result) {
       break;
     }
     result = bfgs.testGradient(gradient_tol);
   } while(result == BFGSSpace::Running && inner_iterations_ < max_inner_iterations_);
-  if(result == BFGSSpace::NoProgress || result == BFGSSpace::Success || inner_iterations_ == max_inner_iterations_)
-  {
-    PCL_DEBUG ("[pcl::registration::TransformationEstimationBFGS::estimateRigidTransformation]");
-    PCL_DEBUG ("BFGS solver finished with exit code %i \n", result);
+  if(result == BFGSSpace::NoProgress || result == BFGSSpace::Success || inner_iterations_ == max_inner_iterations_) {
+    PCL_DEBUG("[pcl::registration::TransformationEstimationBFGS::estimateRigidTransformation]");
+    PCL_DEBUG("BFGS solver finished with exit code %i \n", result);
     transformation_matrix.setIdentity();
     applyState(transformation_matrix, x);
-  }
-  else
-    PCL_THROW_EXCEPTION(pcl::SolverDidntConvergeException,
-                        "[pcl::" << getClassName () << "::TransformationEstimationBFGS::estimateRigidTransformation] BFGS solver didn't converge!");
+  } else
+    PCL_THROW_EXCEPTION(pcl::SolverDidntConvergeException, "[pcl::" << getClassName() << "::TransformationEstimationBFGS::estimateRigidTransformation] BFGS solver didn't converge!");
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointSource, typename PointTarget> inline double
-pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::OptimizationFunctorWithIndices::operator() (const Vector6d& x)
-{
+template<typename PointSource, typename PointTarget>
+inline double pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::OptimizationFunctorWithIndices::operator()(const Vector6d& x) {
   Eigen::Matrix4f transformation_matrix = gicp_->base_transformation_;
   gicp_->applyState(transformation_matrix, x);
   double f = 0;
   std::vector<double> f_array(omp_get_max_threads(), 0.0);
 
-  int m = static_cast<int> (gicp_->tmp_idx_src_->size ());
-  #pragma omp parallel for
-  for(int i = 0; i < m; ++i)
-  {
+  int m = static_cast<int>(gicp_->tmp_idx_src_->size());
+#pragma omp parallel for
+  for(int i = 0; i < m; ++i) {
     // The last coordinate, p_src[3] is guaranteed to be set to 1.0 in registration.hpp
     pcl::Vector4fMapConst p_src = gicp_->tmp_src_->points[(*gicp_->tmp_idx_src_)[i]].getVector4fMap();
     // The last coordinate, p_tgt[3] is guaranteed to be set to 1.0 in registration.hpp
@@ -262,37 +242,35 @@ pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::Optimization
     // The last coordinate is still guaranteed to be set to 1.0
     // Eigen::AlignedVector3<double> res(pp[0] - p_tgt[0], pp[1] - p_tgt[1], pp[2] - p_tgt[2]);
     // Eigen::AlignedVector3<double> temp(gicp_->mahalanobis((*gicp_->tmp_idx_src_)[i]) * res);
-	Eigen::Vector4f res = transformation_matrix * p_src - p_tgt;
-	Eigen::Matrix4f maha = gicp_->mahalanobis((*gicp_->tmp_idx_src_)[i]);
+    Eigen::Vector4f res = transformation_matrix * p_src - p_tgt;
+    Eigen::Matrix4f maha = gicp_->mahalanobis((*gicp_->tmp_idx_src_)[i]);
     // Eigen::Vector4d temp(maha * res);
     // increment= res'*temp/num_matches = temp'*M*temp/num_matches (we postpone 1/num_matches after the loop closes)
     // double ret = double(res.transpose() * temp);
-	double ret = res.dot(maha*res);
-	f_array[omp_get_thread_num()] += ret;
+    double ret = res.dot(maha * res);
+    f_array[omp_get_thread_num()] += ret;
   }
   f = std::accumulate(f_array.begin(), f_array.end(), 0.0);
-  return f/m;
+  return f / m;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointSource, typename PointTarget> inline void
-pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::OptimizationFunctorWithIndices::df (const Vector6d& x, Vector6d& g)
-{
+template<typename PointSource, typename PointTarget>
+inline void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::OptimizationFunctorWithIndices::df(const Vector6d& x, Vector6d& g) {
   Eigen::Matrix4f transformation_matrix = gicp_->base_transformation_;
   gicp_->applyState(transformation_matrix, x);
-  //Eigen::Vector3d g_t = g.head<3> ();
+  // Eigen::Vector3d g_t = g.head<3> ();
   std::vector<Eigen::Matrix4d, Eigen::aligned_allocator<Eigen::Matrix4d>> R_array(omp_get_max_threads());
   std::vector<Eigen::Vector4d, Eigen::aligned_allocator<Eigen::Vector4d>> g_array(omp_get_max_threads());
 
-  for (std::size_t i = 0; i < R_array.size(); i++) {
-	  R_array[i].setZero();
-	  g_array[i].setZero();
+  for(std::size_t i = 0; i < R_array.size(); i++) {
+    R_array[i].setZero();
+    g_array[i].setZero();
   }
 
-  int m = static_cast<int> (gicp_->tmp_idx_src_->size ());
-  #pragma omp parallel for
-  for(int i = 0; i < m; ++i)
-  {
+  int m = static_cast<int>(gicp_->tmp_idx_src_->size());
+#pragma omp parallel for
+  for(int i = 0; i < m; ++i) {
     // The last coordinate, p_src[3] is guaranteed to be set to 1.0 in registration.hpp
     pcl::Vector4fMapConst p_src = gicp_->tmp_src_->points[(*gicp_->tmp_idx_src_)[i]].getVector4fMap();
     // The last coordinate, p_tgt[3] is guaranteed to be set to 1.0 in registration.hpp
@@ -303,7 +281,7 @@ pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::Optimization
     Eigen::Vector4d res(pp[0] - p_tgt[0], pp[1] - p_tgt[1], pp[2] - p_tgt[2], 0.0);
     // temp = M*res
 
-	Eigen::Matrix4d maha = gicp_->mahalanobis((*gicp_->tmp_idx_src_)[i]).template cast<double>();
+    Eigen::Matrix4d maha = gicp_->mahalanobis((*gicp_->tmp_idx_src_)[i]).template cast<double>();
 
     Eigen::Vector4d temp(maha * res);
     // Increment translation gradient
@@ -318,9 +296,9 @@ pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::Optimization
 
   g.setZero();
   Eigen::Matrix4d R = Eigen::Matrix4d::Zero();
-  for (std::size_t i = 0; i < R_array.size(); i++) {
-	  R += R_array[i];
-	  g.head<3>() += g_array[i].head<3>();
+  for(std::size_t i = 0; i < R_array.size(); i++) {
+    R += R_array[i];
+    g.head<3>() += g_array[i].head<3>();
   }
 
   g.head<3>() *= 2.0 / m;
@@ -330,65 +308,60 @@ pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::Optimization
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointSource, typename PointTarget> inline void
-pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::OptimizationFunctorWithIndices::fdf (const Vector6d& x, double& f, Vector6d& g)
-{
+template<typename PointSource, typename PointTarget>
+inline void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::OptimizationFunctorWithIndices::fdf(const Vector6d& x, double& f, Vector6d& g) {
   Eigen::Matrix4f transformation_matrix = gicp_->base_transformation_;
   gicp_->applyState(transformation_matrix, x);
   f = 0;
-  g.setZero ();
-  Eigen::Matrix3d R = Eigen::Matrix3d::Zero ();
-  const auto m = static_cast<int> (gicp_->tmp_idx_src_->size ());
-  for (int i = 0; i < m; ++i)
-  {
+  g.setZero();
+  Eigen::Matrix3d R = Eigen::Matrix3d::Zero();
+  const auto m = static_cast<int>(gicp_->tmp_idx_src_->size());
+  for(int i = 0; i < m; ++i) {
     // The last coordinate, p_src[3] is guaranteed to be set to 1.0 in registration.hpp
-    pcl::Vector4fMapConst p_src = gicp_->tmp_src_->points[(*gicp_->tmp_idx_src_)[i]].getVector4fMap ();
+    pcl::Vector4fMapConst p_src = gicp_->tmp_src_->points[(*gicp_->tmp_idx_src_)[i]].getVector4fMap();
     // The last coordinate, p_tgt[3] is guaranteed to be set to 1.0 in registration.hpp
-    pcl::Vector4fMapConst p_tgt = gicp_->tmp_tgt_->points[(*gicp_->tmp_idx_tgt_)[i]].getVector4fMap ();
-    Eigen::Vector4f pp (transformation_matrix * p_src);
+    pcl::Vector4fMapConst p_tgt = gicp_->tmp_tgt_->points[(*gicp_->tmp_idx_tgt_)[i]].getVector4fMap();
+    Eigen::Vector4f pp(transformation_matrix * p_src);
     // The last coordinate is still guaranteed to be set to 1.0
-    Eigen::Vector3d res (pp[0] - p_tgt[0], pp[1] - p_tgt[1], pp[2] - p_tgt[2]);
+    Eigen::Vector3d res(pp[0] - p_tgt[0], pp[1] - p_tgt[1], pp[2] - p_tgt[2]);
     // temp = M*res
-    Eigen::Vector3d temp (gicp_->mahalanobis((*gicp_->tmp_idx_src_)[i]).template block<3, 3>(0, 0).template cast<double>() * res);
+    Eigen::Vector3d temp(gicp_->mahalanobis((*gicp_->tmp_idx_src_)[i]).template block<3, 3>(0, 0).template cast<double>() * res);
     // Increment total error
-    f+= double(res.transpose() * temp);
+    f += double(res.transpose() * temp);
     // Increment translation gradient
     // g.head<3> ()+= 2*M*res/num_matches (we postpone 2/num_matches after the loop closes)
-    g.head<3> ()+= temp;
+    g.head<3>() += temp;
     pp = gicp_->base_transformation_ * p_src;
-    Eigen::Vector3d p_src3 (pp[0], pp[1], pp[2]);
+    Eigen::Vector3d p_src3(pp[0], pp[1], pp[2]);
     // Increment rotation gradient
-    R+= p_src3 * temp.transpose();
+    R += p_src3 * temp.transpose();
   }
-  f/= double(m);
-  g.head<3> ()*= double(2.0/m);
-  R*= 2.0/m;
+  f /= double(m);
+  g.head<3>() *= double(2.0 / m);
+  R *= 2.0 / m;
   gicp_->computeRDerivative(x, R, g);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointSource, typename PointTarget> inline void
-pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeTransformation (PointCloudSource &output, const Eigen::Matrix4f& guess)
-{
-  pcl::IterativeClosestPoint<PointSource, PointTarget>::initComputeReciprocal ();
+template<typename PointSource, typename PointTarget>
+inline void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeTransformation(PointCloudSource& output, const Eigen::Matrix4f& guess) {
+  pcl::IterativeClosestPoint<PointSource, PointTarget>::initComputeReciprocal();
   using namespace std;
   // Difference between consecutive transforms
   double delta = 0;
   // Get the size of the target
-  const size_t N = indices_->size ();
+  const size_t N = indices_->size();
   // Set the mahalanobis matrices to identity
-  mahalanobis_.resize (N, Eigen::Matrix4f::Identity ());
+  mahalanobis_.resize(N, Eigen::Matrix4f::Identity());
   // Compute target cloud covariance matrices
-  if ((!target_covariances_) || (target_covariances_->empty ()))
-  {
-    target_covariances_.reset (new MatricesVector);
-    computeCovariances<PointTarget> (target_, tree_, *target_covariances_);
+  if((!target_covariances_) || (target_covariances_->empty())) {
+    target_covariances_.reset(new MatricesVector);
+    computeCovariances<PointTarget>(target_, tree_, *target_covariances_);
   }
   // Compute input cloud covariance matrices
-  if ((!input_covariances_) || (input_covariances_->empty ()))
-  {
-    input_covariances_.reset (new MatricesVector);
-    computeCovariances<PointSource> (input_, tree_reciprocal_, *input_covariances_);
+  if((!input_covariances_) || (input_covariances_->empty())) {
+    input_covariances_.reset(new MatricesVector);
+    computeCovariances<PointSource>(input_, tree_reciprocal_, *input_covariances_);
   }
 
   base_transformation_ = Eigen::Matrix4f::Identity();
@@ -399,67 +372,67 @@ pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeTrans
 
   std::vector<std::vector<int>> nn_indices_array(omp_get_max_threads());
   std::vector<std::vector<float>> nn_dists_array(omp_get_max_threads());
-  for (auto& nn_indices : nn_indices_array) { nn_indices.resize(1); }
-  for (auto& nn_dists : nn_dists_array) { nn_dists.resize(1); }
+  for(auto& nn_indices : nn_indices_array) {
+    nn_indices.resize(1);
+  }
+  for(auto& nn_dists : nn_dists_array) {
+    nn_dists.resize(1);
+  }
 
-  while(!converged_)
-  {
+  while(!converged_) {
     std::atomic<size_t> cnt;
     cnt = 0;
-    std::vector<int> source_indices (indices_->size ());
-    std::vector<int> target_indices (indices_->size ());
+    std::vector<int> source_indices(indices_->size());
+    std::vector<int> target_indices(indices_->size());
 
     // guess corresponds to base_t and transformation_ to t
-    Eigen::Matrix4d transform_R = Eigen::Matrix4d::Zero ();
+    Eigen::Matrix4d transform_R = Eigen::Matrix4d::Zero();
     for(size_t i = 0; i < 4; i++)
       for(size_t j = 0; j < 4; j++)
-        for(size_t k = 0; k < 4; k++)
-          transform_R(i,j)+= double(transformation_(i,k)) * double(guess(k,j));
+        for(size_t k = 0; k < 4; k++) transform_R(i, j) += double(transformation_(i, k)) * double(guess(k, j));
 
-    const Eigen::Matrix3d R = transform_R.topLeftCorner<3,3> ();
+    const Eigen::Matrix3d R = transform_R.topLeftCorner<3, 3>();
 
-    #pragma omp parallel for
-    for (std::size_t i = 0; i < N; i++)
-    {
+#pragma omp parallel for
+    for(std::size_t i = 0; i < N; i++) {
       auto& nn_indices = nn_indices_array[omp_get_thread_num()];
       auto& nn_dists = nn_dists_array[omp_get_thread_num()];
 
       PointSource query = output[i];
-      query.getVector4fMap () = transformation_ * query.getVector4fMap ();
+      query.getVector4fMap() = transformation_ * query.getVector4fMap();
 
-      if (!searchForNeighbors (query, nn_indices, nn_dists))
-      {
-        PCL_ERROR ("[pcl::%s::computeTransformation] Unable to find a nearest neighbor in the target dataset for point %d in the source!\n", getClassName ().c_str (), (*indices_)[i]);
+      if(!searchForNeighbors(query, nn_indices, nn_dists)) {
+        PCL_ERROR("[pcl::%s::computeTransformation] Unable to find a nearest neighbor in the target dataset for point %d in the source!\n", getClassName().c_str(), (*indices_)[i]);
         continue;
       }
 
       // Check if the distance to the nearest neighbor is smaller than the user imposed threshold
-      if (nn_dists[0] < dist_threshold)
-      {
-        const Eigen::Matrix3d &C1 = (*input_covariances_)[i];
-        const Eigen::Matrix3d &C2 = (*target_covariances_)[nn_indices[0]];
+      if(nn_dists[0] < dist_threshold) {
+        const Eigen::Matrix3d& C1 = (*input_covariances_)[i];
+        const Eigen::Matrix3d& C2 = (*target_covariances_)[nn_indices[0]];
         Eigen::Matrix4f& M_ = mahalanobis_[i];
-		M_.setZero();
+        M_.setZero();
 
-		Eigen::Matrix3d M = M_.block<3, 3>(0, 0).cast<double>();
+        Eigen::Matrix3d M = M_.block<3, 3>(0, 0).cast<double>();
         // M = R*C1
         M = R * C1;
         // temp = M*R' + C2 = R*C1*R' + C2
         Eigen::Matrix3d temp = M * R.transpose();
-        temp+= C2;
+        temp += C2;
         // M = temp^-1
-        M = temp.inverse ();
-		M_.block<3, 3>(0, 0) = M.cast<float>();
+        M = temp.inverse();
+        M_.block<3, 3>(0, 0) = M.cast<float>();
         int c = cnt++;
-        source_indices[c] = static_cast<int> (i);
+        source_indices[c] = static_cast<int>(i);
         target_indices[c] = nn_indices[0];
       }
     }
     // Resize to the actual number of valid correspondences
-    source_indices.resize(cnt); target_indices.resize(cnt);
+    source_indices.resize(cnt);
+    target_indices.resize(cnt);
 
     std::vector<std::pair<int, int>> indices(source_indices.size());
-    for(std::size_t i = 0; i<source_indices.size(); i++) {
+    for(std::size_t i = 0; i < source_indices.size(); i++) {
       indices[i].first = source_indices[i];
       indices[i].second = target_indices[i];
     }
@@ -473,59 +446,49 @@ pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeTrans
 
     /* optimize transformation using the current assignment and Mahalanobis metrics*/
     previous_transformation_ = transformation_;
-    //optimization right here
-    try
-    {
+    // optimization right here
+    try {
       rigid_transformation_estimation_(output, source_indices, *target_, target_indices, transformation_);
       /* compute the delta from this iteration */
       delta = 0.;
       for(int k = 0; k < 4; k++) {
         for(int l = 0; l < 4; l++) {
           double ratio = 1;
-          if(k < 3 && l < 3) // rotation part of the transform
-            ratio = 1./rotation_epsilon_;
+          if(k < 3 && l < 3)  // rotation part of the transform
+            ratio = 1. / rotation_epsilon_;
           else
-            ratio = 1./transformation_epsilon_;
-          double c_delta = ratio*std::abs(previous_transformation_(k,l) - transformation_(k,l));
-          if(c_delta > delta)
-            delta = c_delta;
+            ratio = 1. / transformation_epsilon_;
+          double c_delta = ratio * std::abs(previous_transformation_(k, l) - transformation_(k, l));
+          if(c_delta > delta) delta = c_delta;
         }
       }
-    }
-    catch (pcl::PCLException &e)
-    {
-      PCL_DEBUG ("[pcl::%s::computeTransformation] Optimization issue %s\n", getClassName ().c_str (), e.what ());
+    } catch(pcl::PCLException& e) {
+      PCL_DEBUG("[pcl::%s::computeTransformation] Optimization issue %s\n", getClassName().c_str(), e.what());
       break;
     }
     nr_iterations_++;
     // Check for convergence
-    if (nr_iterations_ >= max_iterations_ || delta < 1)
-    {
+    if(nr_iterations_ >= max_iterations_ || delta < 1) {
       converged_ = true;
       previous_transformation_ = transformation_;
-      PCL_DEBUG ("[pcl::%s::computeTransformation] Convergence reached. Number of iterations: %d out of %d. Transformation difference: %f\n",
-                 getClassName ().c_str (), nr_iterations_, max_iterations_, (transformation_ - previous_transformation_).array ().abs ().sum ());
-    }
-    else
-      PCL_DEBUG ("[pcl::%s::computeTransformation] Convergence failed\n", getClassName ().c_str ());
+      PCL_DEBUG("[pcl::%s::computeTransformation] Convergence reached. Number of iterations: %d out of %d. Transformation difference: %f\n", getClassName().c_str(), nr_iterations_, max_iterations_, (transformation_ - previous_transformation_).array().abs().sum());
+    } else
+      PCL_DEBUG("[pcl::%s::computeTransformation] Convergence failed\n", getClassName().c_str());
   }
   final_transformation_ = previous_transformation_ * guess;
 
   // Transform the point cloud
-  pcl::transformPointCloud (*input_, output, final_transformation_);
+  pcl::transformPointCloud(*input_, output, final_transformation_);
 }
 
-template <typename PointSource, typename PointTarget> void
-pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::applyState(Eigen::Matrix4f &t, const Vector6d& x) const
-{
+template<typename PointSource, typename PointTarget>
+void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::applyState(Eigen::Matrix4f& t, const Vector6d& x) const {
   // !!! CAUTION Stanford GICP uses the Z Y X euler angles convention
   Eigen::Matrix3f R;
-  R = Eigen::AngleAxisf (static_cast<float> (x[5]), Eigen::Vector3f::UnitZ ())
-    * Eigen::AngleAxisf (static_cast<float> (x[4]), Eigen::Vector3f::UnitY ())
-    * Eigen::AngleAxisf (static_cast<float> (x[3]), Eigen::Vector3f::UnitX ());
-  t.topLeftCorner<3,3> ().matrix () = R * t.topLeftCorner<3,3> ().matrix ();
-  Eigen::Vector4f T (static_cast<float> (x[0]), static_cast<float> (x[1]), static_cast<float> (x[2]), 0.0f);
-  t.col (3) += T;
+  R = Eigen::AngleAxisf(static_cast<float>(x[5]), Eigen::Vector3f::UnitZ()) * Eigen::AngleAxisf(static_cast<float>(x[4]), Eigen::Vector3f::UnitY()) * Eigen::AngleAxisf(static_cast<float>(x[3]), Eigen::Vector3f::UnitX());
+  t.topLeftCorner<3, 3>().matrix() = R * t.topLeftCorner<3, 3>().matrix();
+  Eigen::Vector4f T(static_cast<float>(x[0]), static_cast<float>(x[1]), static_cast<float>(x[2]), 0.0f);
+  t.col(3) += T;
 }
 
-#endif //PCL_REGISTRATION_IMPL_GICP_HPP_
+#endif  // PCL_REGISTRATION_IMPL_GICP_HPP_

--- a/include/pclomp/ndt_omp.h
+++ b/include/pclomp/ndt_omp.h
@@ -49,576 +49,469 @@
 
 #include <unsupported/Eigen/NonLinearOptimization>
 
-namespace pclomp
-{
-	enum NeighborSearchMethod {
-		KDTREE,
-		DIRECT26,
-		DIRECT7,
-		DIRECT1
-	};
+namespace pclomp {
+enum NeighborSearchMethod { KDTREE, DIRECT26, DIRECT7, DIRECT1 };
 
-	struct NdtResult
-	{
-		Eigen::Matrix4f pose;
-		float transform_probability;
-		float nearest_voxel_transformation_likelihood;
-		int iteration_num;
-		std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f>> transformation_array;
-		Eigen::Matrix<double, 6, 6> hessian;
-		EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-	};
+struct NdtResult {
+  Eigen::Matrix4f pose;
+  float transform_probability;
+  float nearest_voxel_transformation_likelihood;
+  int iteration_num;
+  std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f>> transformation_array;
+  Eigen::Matrix<double, 6, 6> hessian;
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
 
-	struct NdtParams
-	{
-		double trans_epsilon;
-		double step_size;
-		double resolution;
-		int max_iterations;
-		pclomp::NeighborSearchMethod search_method;
-		int num_threads;
-		float regularization_scale_factor;
-	};
+struct NdtParams {
+  double trans_epsilon;
+  double step_size;
+  double resolution;
+  int max_iterations;
+  pclomp::NeighborSearchMethod search_method;
+  int num_threads;
+  float regularization_scale_factor;
+};
 
-	/** \brief A 3D Normal Distribution Transform registration implementation for point cloud data.
-	  * \note For more information please see
-	  * <b>Magnusson, M. (2009). The Three-Dimensional Normal-Distributions Transform —
-	  * an Efficient Representation for Registration, Surface Analysis, and Loop Detection.
-	  * PhD thesis, Orebro University. Orebro Studies in Technology 36.</b>,
-	  * <b>More, J., and Thuente, D. (1994). Line Search Algorithm with Guaranteed Sufficient Decrease
-	  * In ACM Transactions on Mathematical Software.</b> and
-	  * Sun, W. and Yuan, Y, (2006) Optimization Theory and Methods: Nonlinear Programming. 89-100
-	  * \note Math refactored by Todor Stoyanov.
-	  * \author Brian Okorn (Space and Naval Warfare Systems Center Pacific)
-	  */
-	template<typename PointSource, typename PointTarget>
-	class NormalDistributionsTransform : public pcl::Registration<PointSource, PointTarget>
-	{
-	protected:
+/** \brief A 3D Normal Distribution Transform registration implementation for point cloud data.
+ * \note For more information please see
+ * <b>Magnusson, M. (2009). The Three-Dimensional Normal-Distributions Transform —
+ * an Efficient Representation for Registration, Surface Analysis, and Loop Detection.
+ * PhD thesis, Orebro University. Orebro Studies in Technology 36.</b>,
+ * <b>More, J., and Thuente, D. (1994). Line Search Algorithm with Guaranteed Sufficient Decrease
+ * In ACM Transactions on Mathematical Software.</b> and
+ * Sun, W. and Yuan, Y, (2006) Optimization Theory and Methods: Nonlinear Programming. 89-100
+ * \note Math refactored by Todor Stoyanov.
+ * \author Brian Okorn (Space and Naval Warfare Systems Center Pacific)
+ */
+template<typename PointSource, typename PointTarget>
+class NormalDistributionsTransform : public pcl::Registration<PointSource, PointTarget> {
+protected:
+  typedef typename pcl::Registration<PointSource, PointTarget>::PointCloudSource PointCloudSource;
+  typedef typename PointCloudSource::Ptr PointCloudSourcePtr;
+  typedef typename PointCloudSource::ConstPtr PointCloudSourceConstPtr;
 
-		typedef typename pcl::Registration<PointSource, PointTarget>::PointCloudSource PointCloudSource;
-		typedef typename PointCloudSource::Ptr PointCloudSourcePtr;
-		typedef typename PointCloudSource::ConstPtr PointCloudSourceConstPtr;
+  typedef typename pcl::Registration<PointSource, PointTarget>::PointCloudTarget PointCloudTarget;
+  typedef typename PointCloudTarget::Ptr PointCloudTargetPtr;
+  typedef typename PointCloudTarget::ConstPtr PointCloudTargetConstPtr;
 
-		typedef typename pcl::Registration<PointSource, PointTarget>::PointCloudTarget PointCloudTarget;
-		typedef typename PointCloudTarget::Ptr PointCloudTargetPtr;
-		typedef typename PointCloudTarget::ConstPtr PointCloudTargetConstPtr;
+  typedef pcl::PointIndices::Ptr PointIndicesPtr;
+  typedef pcl::PointIndices::ConstPtr PointIndicesConstPtr;
 
-		typedef pcl::PointIndices::Ptr PointIndicesPtr;
-		typedef pcl::PointIndices::ConstPtr PointIndicesConstPtr;
+  /** \brief Typename of searchable voxel grid containing mean and covariance. */
+  typedef pclomp::VoxelGridCovariance<PointTarget> TargetGrid;
+  /** \brief Typename of pointer to searchable voxel grid. */
+  typedef TargetGrid *TargetGridPtr;
+  /** \brief Typename of const pointer to searchable voxel grid. */
+  typedef const TargetGrid *TargetGridConstPtr;
+  /** \brief Typename of const pointer to searchable voxel grid leaf. */
+  typedef typename TargetGrid::LeafConstPtr TargetGridLeafConstPtr;
 
-		/** \brief Typename of searchable voxel grid containing mean and covariance. */
-		typedef pclomp::VoxelGridCovariance<PointTarget> TargetGrid;
-		/** \brief Typename of pointer to searchable voxel grid. */
-		typedef TargetGrid* TargetGridPtr;
-		/** \brief Typename of const pointer to searchable voxel grid. */
-		typedef const TargetGrid* TargetGridConstPtr;
-		/** \brief Typename of const pointer to searchable voxel grid leaf. */
-		typedef typename TargetGrid::LeafConstPtr TargetGridLeafConstPtr;
-
-
-	public:
-
+public:
 #if PCL_VERSION >= PCL_VERSION_CALC(1, 10, 0)
-		typedef pcl::shared_ptr< NormalDistributionsTransform<PointSource, PointTarget> > Ptr;
-		typedef pcl::shared_ptr< const NormalDistributionsTransform<PointSource, PointTarget> > ConstPtr;
+  typedef pcl::shared_ptr<NormalDistributionsTransform<PointSource, PointTarget>> Ptr;
+  typedef pcl::shared_ptr<const NormalDistributionsTransform<PointSource, PointTarget>> ConstPtr;
 #else
-		typedef boost::shared_ptr< NormalDistributionsTransform<PointSource, PointTarget> > Ptr;
-		typedef boost::shared_ptr< const NormalDistributionsTransform<PointSource, PointTarget> > ConstPtr;
+  typedef boost::shared_ptr<NormalDistributionsTransform<PointSource, PointTarget>> Ptr;
+  typedef boost::shared_ptr<const NormalDistributionsTransform<PointSource, PointTarget>> ConstPtr;
 #endif
 
+  /** \brief Constructor.
+   * Sets \ref outlier_ratio_ to 0.35, \ref step_size_ to 0.05 and \ref resolution_ to 1.0
+   */
+  NormalDistributionsTransform();
 
-		/** \brief Constructor.
-		  * Sets \ref outlier_ratio_ to 0.35, \ref step_size_ to 0.05 and \ref resolution_ to 1.0
-		  */
-		NormalDistributionsTransform();
+  /** \brief Empty destructor */
+  virtual ~NormalDistributionsTransform() {}
 
-		/** \brief Empty destructor */
-		virtual ~NormalDistributionsTransform() {}
+  void setNumThreads(int n) {
+    num_threads_ = n;
+  }
 
-		void setNumThreads(int n)
-		{
-			num_threads_ = n;
-		}
+  inline int getNumThreads() const {
+    return num_threads_;
+  }
 
-		inline int getNumThreads() const
-		{
-			return num_threads_;
-		}
+  /** \brief Provide a pointer to the input target (e.g., the point cloud that we want to align the input source to).
+   * \param[in] cloud the input point cloud target
+   */
+  inline void setInputTarget(const PointCloudTargetConstPtr &cloud) {
+    pcl::Registration<PointSource, PointTarget>::setInputTarget(cloud);
+    init();
+  }
 
-		/** \brief Provide a pointer to the input target (e.g., the point cloud that we want to align the input source to).
-		  * \param[in] cloud the input point cloud target
-		  */
-		inline void
-			setInputTarget(const PointCloudTargetConstPtr &cloud)
-		{
-			pcl::Registration<PointSource, PointTarget>::setInputTarget(cloud);
-			init();
-		}
+  /** \brief Set/change the voxel grid resolution.
+   * \param[in] resolution side length of voxels
+   */
+  inline void setResolution(float resolution) {
+    // Prevents unnecessary voxel initiations
+    if(resolution_ != resolution) {
+      resolution_ = resolution;
+      if(input_) init();
+    }
+  }
 
-		/** \brief Set/change the voxel grid resolution.
-		  * \param[in] resolution side length of voxels
-		  */
-		inline void
-			setResolution(float resolution)
-		{
-			// Prevents unnecessary voxel initiations
-			if (resolution_ != resolution)
-			{
-				resolution_ = resolution;
-				if (input_)
-					init();
-			}
-		}
+  /** \brief Get voxel grid resolution.
+   * \return side length of voxels
+   */
+  inline float getResolution() const {
+    return (resolution_);
+  }
 
-		/** \brief Get voxel grid resolution.
-		  * \return side length of voxels
-		  */
-		inline float
-			getResolution() const
-		{
-			return (resolution_);
-		}
+  /** \brief Get the newton line search maximum step length.
+   * \return maximum step length
+   */
+  inline double getStepSize() const {
+    return (step_size_);
+  }
 
-		/** \brief Get the newton line search maximum step length.
-		  * \return maximum step length
-		  */
-		inline double
-			getStepSize() const
-		{
-			return (step_size_);
-		}
+  /** \brief Set/change the newton line search maximum step length.
+   * \param[in] step_size maximum step length
+   */
+  inline void setStepSize(double step_size) {
+    step_size_ = step_size;
+  }
 
-		/** \brief Set/change the newton line search maximum step length.
-		  * \param[in] step_size maximum step length
-		  */
-		inline void
-			setStepSize(double step_size)
-		{
-			step_size_ = step_size;
-		}
+  /** \brief Get the point cloud outlier ratio.
+   * \return outlier ratio
+   */
+  inline double getOutlierRatio() const {
+    return (outlier_ratio_);
+  }
 
-		/** \brief Get the point cloud outlier ratio.
-		  * \return outlier ratio
-		  */
-		inline double
-			getOutlierRatio() const
-		{
-			return (outlier_ratio_);
-		}
+  /** \brief Set/change the point cloud outlier ratio.
+   * \param[in] outlier_ratio outlier ratio
+   */
+  inline void setOutlierRatio(double outlier_ratio) {
+    outlier_ratio_ = outlier_ratio;
+  }
 
-		/** \brief Set/change the point cloud outlier ratio.
-		  * \param[in] outlier_ratio outlier ratio
-		  */
-		inline void
-			setOutlierRatio(double outlier_ratio)
-		{
-			outlier_ratio_ = outlier_ratio;
-		}
+  inline void setNeighborhoodSearchMethod(NeighborSearchMethod method) {
+    search_method = method;
+  }
 
-		inline void setNeighborhoodSearchMethod(NeighborSearchMethod method) {
-			search_method = method;
-		}
+  inline NeighborSearchMethod getNeighborhoodSearchMethod() const {
+    return search_method;
+  }
 
-		inline NeighborSearchMethod
-			getNeighborhoodSearchMethod() const
-		{
-			return search_method;
-		}
+  /** \brief Get the registration alignment probability.
+   * \return transformation probability
+   */
+  inline double getTransformationProbability() const {
+    return (trans_probability_);
+  }
 
-		/** \brief Get the registration alignment probability.
-		  * \return transformation probability
-		  */
-		inline double
-			getTransformationProbability() const
-		{
-			return (trans_probability_);
-		}
+  inline double getNearestVoxelTransformationLikelihood() const {
+    return nearest_voxel_transformation_likelihood_;
+  }
 
-		inline double
-			getNearestVoxelTransformationLikelihood() const
-		{
-			return nearest_voxel_transformation_likelihood_;
-		}
+  /** \brief Get the number of iterations required to calculate alignment.
+   * \return final number of iterations
+   */
+  inline int getFinalNumIteration() const {
+    return (nr_iterations_);
+  }
 
-		/** \brief Get the number of iterations required to calculate alignment.
-		  * \return final number of iterations
-		  */
-		inline int
-			getFinalNumIteration() const
-		{
-			return (nr_iterations_);
-		}
+  /** \brief Return the hessian matrix */
+  inline Eigen::Matrix<double, 6, 6> getHessian() const {
+    return hessian_;
+  }
 
-		/** \brief Return the hessian matrix */
-		inline Eigen::Matrix<double, 6, 6>
-			getHessian() const
-		{
-			return hessian_;
-		}
+  /** \brief Return the transformation array */
+  inline const std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f>> getFinalTransformationArray() const {
+    return transformation_array_;
+  }
 
-		/** \brief Return the transformation array */
-		inline const std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f>>
-			getFinalTransformationArray() const
-		{
-			return transformation_array_;
-		}
+  /** \brief Convert 6 element transformation vector to affine transformation.
+   * \param[in] x transformation vector of the form [x, y, z, roll, pitch, yaw]
+   * \param[out] trans affine transform corresponding to given transformation vector
+   */
+  static void convertTransform(const Eigen::Matrix<double, 6, 1> &x, Eigen::Affine3f &trans) {
+    trans = Eigen::Translation<float, 3>(float(x(0)), float(x(1)), float(x(2))) * Eigen::AngleAxis<float>(float(x(3)), Eigen::Vector3f::UnitX()) * Eigen::AngleAxis<float>(float(x(4)), Eigen::Vector3f::UnitY()) * Eigen::AngleAxis<float>(float(x(5)), Eigen::Vector3f::UnitZ());
+  }
 
-		/** \brief Convert 6 element transformation vector to affine transformation.
-		  * \param[in] x transformation vector of the form [x, y, z, roll, pitch, yaw]
-		  * \param[out] trans affine transform corresponding to given transformation vector
-		  */
-		static void
-			convertTransform(const Eigen::Matrix<double, 6, 1> &x, Eigen::Affine3f &trans)
-		{
-			trans = Eigen::Translation<float, 3>(float(x(0)), float(x(1)), float(x(2))) *
-				Eigen::AngleAxis<float>(float(x(3)), Eigen::Vector3f::UnitX()) *
-				Eigen::AngleAxis<float>(float(x(4)), Eigen::Vector3f::UnitY()) *
-				Eigen::AngleAxis<float>(float(x(5)), Eigen::Vector3f::UnitZ());
-		}
+  /** \brief Convert 6 element transformation vector to transformation matrix.
+   * \param[in] x transformation vector of the form [x, y, z, roll, pitch, yaw]
+   * \param[out] trans 4x4 transformation matrix corresponding to given transformation vector
+   */
+  static void convertTransform(const Eigen::Matrix<double, 6, 1> &x, Eigen::Matrix4f &trans) {
+    Eigen::Affine3f _affine;
+    convertTransform(x, _affine);
+    trans = _affine.matrix();
+  }
 
-		/** \brief Convert 6 element transformation vector to transformation matrix.
-		  * \param[in] x transformation vector of the form [x, y, z, roll, pitch, yaw]
-		  * \param[out] trans 4x4 transformation matrix corresponding to given transformation vector
-		  */
-		static void
-			convertTransform(const Eigen::Matrix<double, 6, 1> &x, Eigen::Matrix4f &trans)
-		{
-			Eigen::Affine3f _affine;
-			convertTransform(x, _affine);
-			trans = _affine.matrix();
-		}
+  // negative log likelihood function
+  // lower is better
+  double calculateScore(const PointCloudSource &cloud) const;
+  double calculateTransformationProbability(const PointCloudSource &cloud) const;
+  double calculateNearestVoxelTransformationLikelihood(const PointCloudSource &cloud) const;
 
-		// negative log likelihood function
-		// lower is better
-		double calculateScore(const PointCloudSource& cloud) const;
-		double calculateTransformationProbability(const PointCloudSource& cloud) const;
-		double calculateNearestVoxelTransformationLikelihood(const PointCloudSource& cloud) const;
+  inline void setRegularizationScaleFactor(float regularization_scale_factor) {
+    regularization_scale_factor_ = regularization_scale_factor;
+  }
 
-		inline void setRegularizationScaleFactor(float regularization_scale_factor)
-		{
-			regularization_scale_factor_ = regularization_scale_factor;
-		}
+  inline void setRegularizationPose(Eigen::Matrix4f regularization_pose) {
+    regularization_pose_ = regularization_pose;
+  }
 
-		inline void setRegularizationPose(Eigen::Matrix4f regularization_pose)
-		{
-			regularization_pose_ = regularization_pose;
-		}
+  inline void unsetRegularizationPose() {
+    regularization_pose_ = boost::none;
+  }
 
-		inline void unsetRegularizationPose()
-		{
-			regularization_pose_ = boost::none;
-		}
+  NdtResult getResult() {
+    NdtResult ndt_result;
+    ndt_result.pose = this->getFinalTransformation();
+    ndt_result.transformation_array = getFinalTransformationArray();
+    ndt_result.transform_probability = getTransformationProbability();
+    ndt_result.nearest_voxel_transformation_likelihood = getNearestVoxelTransformationLikelihood();
+    ndt_result.iteration_num = getFinalNumIteration();
+    ndt_result.hessian = getHessian();
+    return ndt_result;
+  }
 
-		NdtResult getResult()
-		{
-			NdtResult ndt_result;
-			ndt_result.pose = this->getFinalTransformation();
-			ndt_result.transformation_array = getFinalTransformationArray();
-			ndt_result.transform_probability = getTransformationProbability();
-			ndt_result.nearest_voxel_transformation_likelihood =
-				getNearestVoxelTransformationLikelihood();
-			ndt_result.iteration_num = getFinalNumIteration();
-			ndt_result.hessian = getHessian();
-			return ndt_result;
-		}
+  void setParams(const NdtParams &ndt_params) {
+    this->setTransformationEpsilon(ndt_params.trans_epsilon);
+    this->setStepSize(ndt_params.step_size);
+    this->setResolution(ndt_params.resolution);
+    this->setMaximumIterations(ndt_params.max_iterations);
+    setRegularizationScaleFactor(ndt_params.regularization_scale_factor);
+    setNeighborhoodSearchMethod(ndt_params.search_method);
+    setNumThreads(ndt_params.num_threads);
+  }
 
-		void setParams(const NdtParams & ndt_params)
-		{
-			this->setTransformationEpsilon(ndt_params.trans_epsilon);
-			this->setStepSize(ndt_params.step_size);
-			this->setResolution(ndt_params.resolution);
-			this->setMaximumIterations(ndt_params.max_iterations);
-			setRegularizationScaleFactor(ndt_params.regularization_scale_factor);
-			setNeighborhoodSearchMethod(ndt_params.search_method);
-			setNumThreads(ndt_params.num_threads);
-		}
+  NdtParams getParams() const {
+    NdtParams ndt_params;
+    ndt_params.trans_epsilon = transformation_epsilon_;
+    ndt_params.step_size = getStepSize();
+    ndt_params.resolution = getResolution();
+    ndt_params.max_iterations = max_iterations_;
+    ndt_params.regularization_scale_factor = regularization_scale_factor_;
+    ndt_params.search_method = getNeighborhoodSearchMethod();
+    ndt_params.num_threads = num_threads_;
+    return ndt_params;
+  }
 
-		NdtParams getParams() const
-		{
-			NdtParams ndt_params;
-			ndt_params.trans_epsilon = transformation_epsilon_;
-			ndt_params.step_size = getStepSize();
-			ndt_params.resolution = getResolution();
-			ndt_params.max_iterations = max_iterations_;
-			ndt_params.regularization_scale_factor = regularization_scale_factor_;
-			ndt_params.search_method = getNeighborhoodSearchMethod();
-			ndt_params.num_threads = num_threads_;
-			return ndt_params;
-		}
+protected:
+  using pcl::Registration<PointSource, PointTarget>::reg_name_;
+  using pcl::Registration<PointSource, PointTarget>::getClassName;
+  using pcl::Registration<PointSource, PointTarget>::input_;
+  using pcl::Registration<PointSource, PointTarget>::indices_;
+  using pcl::Registration<PointSource, PointTarget>::target_;
+  using pcl::Registration<PointSource, PointTarget>::nr_iterations_;
+  using pcl::Registration<PointSource, PointTarget>::max_iterations_;
+  using pcl::Registration<PointSource, PointTarget>::previous_transformation_;
+  using pcl::Registration<PointSource, PointTarget>::final_transformation_;
+  using pcl::Registration<PointSource, PointTarget>::transformation_;
+  using pcl::Registration<PointSource, PointTarget>::transformation_epsilon_;
+  using pcl::Registration<PointSource, PointTarget>::converged_;
+  using pcl::Registration<PointSource, PointTarget>::corr_dist_threshold_;
+  using pcl::Registration<PointSource, PointTarget>::inlier_threshold_;
 
-	protected:
+  using pcl::Registration<PointSource, PointTarget>::update_visualizer_;
 
-		using pcl::Registration<PointSource, PointTarget>::reg_name_;
-		using pcl::Registration<PointSource, PointTarget>::getClassName;
-		using pcl::Registration<PointSource, PointTarget>::input_;
-		using pcl::Registration<PointSource, PointTarget>::indices_;
-		using pcl::Registration<PointSource, PointTarget>::target_;
-		using pcl::Registration<PointSource, PointTarget>::nr_iterations_;
-		using pcl::Registration<PointSource, PointTarget>::max_iterations_;
-		using pcl::Registration<PointSource, PointTarget>::previous_transformation_;
-		using pcl::Registration<PointSource, PointTarget>::final_transformation_;
-		using pcl::Registration<PointSource, PointTarget>::transformation_;
-		using pcl::Registration<PointSource, PointTarget>::transformation_epsilon_;
-		using pcl::Registration<PointSource, PointTarget>::converged_;
-		using pcl::Registration<PointSource, PointTarget>::corr_dist_threshold_;
-		using pcl::Registration<PointSource, PointTarget>::inlier_threshold_;
+  /** \brief Estimate the transformation and returns the transformed source (input) as output.
+   * \param[out] output the resultant input transformed point cloud dataset
+   */
+  virtual void computeTransformation(PointCloudSource &output) {
+    computeTransformation(output, Eigen::Matrix4f::Identity());
+  }
 
-		using pcl::Registration<PointSource, PointTarget>::update_visualizer_;
+  /** \brief Estimate the transformation and returns the transformed source (input) as output.
+   * \param[out] output the resultant input transformed point cloud dataset
+   * \param[in] guess the initial gross estimation of the transformation
+   */
+  virtual void computeTransformation(PointCloudSource &output, const Eigen::Matrix4f &guess);
 
-		/** \brief Estimate the transformation and returns the transformed source (input) as output.
-		  * \param[out] output the resultant input transformed point cloud dataset
-		  */
-		virtual void
-			computeTransformation(PointCloudSource &output)
-		{
-			computeTransformation(output, Eigen::Matrix4f::Identity());
-		}
+  /** \brief Initiate covariance voxel structure. */
+  void inline init() {
+    target_cells_.setLeafSize(resolution_, resolution_, resolution_);
+    target_cells_.setInputCloud(target_);
+    // Initiate voxel structure.
+    target_cells_.filter(true);
+  }
 
-		/** \brief Estimate the transformation and returns the transformed source (input) as output.
-		  * \param[out] output the resultant input transformed point cloud dataset
-		  * \param[in] guess the initial gross estimation of the transformation
-		  */
-		virtual void
-			computeTransformation(PointCloudSource &output, const Eigen::Matrix4f &guess);
+  /** \brief Compute derivatives of probability function w.r.t. the transformation vector.
+   * \note Equation 6.10, 6.12 and 6.13 [Magnusson 2009].
+   * \param[out] score_gradient the gradient vector of the probability function w.r.t. the transformation vector
+   * \param[out] hessian the hessian matrix of the probability function w.r.t. the transformation vector
+   * \param[in] trans_cloud transformed point cloud
+   * \param[in] p the current transform vector
+   * \param[in] compute_hessian flag to calculate hessian, unnecessary for step calculation.
+   */
+  double computeDerivatives(Eigen::Matrix<double, 6, 1> &score_gradient, Eigen::Matrix<double, 6, 6> &hessian, PointCloudSource &trans_cloud, Eigen::Matrix<double, 6, 1> &p, bool compute_hessian = true);
 
-		/** \brief Initiate covariance voxel structure. */
-		void inline
-			init()
-		{
-			target_cells_.setLeafSize(resolution_, resolution_, resolution_);
-			target_cells_.setInputCloud(target_);
-			// Initiate voxel structure.
-			target_cells_.filter(true);
-		}
+  /** \brief Compute individual point contributions to derivatives of probability function w.r.t. the transformation vector.
+   * \note Equation 6.10, 6.12 and 6.13 [Magnusson 2009].
+   * \param[in,out] score_gradient the gradient vector of the probability function w.r.t. the transformation vector
+   * \param[in,out] hessian the hessian matrix of the probability function w.r.t. the transformation vector
+   * \param[in] x_trans transformed point minus mean of occupied covariance voxel
+   * \param[in] c_inv covariance of occupied covariance voxel
+   * \param[in] compute_hessian flag to calculate hessian, unnecessary for step calculation.
+   */
+  double updateDerivatives(Eigen::Matrix<double, 6, 1> &score_gradient, Eigen::Matrix<double, 6, 6> &hessian, const Eigen::Matrix<float, 4, 6> &point_gradient_, const Eigen::Matrix<float, 24, 6> &point_hessian_, const Eigen::Vector3d &x_trans, const Eigen::Matrix3d &c_inv, bool compute_hessian = true) const;
 
-		/** \brief Compute derivatives of probability function w.r.t. the transformation vector.
-		  * \note Equation 6.10, 6.12 and 6.13 [Magnusson 2009].
-		  * \param[out] score_gradient the gradient vector of the probability function w.r.t. the transformation vector
-		  * \param[out] hessian the hessian matrix of the probability function w.r.t. the transformation vector
-		  * \param[in] trans_cloud transformed point cloud
-		  * \param[in] p the current transform vector
-		  * \param[in] compute_hessian flag to calculate hessian, unnecessary for step calculation.
-		  */
-		double
-			computeDerivatives(Eigen::Matrix<double, 6, 1> &score_gradient,
-				Eigen::Matrix<double, 6, 6> &hessian,
-				PointCloudSource &trans_cloud,
-				Eigen::Matrix<double, 6, 1> &p,
-				bool compute_hessian = true);
+  /** \brief Precompute angular components of derivatives.
+   * \note Equation 6.19 and 6.21 [Magnusson 2009].
+   * \param[in] p the current transform vector
+   * \param[in] compute_hessian flag to calculate hessian, unnecessary for step calculation.
+   */
+  void computeAngleDerivatives(Eigen::Matrix<double, 6, 1> &p, bool compute_hessian = true);
 
-		/** \brief Compute individual point contributions to derivatives of probability function w.r.t. the transformation vector.
-		  * \note Equation 6.10, 6.12 and 6.13 [Magnusson 2009].
-		  * \param[in,out] score_gradient the gradient vector of the probability function w.r.t. the transformation vector
-		  * \param[in,out] hessian the hessian matrix of the probability function w.r.t. the transformation vector
-		  * \param[in] x_trans transformed point minus mean of occupied covariance voxel
-		  * \param[in] c_inv covariance of occupied covariance voxel
-		  * \param[in] compute_hessian flag to calculate hessian, unnecessary for step calculation.
-		  */
-		double
-			updateDerivatives(Eigen::Matrix<double, 6, 1> &score_gradient,
-				Eigen::Matrix<double, 6, 6> &hessian,
-				const Eigen::Matrix<float, 4, 6> &point_gradient_,
-				const Eigen::Matrix<float, 24, 6> &point_hessian_,
-				const Eigen::Vector3d &x_trans, const Eigen::Matrix3d &c_inv,
-				bool compute_hessian = true) const;
+  /** \brief Compute point derivatives.
+   * \note Equation 6.18-21 [Magnusson 2009].
+   * \param[in] x point from the input cloud
+   * \param[in] compute_hessian flag to calculate hessian, unnecessary for step calculation.
+   */
+  void computePointDerivatives(Eigen::Vector3d &x, Eigen::Matrix<double, 3, 6> &point_gradient_, Eigen::Matrix<double, 18, 6> &point_hessian_, bool compute_hessian = true) const;
 
-		/** \brief Precompute angular components of derivatives.
-		  * \note Equation 6.19 and 6.21 [Magnusson 2009].
-		  * \param[in] p the current transform vector
-		  * \param[in] compute_hessian flag to calculate hessian, unnecessary for step calculation.
-		  */
-		void
-			computeAngleDerivatives(Eigen::Matrix<double, 6, 1> &p, bool compute_hessian = true);
+  void computePointDerivatives(Eigen::Vector3d &x, Eigen::Matrix<float, 4, 6> &point_gradient_, Eigen::Matrix<float, 24, 6> &point_hessian_, bool compute_hessian = true) const;
 
-		/** \brief Compute point derivatives.
-		  * \note Equation 6.18-21 [Magnusson 2009].
-		  * \param[in] x point from the input cloud
-		  * \param[in] compute_hessian flag to calculate hessian, unnecessary for step calculation.
-		  */
-		void
-			computePointDerivatives(Eigen::Vector3d &x, Eigen::Matrix<double, 3, 6>& point_gradient_, Eigen::Matrix<double, 18, 6>& point_hessian_, bool compute_hessian = true) const;
+  /** \brief Compute hessian of probability function w.r.t. the transformation vector.
+   * \note Equation 6.13 [Magnusson 2009].
+   * \param[out] hessian the hessian matrix of the probability function w.r.t. the transformation vector
+   * \param[in] trans_cloud transformed point cloud
+   * \param[in] p the current transform vector
+   */
+  void computeHessian(Eigen::Matrix<double, 6, 6> &hessian, PointCloudSource &trans_cloud, Eigen::Matrix<double, 6, 1> &p);
 
-		void
-			computePointDerivatives(Eigen::Vector3d &x, Eigen::Matrix<float, 4, 6>& point_gradient_, Eigen::Matrix<float, 24, 6>& point_hessian_, bool compute_hessian = true) const;
+  /** \brief Compute individual point contributions to hessian of probability function w.r.t. the transformation vector.
+   * \note Equation 6.13 [Magnusson 2009].
+   * \param[in,out] hessian the hessian matrix of the probability function w.r.t. the transformation vector
+   * \param[in] x_trans transformed point minus mean of occupied covariance voxel
+   * \param[in] c_inv covariance of occupied covariance voxel
+   */
+  void updateHessian(Eigen::Matrix<double, 6, 6> &hessian, const Eigen::Matrix<double, 3, 6> &point_gradient_, const Eigen::Matrix<double, 18, 6> &point_hessian_, const Eigen::Vector3d &x_trans, const Eigen::Matrix3d &c_inv) const;
 
-		/** \brief Compute hessian of probability function w.r.t. the transformation vector.
-		  * \note Equation 6.13 [Magnusson 2009].
-		  * \param[out] hessian the hessian matrix of the probability function w.r.t. the transformation vector
-		  * \param[in] trans_cloud transformed point cloud
-		  * \param[in] p the current transform vector
-		  */
-		void
-			computeHessian(Eigen::Matrix<double, 6, 6> &hessian,
-				PointCloudSource &trans_cloud,
-				Eigen::Matrix<double, 6, 1> &p);
+  /** \brief Compute line search step length and update transform and probability derivatives using More-Thuente method.
+   * \note Search Algorithm [More, Thuente 1994]
+   * \param[in] x initial transformation vector, \f$ x \f$ in Equation 1.3 (Moore, Thuente 1994) and \f$ \vec{p} \f$ in Algorithm 2 [Magnusson 2009]
+   * \param[in] step_dir descent direction, \f$ p \f$ in Equation 1.3 (Moore, Thuente 1994) and \f$ \delta \vec{p} \f$ normalized in Algorithm 2 [Magnusson 2009]
+   * \param[in] step_init initial step length estimate, \f$ \alpha_0 \f$ in Moore-Thuente (1994) and the normal of \f$ \delta \vec{p} \f$ in Algorithm 2 [Magnusson 2009]
+   * \param[in] step_max maximum step length, \f$ \alpha_max \f$ in Moore-Thuente (1994)
+   * \param[in] step_min minimum step length, \f$ \alpha_min \f$ in Moore-Thuente (1994)
+   * \param[out] score final score function value, \f$ f(x + \alpha p) \f$ in Equation 1.3 (Moore, Thuente 1994) and \f$ score \f$ in Algorithm 2 [Magnusson 2009]
+   * \param[in,out] score_gradient gradient of score function w.r.t. transformation vector, \f$ f'(x + \alpha p) \f$ in Moore-Thuente (1994) and \f$ \vec{g} \f$ in Algorithm 2 [Magnusson 2009]
+   * \param[out] hessian hessian of score function w.r.t. transformation vector, \f$ f''(x + \alpha p) \f$ in Moore-Thuente (1994) and \f$ H \f$ in Algorithm 2 [Magnusson 2009]
+   * \param[in,out] trans_cloud transformed point cloud, \f$ X \f$ transformed by \f$ T(\vec{p},\vec{x}) \f$ in Algorithm 2 [Magnusson 2009]
+   * \return final step length
+   */
+  double computeStepLengthMT(const Eigen::Matrix<double, 6, 1> &x, Eigen::Matrix<double, 6, 1> &step_dir, double step_init, double step_max, double step_min, double &score, Eigen::Matrix<double, 6, 1> &score_gradient, Eigen::Matrix<double, 6, 6> &hessian, PointCloudSource &trans_cloud);
 
-		/** \brief Compute individual point contributions to hessian of probability function w.r.t. the transformation vector.
-		  * \note Equation 6.13 [Magnusson 2009].
-		  * \param[in,out] hessian the hessian matrix of the probability function w.r.t. the transformation vector
-		  * \param[in] x_trans transformed point minus mean of occupied covariance voxel
-		  * \param[in] c_inv covariance of occupied covariance voxel
-		  */
-		void
-			updateHessian(Eigen::Matrix<double, 6, 6> &hessian,
-				const Eigen::Matrix<double, 3, 6> &point_gradient_,
-				const Eigen::Matrix<double, 18, 6> &point_hessian_,
-				const Eigen::Vector3d &x_trans, const Eigen::Matrix3d &c_inv) const;
+  /** \brief Update interval of possible step lengths for More-Thuente method, \f$ I \f$ in More-Thuente (1994)
+   * \note Updating Algorithm until some value satisfies \f$ \psi(\alpha_k) \leq 0 \f$ and \f$ \phi'(\alpha_k) \geq 0 \f$
+   * and Modified Updating Algorithm from then on [More, Thuente 1994].
+   * \param[in,out] a_l first endpoint of interval \f$ I \f$, \f$ \alpha_l \f$ in Moore-Thuente (1994)
+   * \param[in,out] f_l value at first endpoint, \f$ f_l \f$ in Moore-Thuente (1994), \f$ \psi(\alpha_l) \f$ for Update Algorithm and \f$ \phi(\alpha_l) \f$ for Modified Update Algorithm
+   * \param[in,out] g_l derivative at first endpoint, \f$ g_l \f$ in Moore-Thuente (1994), \f$ \psi'(\alpha_l) \f$ for Update Algorithm and \f$ \phi'(\alpha_l) \f$ for Modified Update Algorithm
+   * \param[in,out] a_u second endpoint of interval \f$ I \f$, \f$ \alpha_u \f$ in Moore-Thuente (1994)
+   * \param[in,out] f_u value at second endpoint, \f$ f_u \f$ in Moore-Thuente (1994), \f$ \psi(\alpha_u) \f$ for Update Algorithm and \f$ \phi(\alpha_u) \f$ for Modified Update Algorithm
+   * \param[in,out] g_u derivative at second endpoint, \f$ g_u \f$ in Moore-Thuente (1994), \f$ \psi'(\alpha_u) \f$ for Update Algorithm and \f$ \phi'(\alpha_u) \f$ for Modified Update Algorithm
+   * \param[in] a_t trial value, \f$ \alpha_t \f$ in Moore-Thuente (1994)
+   * \param[in] f_t value at trial value, \f$ f_t \f$ in Moore-Thuente (1994), \f$ \psi(\alpha_t) \f$ for Update Algorithm and \f$ \phi(\alpha_t) \f$ for Modified Update Algorithm
+   * \param[in] g_t derivative at trial value, \f$ g_t \f$ in Moore-Thuente (1994), \f$ \psi'(\alpha_t) \f$ for Update Algorithm and \f$ \phi'(\alpha_t) \f$ for Modified Update Algorithm
+   * \return if interval converges
+   */
+  bool updateIntervalMT(double &a_l, double &f_l, double &g_l, double &a_u, double &f_u, double &g_u, double a_t, double f_t, double g_t);
 
-		/** \brief Compute line search step length and update transform and probability derivatives using More-Thuente method.
-		  * \note Search Algorithm [More, Thuente 1994]
-		  * \param[in] x initial transformation vector, \f$ x \f$ in Equation 1.3 (Moore, Thuente 1994) and \f$ \vec{p} \f$ in Algorithm 2 [Magnusson 2009]
-		  * \param[in] step_dir descent direction, \f$ p \f$ in Equation 1.3 (Moore, Thuente 1994) and \f$ \delta \vec{p} \f$ normalized in Algorithm 2 [Magnusson 2009]
-		  * \param[in] step_init initial step length estimate, \f$ \alpha_0 \f$ in Moore-Thuente (1994) and the normal of \f$ \delta \vec{p} \f$ in Algorithm 2 [Magnusson 2009]
-		  * \param[in] step_max maximum step length, \f$ \alpha_max \f$ in Moore-Thuente (1994)
-		  * \param[in] step_min minimum step length, \f$ \alpha_min \f$ in Moore-Thuente (1994)
-		  * \param[out] score final score function value, \f$ f(x + \alpha p) \f$ in Equation 1.3 (Moore, Thuente 1994) and \f$ score \f$ in Algorithm 2 [Magnusson 2009]
-		  * \param[in,out] score_gradient gradient of score function w.r.t. transformation vector, \f$ f'(x + \alpha p) \f$ in Moore-Thuente (1994) and \f$ \vec{g} \f$ in Algorithm 2 [Magnusson 2009]
-		  * \param[out] hessian hessian of score function w.r.t. transformation vector, \f$ f''(x + \alpha p) \f$ in Moore-Thuente (1994) and \f$ H \f$ in Algorithm 2 [Magnusson 2009]
-		  * \param[in,out] trans_cloud transformed point cloud, \f$ X \f$ transformed by \f$ T(\vec{p},\vec{x}) \f$ in Algorithm 2 [Magnusson 2009]
-		  * \return final step length
-		  */
-		double
-			computeStepLengthMT(const Eigen::Matrix<double, 6, 1> &x,
-				Eigen::Matrix<double, 6, 1> &step_dir,
-				double step_init,
-				double step_max, double step_min,
-				double &score,
-				Eigen::Matrix<double, 6, 1> &score_gradient,
-				Eigen::Matrix<double, 6, 6> &hessian,
-				PointCloudSource &trans_cloud);
+  /** \brief Select new trial value for More-Thuente method.
+   * \note Trial Value Selection [More, Thuente 1994], \f$ \psi(\alpha_k) \f$ is used for \f$ f_k \f$ and \f$ g_k \f$
+   * until some value satisfies the test \f$ \psi(\alpha_k) \leq 0 \f$ and \f$ \phi'(\alpha_k) \geq 0 \f$
+   * then \f$ \phi(\alpha_k) \f$ is used from then on.
+   * \note Interpolation Minimizer equations from Optimization Theory and Methods: Nonlinear Programming By Wenyu Sun, Ya-xiang Yuan (89-100).
+   * \param[in] a_l first endpoint of interval \f$ I \f$, \f$ \alpha_l \f$ in Moore-Thuente (1994)
+   * \param[in] f_l value at first endpoint, \f$ f_l \f$ in Moore-Thuente (1994)
+   * \param[in] g_l derivative at first endpoint, \f$ g_l \f$ in Moore-Thuente (1994)
+   * \param[in] a_u second endpoint of interval \f$ I \f$, \f$ \alpha_u \f$ in Moore-Thuente (1994)
+   * \param[in] f_u value at second endpoint, \f$ f_u \f$ in Moore-Thuente (1994)
+   * \param[in] g_u derivative at second endpoint, \f$ g_u \f$ in Moore-Thuente (1994)
+   * \param[in] a_t previous trial value, \f$ \alpha_t \f$ in Moore-Thuente (1994)
+   * \param[in] f_t value at previous trial value, \f$ f_t \f$ in Moore-Thuente (1994)
+   * \param[in] g_t derivative at previous trial value, \f$ g_t \f$ in Moore-Thuente (1994)
+   * \return new trial value
+   */
+  double trialValueSelectionMT(double a_l, double f_l, double g_l, double a_u, double f_u, double g_u, double a_t, double f_t, double g_t);
 
-		/** \brief Update interval of possible step lengths for More-Thuente method, \f$ I \f$ in More-Thuente (1994)
-		  * \note Updating Algorithm until some value satisfies \f$ \psi(\alpha_k) \leq 0 \f$ and \f$ \phi'(\alpha_k) \geq 0 \f$
-		  * and Modified Updating Algorithm from then on [More, Thuente 1994].
-		  * \param[in,out] a_l first endpoint of interval \f$ I \f$, \f$ \alpha_l \f$ in Moore-Thuente (1994)
-		  * \param[in,out] f_l value at first endpoint, \f$ f_l \f$ in Moore-Thuente (1994), \f$ \psi(\alpha_l) \f$ for Update Algorithm and \f$ \phi(\alpha_l) \f$ for Modified Update Algorithm
-		  * \param[in,out] g_l derivative at first endpoint, \f$ g_l \f$ in Moore-Thuente (1994), \f$ \psi'(\alpha_l) \f$ for Update Algorithm and \f$ \phi'(\alpha_l) \f$ for Modified Update Algorithm
-		  * \param[in,out] a_u second endpoint of interval \f$ I \f$, \f$ \alpha_u \f$ in Moore-Thuente (1994)
-		  * \param[in,out] f_u value at second endpoint, \f$ f_u \f$ in Moore-Thuente (1994), \f$ \psi(\alpha_u) \f$ for Update Algorithm and \f$ \phi(\alpha_u) \f$ for Modified Update Algorithm
-		  * \param[in,out] g_u derivative at second endpoint, \f$ g_u \f$ in Moore-Thuente (1994), \f$ \psi'(\alpha_u) \f$ for Update Algorithm and \f$ \phi'(\alpha_u) \f$ for Modified Update Algorithm
-		  * \param[in] a_t trial value, \f$ \alpha_t \f$ in Moore-Thuente (1994)
-		  * \param[in] f_t value at trial value, \f$ f_t \f$ in Moore-Thuente (1994), \f$ \psi(\alpha_t) \f$ for Update Algorithm and \f$ \phi(\alpha_t) \f$ for Modified Update Algorithm
-		  * \param[in] g_t derivative at trial value, \f$ g_t \f$ in Moore-Thuente (1994), \f$ \psi'(\alpha_t) \f$ for Update Algorithm and \f$ \phi'(\alpha_t) \f$ for Modified Update Algorithm
-		  * \return if interval converges
-		  */
-		bool
-			updateIntervalMT(double &a_l, double &f_l, double &g_l,
-				double &a_u, double &f_u, double &g_u,
-				double a_t, double f_t, double g_t);
+  /** \brief Auxiliary function used to determine endpoints of More-Thuente interval.
+   * \note \f$ \psi(\alpha) \f$ in Equation 1.6 (Moore, Thuente 1994)
+   * \param[in] a the step length, \f$ \alpha \f$ in More-Thuente (1994)
+   * \param[in] f_a function value at step length a, \f$ \phi(\alpha) \f$ in More-Thuente (1994)
+   * \param[in] f_0 initial function value, \f$ \phi(0) \f$ in Moore-Thuente (1994)
+   * \param[in] g_0 initial function gradiant, \f$ \phi'(0) \f$ in More-Thuente (1994)
+   * \param[in] mu the step length, constant \f$ \mu \f$ in Equation 1.1 [More, Thuente 1994]
+   * \return sufficient decrease value
+   */
+  inline double auxiliaryFunction_PsiMT(double a, double f_a, double f_0, double g_0, double mu = 1.e-4) {
+    return (f_a - f_0 - mu * g_0 * a);
+  }
 
-		/** \brief Select new trial value for More-Thuente method.
-		  * \note Trial Value Selection [More, Thuente 1994], \f$ \psi(\alpha_k) \f$ is used for \f$ f_k \f$ and \f$ g_k \f$
-		  * until some value satisfies the test \f$ \psi(\alpha_k) \leq 0 \f$ and \f$ \phi'(\alpha_k) \geq 0 \f$
-		  * then \f$ \phi(\alpha_k) \f$ is used from then on.
-		  * \note Interpolation Minimizer equations from Optimization Theory and Methods: Nonlinear Programming By Wenyu Sun, Ya-xiang Yuan (89-100).
-		  * \param[in] a_l first endpoint of interval \f$ I \f$, \f$ \alpha_l \f$ in Moore-Thuente (1994)
-		  * \param[in] f_l value at first endpoint, \f$ f_l \f$ in Moore-Thuente (1994)
-		  * \param[in] g_l derivative at first endpoint, \f$ g_l \f$ in Moore-Thuente (1994)
-		  * \param[in] a_u second endpoint of interval \f$ I \f$, \f$ \alpha_u \f$ in Moore-Thuente (1994)
-		  * \param[in] f_u value at second endpoint, \f$ f_u \f$ in Moore-Thuente (1994)
-		  * \param[in] g_u derivative at second endpoint, \f$ g_u \f$ in Moore-Thuente (1994)
-		  * \param[in] a_t previous trial value, \f$ \alpha_t \f$ in Moore-Thuente (1994)
-		  * \param[in] f_t value at previous trial value, \f$ f_t \f$ in Moore-Thuente (1994)
-		  * \param[in] g_t derivative at previous trial value, \f$ g_t \f$ in Moore-Thuente (1994)
-		  * \return new trial value
-		  */
-		double
-			trialValueSelectionMT(double a_l, double f_l, double g_l,
-				double a_u, double f_u, double g_u,
-				double a_t, double f_t, double g_t);
+  /** \brief Auxiliary function derivative used to determine endpoints of More-Thuente interval.
+   * \note \f$ \psi'(\alpha) \f$, derivative of Equation 1.6 (Moore, Thuente 1994)
+   * \param[in] g_a function gradient at step length a, \f$ \phi'(\alpha) \f$ in More-Thuente (1994)
+   * \param[in] g_0 initial function gradiant, \f$ \phi'(0) \f$ in More-Thuente (1994)
+   * \param[in] mu the step length, constant \f$ \mu \f$ in Equation 1.1 [More, Thuente 1994]
+   * \return sufficient decrease derivative
+   */
+  inline double auxiliaryFunction_dPsiMT(double g_a, double g_0, double mu = 1.e-4) {
+    return (g_a - mu * g_0);
+  }
 
-		/** \brief Auxiliary function used to determine endpoints of More-Thuente interval.
-		  * \note \f$ \psi(\alpha) \f$ in Equation 1.6 (Moore, Thuente 1994)
-		  * \param[in] a the step length, \f$ \alpha \f$ in More-Thuente (1994)
-		  * \param[in] f_a function value at step length a, \f$ \phi(\alpha) \f$ in More-Thuente (1994)
-		  * \param[in] f_0 initial function value, \f$ \phi(0) \f$ in Moore-Thuente (1994)
-		  * \param[in] g_0 initial function gradiant, \f$ \phi'(0) \f$ in More-Thuente (1994)
-		  * \param[in] mu the step length, constant \f$ \mu \f$ in Equation 1.1 [More, Thuente 1994]
-		  * \return sufficient decrease value
-		  */
-		inline double
-			auxiliaryFunction_PsiMT(double a, double f_a, double f_0, double g_0, double mu = 1.e-4)
-		{
-			return (f_a - f_0 - mu * g_0 * a);
-		}
+  /** \brief The voxel grid generated from target cloud containing point means and covariances. */
+  TargetGrid target_cells_;
 
-		/** \brief Auxiliary function derivative used to determine endpoints of More-Thuente interval.
-		  * \note \f$ \psi'(\alpha) \f$, derivative of Equation 1.6 (Moore, Thuente 1994)
-		  * \param[in] g_a function gradient at step length a, \f$ \phi'(\alpha) \f$ in More-Thuente (1994)
-		  * \param[in] g_0 initial function gradiant, \f$ \phi'(0) \f$ in More-Thuente (1994)
-		  * \param[in] mu the step length, constant \f$ \mu \f$ in Equation 1.1 [More, Thuente 1994]
-		  * \return sufficient decrease derivative
-		  */
-		inline double
-			auxiliaryFunction_dPsiMT(double g_a, double g_0, double mu = 1.e-4)
-		{
-			return (g_a - mu * g_0);
-		}
+  // double fitness_epsilon_;
 
-		/** \brief The voxel grid generated from target cloud containing point means and covariances. */
-		TargetGrid target_cells_;
+  /** \brief The side length of voxels. */
+  float resolution_;
 
-		//double fitness_epsilon_;
+  /** \brief The maximum step length. */
+  double step_size_;
 
-		/** \brief The side length of voxels. */
-		float resolution_;
+  /** \brief The ratio of outliers of points w.r.t. a normal distribution, Equation 6.7 [Magnusson 2009]. */
+  double outlier_ratio_;
 
-		/** \brief The maximum step length. */
-		double step_size_;
+  /** \brief The normalization constants used fit the point distribution to a normal distribution, Equation 6.8 [Magnusson 2009]. */
+  double gauss_d1_, gauss_d2_, gauss_d3_;
 
-		/** \brief The ratio of outliers of points w.r.t. a normal distribution, Equation 6.7 [Magnusson 2009]. */
-		double outlier_ratio_;
+  /** \brief The probability score of the transform applied to the input cloud, Equation 6.9 and 6.10 [Magnusson 2009]. */
+  double trans_probability_;
 
-		/** \brief The normalization constants used fit the point distribution to a normal distribution, Equation 6.8 [Magnusson 2009]. */
-		double gauss_d1_, gauss_d2_, gauss_d3_;
+  /** \brief Precomputed Angular Gradient
+   *
+   * The precomputed angular derivatives for the jacobian of a transformation vector, Equation 6.19 [Magnusson 2009].
+   */
+  Eigen::Vector3d j_ang_a_, j_ang_b_, j_ang_c_, j_ang_d_, j_ang_e_, j_ang_f_, j_ang_g_, j_ang_h_;
 
-		/** \brief The probability score of the transform applied to the input cloud, Equation 6.9 and 6.10 [Magnusson 2009]. */
-		double trans_probability_;
+  Eigen::Matrix<float, 8, 4> j_ang;
 
-		/** \brief Precomputed Angular Gradient
-		  *
-		  * The precomputed angular derivatives for the jacobian of a transformation vector, Equation 6.19 [Magnusson 2009].
-		  */
-		Eigen::Vector3d j_ang_a_, j_ang_b_, j_ang_c_, j_ang_d_, j_ang_e_, j_ang_f_, j_ang_g_, j_ang_h_;
+  /** \brief Precomputed Angular Hessian
+   *
+   * The precomputed angular derivatives for the hessian of a transformation vector, Equation 6.19 [Magnusson 2009].
+   */
+  Eigen::Vector3d h_ang_a2_, h_ang_a3_, h_ang_b2_, h_ang_b3_, h_ang_c2_, h_ang_c3_, h_ang_d1_, h_ang_d2_, h_ang_d3_, h_ang_e1_, h_ang_e2_, h_ang_e3_, h_ang_f1_, h_ang_f2_, h_ang_f3_;
 
-		Eigen::Matrix<float, 8, 4> j_ang;
+  Eigen::Matrix<float, 16, 4> h_ang;
 
-		/** \brief Precomputed Angular Hessian
-		  *
-		  * The precomputed angular derivatives for the hessian of a transformation vector, Equation 6.19 [Magnusson 2009].
-		  */
-		Eigen::Vector3d h_ang_a2_, h_ang_a3_,
-			h_ang_b2_, h_ang_b3_,
-			h_ang_c2_, h_ang_c3_,
-			h_ang_d1_, h_ang_d2_, h_ang_d3_,
-			h_ang_e1_, h_ang_e2_, h_ang_e3_,
-			h_ang_f1_, h_ang_f2_, h_ang_f3_;
-
-		Eigen::Matrix<float, 16, 4> h_ang;
-
-		/** \brief The first order derivative of the transformation of a point w.r.t. the transform vector, \f$ J_E \f$ in Equation 6.18 [Magnusson 2009]. */
+  /** \brief The first order derivative of the transformation of a point w.r.t. the transform vector, \f$ J_E \f$ in Equation 6.18 [Magnusson 2009]. */
   //      Eigen::Matrix<double, 3, 6> point_gradient_;
 
-		/** \brief The second order derivative of the transformation of a point w.r.t. the transform vector, \f$ H_E \f$ in Equation 6.20 [Magnusson 2009]. */
+  /** \brief The second order derivative of the transformation of a point w.r.t. the transform vector, \f$ H_E \f$ in Equation 6.20 [Magnusson 2009]. */
   //      Eigen::Matrix<double, 18, 6> point_hessian_;
 
-    int num_threads_;
+  int num_threads_;
 
-	Eigen::Matrix<double, 6, 6> hessian_;
-	std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f>> transformation_array_;
-	double nearest_voxel_transformation_likelihood_;
+  Eigen::Matrix<double, 6, 6> hessian_;
+  std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f>> transformation_array_;
+  double nearest_voxel_transformation_likelihood_;
 
-	float regularization_scale_factor_;
-	boost::optional<Eigen::Matrix4f> regularization_pose_;
-	Eigen::Vector3f regularization_pose_translation_;
+  float regularization_scale_factor_;
+  boost::optional<Eigen::Matrix4f> regularization_pose_;
+  Eigen::Vector3f regularization_pose_translation_;
 
-	public:
-		NeighborSearchMethod search_method;
+public:
+  NeighborSearchMethod search_method;
 
-		EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-	};
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
 
-}
+}  // namespace pclomp
 
-#endif // PCL_REGISTRATION_NDT_H_
+#endif  // PCL_REGISTRATION_NDT_H_

--- a/include/pclomp/ndt_omp_impl.hpp
+++ b/include/pclomp/ndt_omp_impl.hpp
@@ -44,30 +44,18 @@
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template<typename PointSource, typename PointTarget>
-pclomp::NormalDistributionsTransform<PointSource, PointTarget>::NormalDistributionsTransform ()
-  : target_cells_ ()
-  , resolution_ (1.0f)
-  , step_size_ (0.1)
-  , outlier_ratio_ (0.55)
-  , gauss_d1_ ()
-  , gauss_d2_ ()
-  , gauss_d3_ ()
-  , trans_probability_ ()
-  , regularization_pose_ (boost::none)
-  , j_ang_a_ (), j_ang_b_ (), j_ang_c_ (), j_ang_d_ (), j_ang_e_ (), j_ang_f_ (), j_ang_g_ (), j_ang_h_ ()
-  , h_ang_a2_ (), h_ang_a3_ (), h_ang_b2_ (), h_ang_b3_ (), h_ang_c2_ (), h_ang_c3_ (), h_ang_d1_ (), h_ang_d2_ ()
-  , h_ang_d3_ (), h_ang_e1_ (), h_ang_e2_ (), h_ang_e3_ (), h_ang_f1_ (), h_ang_f2_ (), h_ang_f3_ ()
-{
+pclomp::NormalDistributionsTransform<PointSource, PointTarget>::NormalDistributionsTransform()
+    : target_cells_(), resolution_(1.0f), step_size_(0.1), outlier_ratio_(0.55), gauss_d1_(), gauss_d2_(), gauss_d3_(), trans_probability_(), regularization_pose_(boost::none), j_ang_a_(), j_ang_b_(), j_ang_c_(), j_ang_d_(), j_ang_e_(), j_ang_f_(), j_ang_g_(), j_ang_h_(), h_ang_a2_(), h_ang_a3_(), h_ang_b2_(), h_ang_b3_(), h_ang_c2_(), h_ang_c3_(), h_ang_d1_(), h_ang_d2_(), h_ang_d3_(), h_ang_e1_(), h_ang_e2_(), h_ang_e3_(), h_ang_f1_(), h_ang_f2_(), h_ang_f3_() {
   reg_name_ = "NormalDistributionsTransform";
 
   double gauss_c1, gauss_c2;
 
   // Initializes the gaussian fitting parameters (eq. 6.8) [Magnusson 2009]
   gauss_c1 = 10.0 * (1 - outlier_ratio_);
-  gauss_c2 = outlier_ratio_ / pow (resolution_, 3);
-  gauss_d3_ = -log (gauss_c2);
-  gauss_d1_ = -log ( gauss_c1 + gauss_c2 ) - gauss_d3_;
-  gauss_d2_ = -2 * log ((-log ( gauss_c1 * exp ( -0.5 ) + gauss_c2 ) - gauss_d3_) / gauss_d1_);
+  gauss_c2 = outlier_ratio_ / pow(resolution_, 3);
+  gauss_d3_ = -log(gauss_c2);
+  gauss_d1_ = -log(gauss_c1 + gauss_c2) - gauss_d3_;
+  gauss_d2_ = -2 * log((-log(gauss_c1 * exp(-0.5) + gauss_c2) - gauss_d3_) / gauss_d1_);
 
   transformation_epsilon_ = 0.1;
   max_iterations_ = 35;
@@ -76,11 +64,9 @@ pclomp::NormalDistributionsTransform<PointSource, PointTarget>::NormalDistributi
   num_threads_ = omp_get_max_threads();
 }
 
-
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget> void
-pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeTransformation (PointCloudSource &output, const Eigen::Matrix4f &guess)
-{
+template<typename PointSource, typename PointTarget>
+void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeTransformation(PointCloudSource &output, const Eigen::Matrix4f &guess) {
   nr_iterations_ = 0;
   converged_ = false;
 
@@ -88,129 +74,114 @@ pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeTransform
 
   // Initializes the gaussian fitting parameters (eq. 6.8) [Magnusson 2009]
   gauss_c1 = 10 * (1 - outlier_ratio_);
-  gauss_c2 = outlier_ratio_ / pow (resolution_, 3);
-  gauss_d3_ = -log (gauss_c2);
-  gauss_d1_ = -log ( gauss_c1 + gauss_c2 ) - gauss_d3_;
-  gauss_d2_ = -2 * log ((-log ( gauss_c1 * exp ( -0.5 ) + gauss_c2 ) - gauss_d3_) / gauss_d1_);
+  gauss_c2 = outlier_ratio_ / pow(resolution_, 3);
+  gauss_d3_ = -log(gauss_c2);
+  gauss_d1_ = -log(gauss_c1 + gauss_c2) - gauss_d3_;
+  gauss_d2_ = -2 * log((-log(gauss_c1 * exp(-0.5) + gauss_c2) - gauss_d3_) / gauss_d1_);
 
-  if (guess != Eigen::Matrix4f::Identity ())
-  {
+  if(guess != Eigen::Matrix4f::Identity()) {
     // Initialise final transformation to the guessed one
     final_transformation_ = guess;
     // Apply guessed transformation prior to search for neighbours
-    transformPointCloud (output, output, guess);
+    transformPointCloud(output, output, guess);
   }
 
   Eigen::Transform<float, 3, Eigen::Affine, Eigen::ColMajor> eig_transformation;
-  eig_transformation.matrix () = final_transformation_;
+  eig_transformation.matrix() = final_transformation_;
   transformation_array_.clear();
   transformation_array_.push_back(final_transformation_);
 
   // Convert initial guess matrix to 6 element transformation vector
   Eigen::Matrix<double, 6, 1> p, delta_p, score_gradient;
-  Eigen::Vector3f init_translation = eig_transformation.translation ();
-  Eigen::Vector3f init_rotation = eig_transformation.rotation ().eulerAngles (0, 1, 2);
-  p << init_translation (0), init_translation (1), init_translation (2),
-  init_rotation (0), init_rotation (1), init_rotation (2);
+  Eigen::Vector3f init_translation = eig_transformation.translation();
+  Eigen::Vector3f init_rotation = eig_transformation.rotation().eulerAngles(0, 1, 2);
+  p << init_translation(0), init_translation(1), init_translation(2), init_rotation(0), init_rotation(1), init_rotation(2);
 
   Eigen::Matrix<double, 6, 6> hessian;
 
   double score = 0;
   double delta_p_norm;
 
-  if (regularization_pose_)
-  {
+  if(regularization_pose_) {
     Eigen::Transform<float, 3, Eigen::Affine, Eigen::ColMajor> regularization_pose_transformation;
     regularization_pose_transformation.matrix() = regularization_pose_.get();
     regularization_pose_translation_ = regularization_pose_transformation.translation();
   }
 
   // Calculate derivatives of initial transform vector, subsequent derivative calculations are done in the step length determination.
-  score = computeDerivatives (score_gradient, hessian, output, p);
+  score = computeDerivatives(score_gradient, hessian, output, p);
 
-  while (!converged_)
-  {
+  while(!converged_) {
     // Store previous transformation
     previous_transformation_ = transformation_;
 
     // Solve for decent direction using newton method, line 23 in Algorithm 2 [Magnusson 2009]
-    Eigen::JacobiSVD<Eigen::Matrix<double, 6, 6> > sv (hessian, Eigen::ComputeFullU | Eigen::ComputeFullV);
+    Eigen::JacobiSVD<Eigen::Matrix<double, 6, 6>> sv(hessian, Eigen::ComputeFullU | Eigen::ComputeFullV);
     // Negative for maximization as opposed to minimization
-    delta_p = sv.solve (-score_gradient);
+    delta_p = sv.solve(-score_gradient);
 
-    //Calculate step length with guaranteed sufficient decrease [More, Thuente 1994]
-    delta_p_norm = delta_p.norm ();
+    // Calculate step length with guaranteed sufficient decrease [More, Thuente 1994]
+    delta_p_norm = delta_p.norm();
 
-    if (delta_p_norm == 0 || delta_p_norm != delta_p_norm)
-    {
-      if (input_->points.empty()) {
+    if(delta_p_norm == 0 || delta_p_norm != delta_p_norm) {
+      if(input_->points.empty()) {
         trans_probability_ = 0.0f;
-      }
-      else {
-        trans_probability_ = score / static_cast<double> (input_->points.size ());
+      } else {
+        trans_probability_ = score / static_cast<double>(input_->points.size());
       }
 
       converged_ = delta_p_norm == delta_p_norm;
       return;
     }
 
-    delta_p.normalize ();
-    delta_p_norm = computeStepLengthMT (p, delta_p, delta_p_norm, step_size_, transformation_epsilon_ / 2, score, score_gradient, hessian, output);
+    delta_p.normalize();
+    delta_p_norm = computeStepLengthMT(p, delta_p, delta_p_norm, step_size_, transformation_epsilon_ / 2, score, score_gradient, hessian, output);
     delta_p *= delta_p_norm;
 
-
-    transformation_ = (Eigen::Translation<float, 3> (static_cast<float> (delta_p (0)), static_cast<float> (delta_p (1)), static_cast<float> (delta_p (2))) *
-                       Eigen::AngleAxis<float> (static_cast<float> (delta_p (3)), Eigen::Vector3f::UnitX ()) *
-                       Eigen::AngleAxis<float> (static_cast<float> (delta_p (4)), Eigen::Vector3f::UnitY ()) *
-                       Eigen::AngleAxis<float> (static_cast<float> (delta_p (5)), Eigen::Vector3f::UnitZ ())).matrix ();
+    transformation_ = (Eigen::Translation<float, 3>(static_cast<float>(delta_p(0)), static_cast<float>(delta_p(1)), static_cast<float>(delta_p(2))) * Eigen::AngleAxis<float>(static_cast<float>(delta_p(3)), Eigen::Vector3f::UnitX()) * Eigen::AngleAxis<float>(static_cast<float>(delta_p(4)), Eigen::Vector3f::UnitY()) * Eigen::AngleAxis<float>(static_cast<float>(delta_p(5)), Eigen::Vector3f::UnitZ()))
+                          .matrix();
 
     transformation_array_.push_back(final_transformation_);
 
     p = p + delta_p;
 
     // Update Visualizer (untested)
-    if (update_visualizer_ != 0)
-      update_visualizer_ (output, std::vector<int>(), *target_, std::vector<int>() );
+    if(update_visualizer_ != 0) update_visualizer_(output, std::vector<int>(), *target_, std::vector<int>());
 
-    if (nr_iterations_ > max_iterations_ ||
-        (nr_iterations_ && (std::fabs (delta_p_norm) < transformation_epsilon_)))
-    {
+    if(nr_iterations_ > max_iterations_ || (nr_iterations_ && (std::fabs(delta_p_norm) < transformation_epsilon_))) {
       converged_ = true;
     }
 
     nr_iterations_++;
-
   }
 
   // Store transformation probability. The relative differences within each scan registration are accurate
   // but the normalization constants need to be modified for it to be globally accurate
-  if (input_->points.empty()) {
+  if(input_->points.empty()) {
     trans_probability_ = 0.0f;
-  }
-  else {
-    trans_probability_ = score / static_cast<double> (input_->points.size ());
+  } else {
+    trans_probability_ = score / static_cast<double>(input_->points.size());
   }
 
   hessian_ = hessian;
 }
 
 #ifndef _OPENMP
-int omp_get_max_threads() { return 1; }
-int omp_get_thread_num() { return 0; }
+int omp_get_max_threads() {
+  return 1;
+}
+int omp_get_thread_num() {
+  return 0;
+}
 #endif
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget> double
-pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeDerivatives(Eigen::Matrix<double, 6, 1> &score_gradient,
-	Eigen::Matrix<double, 6, 6> &hessian,
-	PointCloudSource &trans_cloud,
-	Eigen::Matrix<double, 6, 1> &p,
-	bool compute_hessian)
-{
-	score_gradient.setZero();
-	hessian.setZero();
-	double score = 0;
-	int total_neighborhood_count = 0;
+template<typename PointSource, typename PointTarget>
+double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeDerivatives(Eigen::Matrix<double, 6, 1> &score_gradient, Eigen::Matrix<double, 6, 6> &hessian, PointCloudSource &trans_cloud, Eigen::Matrix<double, 6, 1> &p, bool compute_hessian) {
+  score_gradient.setZero();
+  hessian.setZero();
+  double score = 0;
+  int total_neighborhood_count = 0;
   double nearest_voxel_score = 0;
   size_t found_neigborhood_voxel_num = 0;
 
@@ -220,409 +191,380 @@ pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeDerivativ
   std::vector<Eigen::Matrix<double, 6, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 6, 1>>> score_gradients(input_->points.size());
   std::vector<Eigen::Matrix<double, 6, 6>, Eigen::aligned_allocator<Eigen::Matrix<double, 6, 6>>> hessians(input_->points.size());
   std::vector<int> neighborhood_counts(input_->points.size());
-  for (std::size_t i = 0; i < input_->points.size(); i++) {
-		scores[i] = 0;
+  for(std::size_t i = 0; i < input_->points.size(); i++) {
+    scores[i] = 0;
     nearest_voxel_scores[i] = 0;
     found_neigborhood_voxel_nums[i] = 0;
-		score_gradients[i].setZero();
-		hessians[i].setZero();
-		neighborhood_counts[i] = 0;
-	}
+    score_gradients[i].setZero();
+    hessians[i].setZero();
+    neighborhood_counts[i] = 0;
+  }
 
-	// Precompute Angular Derivatives (eq. 6.19 and 6.21)[Magnusson 2009]
-	computeAngleDerivatives(p);
+  // Precompute Angular Derivatives (eq. 6.19 and 6.21)[Magnusson 2009]
+  computeAngleDerivatives(p);
 
   std::vector<std::vector<TargetGridLeafConstPtr>> neighborhoods(num_threads_);
   std::vector<std::vector<float>> distancess(num_threads_);
 
-	// Update gradient and hessian for each point, line 17 in Algorithm 2 [Magnusson 2009]
+  // Update gradient and hessian for each point, line 17 in Algorithm 2 [Magnusson 2009]
 #pragma omp parallel for num_threads(num_threads_) schedule(guided, 8)
-	for (std::size_t idx = 0; idx < input_->points.size(); idx++)
-	{
-		int thread_n = omp_get_thread_num();
+  for(std::size_t idx = 0; idx < input_->points.size(); idx++) {
+    int thread_n = omp_get_thread_num();
 
-		// Original Point and Transformed Point
-		PointSource x_pt, x_trans_pt;
-		// Original Point and Transformed Point (for math)
-		Eigen::Vector3d x, x_trans;
-		// Occupied Voxel
-		TargetGridLeafConstPtr cell;
-		// Inverse Covariance of Occupied Voxel
-		Eigen::Matrix3d c_inv;
+    // Original Point and Transformed Point
+    PointSource x_pt, x_trans_pt;
+    // Original Point and Transformed Point (for math)
+    Eigen::Vector3d x, x_trans;
+    // Occupied Voxel
+    TargetGridLeafConstPtr cell;
+    // Inverse Covariance of Occupied Voxel
+    Eigen::Matrix3d c_inv;
 
-		// Initialize Point Gradient and Hessian
-		Eigen::Matrix<float, 4, 6> point_gradient_;
-		Eigen::Matrix<float, 24, 6> point_hessian_;
-		point_gradient_.setZero();
-		point_gradient_.block<3, 3>(0, 0).setIdentity();
-		point_hessian_.setZero();
+    // Initialize Point Gradient and Hessian
+    Eigen::Matrix<float, 4, 6> point_gradient_;
+    Eigen::Matrix<float, 24, 6> point_hessian_;
+    point_gradient_.setZero();
+    point_gradient_.block<3, 3>(0, 0).setIdentity();
+    point_hessian_.setZero();
 
-		x_trans_pt = trans_cloud.points[idx];
+    x_trans_pt = trans_cloud.points[idx];
 
-		auto& neighborhood = neighborhoods[thread_n];
-		auto& distances = distancess[thread_n];
+    auto &neighborhood = neighborhoods[thread_n];
+    auto &distances = distancess[thread_n];
 
-		// Find neighbors (Radius search has been experimentally faster than direct neighbor checking.
-		switch (search_method) {
-		case KDTREE:
-			target_cells_.radiusSearch(x_trans_pt, resolution_, neighborhood, distances);
-			break;
-		case DIRECT26:
-			target_cells_.getNeighborhoodAtPoint(x_trans_pt, neighborhood);
-			break;
-		default:
-		case DIRECT7:
-			target_cells_.getNeighborhoodAtPoint7(x_trans_pt, neighborhood);
-			break;
-		case DIRECT1:
-			target_cells_.getNeighborhoodAtPoint1(x_trans_pt, neighborhood);
-			break;
-		}
+    // Find neighbors (Radius search has been experimentally faster than direct neighbor checking.
+    switch(search_method) {
+      case KDTREE:
+        target_cells_.radiusSearch(x_trans_pt, resolution_, neighborhood, distances);
+        break;
+      case DIRECT26:
+        target_cells_.getNeighborhoodAtPoint(x_trans_pt, neighborhood);
+        break;
+      default:
+      case DIRECT7:
+        target_cells_.getNeighborhoodAtPoint7(x_trans_pt, neighborhood);
+        break;
+      case DIRECT1:
+        target_cells_.getNeighborhoodAtPoint1(x_trans_pt, neighborhood);
+        break;
+    }
 
-		double sum_score_pt = 0;
+    double sum_score_pt = 0;
     double nearest_voxel_score_pt = 0;
-		Eigen::Matrix<double, 6, 1> score_gradient_pt = Eigen::Matrix<double, 6, 1>::Zero();
-		Eigen::Matrix<double, 6, 6> hessian_pt = Eigen::Matrix<double, 6, 6>::Zero();
-		int neighborhood_count = 0;
+    Eigen::Matrix<double, 6, 1> score_gradient_pt = Eigen::Matrix<double, 6, 1>::Zero();
+    Eigen::Matrix<double, 6, 6> hessian_pt = Eigen::Matrix<double, 6, 6>::Zero();
+    int neighborhood_count = 0;
 
-		for (typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it = neighborhood.begin(); neighborhood_it != neighborhood.end(); neighborhood_it++)
-		{
-			cell = *neighborhood_it;
-			x_pt = input_->points[idx];
-			x = Eigen::Vector3d(x_pt.x, x_pt.y, x_pt.z);
+    for(typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it = neighborhood.begin(); neighborhood_it != neighborhood.end(); neighborhood_it++) {
+      cell = *neighborhood_it;
+      x_pt = input_->points[idx];
+      x = Eigen::Vector3d(x_pt.x, x_pt.y, x_pt.z);
 
-			x_trans = Eigen::Vector3d(x_trans_pt.x, x_trans_pt.y, x_trans_pt.z);
+      x_trans = Eigen::Vector3d(x_trans_pt.x, x_trans_pt.y, x_trans_pt.z);
 
-			// Denorm point, x_k' in Equations 6.12 and 6.13 [Magnusson 2009]
-			x_trans -= cell->getMean();
-			// Uses precomputed covariance for speed.
-			c_inv = cell->getInverseCov();
+      // Denorm point, x_k' in Equations 6.12 and 6.13 [Magnusson 2009]
+      x_trans -= cell->getMean();
+      // Uses precomputed covariance for speed.
+      c_inv = cell->getInverseCov();
 
-			// Compute derivative of transform function w.r.t. transform vector, J_E and H_E in Equations 6.18 and 6.20 [Magnusson 2009]
-			computePointDerivatives(x, point_gradient_, point_hessian_);
-			// Update score, gradient and hessian, lines 19-21 in Algorithm 2, according to Equations 6.10, 6.12 and 6.13, respectively [Magnusson 2009]
-			double score_pt = updateDerivatives(score_gradient_pt, hessian_pt, point_gradient_, point_hessian_, x_trans, c_inv, compute_hessian);
-			neighborhood_count++;
+      // Compute derivative of transform function w.r.t. transform vector, J_E and H_E in Equations 6.18 and 6.20 [Magnusson 2009]
+      computePointDerivatives(x, point_gradient_, point_hessian_);
+      // Update score, gradient and hessian, lines 19-21 in Algorithm 2, according to Equations 6.10, 6.12 and 6.13, respectively [Magnusson 2009]
+      double score_pt = updateDerivatives(score_gradient_pt, hessian_pt, point_gradient_, point_hessian_, x_trans, c_inv, compute_hessian);
+      neighborhood_count++;
       sum_score_pt += score_pt;
-      if (score_pt > nearest_voxel_score_pt) {
+      if(score_pt > nearest_voxel_score_pt) {
         nearest_voxel_score_pt = score_pt;
       }
-		}
+    }
 
     if(!neighborhood.empty()) {
       ++found_neigborhood_voxel_nums[idx];
     }
 
-		scores[idx] = sum_score_pt;
+    scores[idx] = sum_score_pt;
     nearest_voxel_scores[idx] = nearest_voxel_score_pt;
-		score_gradients[idx].noalias() = score_gradient_pt;
-		hessians[idx].noalias() = hessian_pt;
-		neighborhood_counts[idx] += neighborhood_count;
-	}
+    score_gradients[idx].noalias() = score_gradient_pt;
+    hessians[idx].noalias() = hessian_pt;
+    neighborhood_counts[idx] += neighborhood_count;
+  }
 
   // Ensure that the result is invariant against the summing up order
-  for (std::size_t i = 0; i < input_->points.size(); i++) {
-		score += scores[i];
+  for(std::size_t i = 0; i < input_->points.size(); i++) {
+    score += scores[i];
     nearest_voxel_score += nearest_voxel_scores[i];
     found_neigborhood_voxel_num += found_neigborhood_voxel_nums[i];
-		score_gradient += score_gradients[i];
-		hessian += hessians[i];
-		total_neighborhood_count += neighborhood_counts[i];
-	}
-
-	if (regularization_pose_) {
-		float regularization_score = 0.0f;
-		Eigen::Matrix<double, 6, 1> regularization_gradient = Eigen::Matrix<double, 6, 1>::Zero();
-		Eigen::Matrix<double, 6, 6> regularization_hessian = Eigen::Matrix<double, 6, 6>::Zero();
-
-		const float dx = regularization_pose_translation_(0) - static_cast<float>(p(0, 0));
-		const float dy = regularization_pose_translation_(1) - static_cast<float>(p(1, 0));
-		const auto sin_yaw = static_cast<float>(sin(p(5, 0)));
-		const auto cos_yaw = static_cast<float>(cos(p(5, 0)));
-		const float longitudinal_distance = dy * sin_yaw + dx * cos_yaw;
-		const auto neighborhood_count_weight = static_cast<float>(total_neighborhood_count);
-
-		regularization_score = - regularization_scale_factor_ * neighborhood_count_weight * longitudinal_distance * longitudinal_distance;
-
-		regularization_gradient(0, 0) = regularization_scale_factor_ * neighborhood_count_weight * 2.0f * cos_yaw * longitudinal_distance;
-		regularization_gradient(1, 0) = regularization_scale_factor_ * neighborhood_count_weight * 2.0f * sin_yaw * longitudinal_distance;
-
-		regularization_hessian(0, 0) = - regularization_scale_factor_ * neighborhood_count_weight * 2.0f * cos_yaw * cos_yaw;
-		regularization_hessian(0, 1) = - regularization_scale_factor_ * neighborhood_count_weight * 2.0f * cos_yaw * sin_yaw;
-		regularization_hessian(1, 1) = - regularization_scale_factor_ * neighborhood_count_weight * 2.0f * sin_yaw * sin_yaw;
-		regularization_hessian(1, 0) = regularization_hessian(0, 1);
-
-		score += regularization_score;
-		score_gradient += regularization_gradient;
-		hessian += regularization_hessian;
-	}
-
-  if (found_neigborhood_voxel_num != 0) {
-    nearest_voxel_transformation_likelihood_ = nearest_voxel_score / static_cast<double>(found_neigborhood_voxel_num);
+    score_gradient += score_gradients[i];
+    hessian += hessians[i];
+    total_neighborhood_count += neighborhood_counts[i];
   }
-  else {
+
+  if(regularization_pose_) {
+    float regularization_score = 0.0f;
+    Eigen::Matrix<double, 6, 1> regularization_gradient = Eigen::Matrix<double, 6, 1>::Zero();
+    Eigen::Matrix<double, 6, 6> regularization_hessian = Eigen::Matrix<double, 6, 6>::Zero();
+
+    const float dx = regularization_pose_translation_(0) - static_cast<float>(p(0, 0));
+    const float dy = regularization_pose_translation_(1) - static_cast<float>(p(1, 0));
+    const auto sin_yaw = static_cast<float>(sin(p(5, 0)));
+    const auto cos_yaw = static_cast<float>(cos(p(5, 0)));
+    const float longitudinal_distance = dy * sin_yaw + dx * cos_yaw;
+    const auto neighborhood_count_weight = static_cast<float>(total_neighborhood_count);
+
+    regularization_score = -regularization_scale_factor_ * neighborhood_count_weight * longitudinal_distance * longitudinal_distance;
+
+    regularization_gradient(0, 0) = regularization_scale_factor_ * neighborhood_count_weight * 2.0f * cos_yaw * longitudinal_distance;
+    regularization_gradient(1, 0) = regularization_scale_factor_ * neighborhood_count_weight * 2.0f * sin_yaw * longitudinal_distance;
+
+    regularization_hessian(0, 0) = -regularization_scale_factor_ * neighborhood_count_weight * 2.0f * cos_yaw * cos_yaw;
+    regularization_hessian(0, 1) = -regularization_scale_factor_ * neighborhood_count_weight * 2.0f * cos_yaw * sin_yaw;
+    regularization_hessian(1, 1) = -regularization_scale_factor_ * neighborhood_count_weight * 2.0f * sin_yaw * sin_yaw;
+    regularization_hessian(1, 0) = regularization_hessian(0, 1);
+
+    score += regularization_score;
+    score_gradient += regularization_gradient;
+    hessian += regularization_hessian;
+  }
+
+  if(found_neigborhood_voxel_num != 0) {
+    nearest_voxel_transformation_likelihood_ = nearest_voxel_score / static_cast<double>(found_neigborhood_voxel_num);
+  } else {
     nearest_voxel_transformation_likelihood_ = 0.0;
   }
 
-	return (score);
+  return (score);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget> void
-pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeAngleDerivatives(Eigen::Matrix<double, 6, 1> &p, bool compute_hessian)
-{
-	// Simplified math for near 0 angles
-	double cx, cy, cz, sx, sy, sz;
-	if (fabs(p(3)) < 10e-5)
-	{
-		//p(3) = 0;
-		cx = 1.0;
-		sx = 0.0;
-	}
-	else
-	{
-		cx = cos(p(3));
-		sx = sin(p(3));
-	}
-	if (fabs(p(4)) < 10e-5)
-	{
-		//p(4) = 0;
-		cy = 1.0;
-		sy = 0.0;
-	}
-	else
-	{
-		cy = cos(p(4));
-		sy = sin(p(4));
-	}
+template<typename PointSource, typename PointTarget>
+void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeAngleDerivatives(Eigen::Matrix<double, 6, 1> &p, bool compute_hessian) {
+  // Simplified math for near 0 angles
+  double cx, cy, cz, sx, sy, sz;
+  if(fabs(p(3)) < 10e-5) {
+    // p(3) = 0;
+    cx = 1.0;
+    sx = 0.0;
+  } else {
+    cx = cos(p(3));
+    sx = sin(p(3));
+  }
+  if(fabs(p(4)) < 10e-5) {
+    // p(4) = 0;
+    cy = 1.0;
+    sy = 0.0;
+  } else {
+    cy = cos(p(4));
+    sy = sin(p(4));
+  }
 
-	if (fabs(p(5)) < 10e-5)
-	{
-		//p(5) = 0;
-		cz = 1.0;
-		sz = 0.0;
-	}
-	else
-	{
-		cz = cos(p(5));
-		sz = sin(p(5));
-	}
+  if(fabs(p(5)) < 10e-5) {
+    // p(5) = 0;
+    cz = 1.0;
+    sz = 0.0;
+  } else {
+    cz = cos(p(5));
+    sz = sin(p(5));
+  }
 
-	// Precomputed angular gradiant components. Letters correspond to Equation 6.19 [Magnusson 2009]
-	j_ang_a_ << (-sx * sz + cx * sy * cz), (-sx * cz - cx * sy * sz), (-cx * cy);
-	j_ang_b_ << (cx * sz + sx * sy * cz), (cx * cz - sx * sy * sz), (-sx * cy);
-	j_ang_c_ << (-sy * cz), sy * sz, cy;
-	j_ang_d_ << sx * cy * cz, (-sx * cy * sz), sx * sy;
-	j_ang_e_ << (-cx * cy * cz), cx * cy * sz, (-cx * sy);
-	j_ang_f_ << (-cy * sz), (-cy * cz), 0;
-	j_ang_g_ << (cx * cz - sx * sy * sz), (-cx * sz - sx * sy * cz), 0;
-	j_ang_h_ << (sx * cz + cx * sy * sz), (cx * sy * cz - sx * sz), 0;
+  // Precomputed angular gradiant components. Letters correspond to Equation 6.19 [Magnusson 2009]
+  j_ang_a_ << (-sx * sz + cx * sy * cz), (-sx * cz - cx * sy * sz), (-cx * cy);
+  j_ang_b_ << (cx * sz + sx * sy * cz), (cx * cz - sx * sy * sz), (-sx * cy);
+  j_ang_c_ << (-sy * cz), sy * sz, cy;
+  j_ang_d_ << sx * cy * cz, (-sx * cy * sz), sx * sy;
+  j_ang_e_ << (-cx * cy * cz), cx * cy * sz, (-cx * sy);
+  j_ang_f_ << (-cy * sz), (-cy * cz), 0;
+  j_ang_g_ << (cx * cz - sx * sy * sz), (-cx * sz - sx * sy * cz), 0;
+  j_ang_h_ << (sx * cz + cx * sy * sz), (cx * sy * cz - sx * sz), 0;
 
-	j_ang.setZero();
-	j_ang.row(0).noalias() = Eigen::Vector4f((-sx * sz + cx * sy * cz), (-sx * cz - cx * sy * sz), (-cx * cy), 0.0f);
-	j_ang.row(1).noalias() = Eigen::Vector4f((cx * sz + sx * sy * cz), (cx * cz - sx * sy * sz), (-sx * cy), 0.0f);
-	j_ang.row(2).noalias() = Eigen::Vector4f((-sy * cz), sy * sz, cy, 0.0f);
-	j_ang.row(3).noalias() = Eigen::Vector4f(sx * cy * cz, (-sx * cy * sz), sx * sy, 0.0f);
-	j_ang.row(4).noalias() = Eigen::Vector4f((-cx * cy * cz), cx * cy * sz, (-cx * sy), 0.0f);
-	j_ang.row(5).noalias() = Eigen::Vector4f((-cy * sz), (-cy * cz), 0, 0.0f);
-	j_ang.row(6).noalias() = Eigen::Vector4f((cx * cz - sx * sy * sz), (-cx * sz - sx * sy * cz), 0, 0.0f);
-	j_ang.row(7).noalias() = Eigen::Vector4f((sx * cz + cx * sy * sz), (cx * sy * cz - sx * sz), 0, 0.0f);
+  j_ang.setZero();
+  j_ang.row(0).noalias() = Eigen::Vector4f((-sx * sz + cx * sy * cz), (-sx * cz - cx * sy * sz), (-cx * cy), 0.0f);
+  j_ang.row(1).noalias() = Eigen::Vector4f((cx * sz + sx * sy * cz), (cx * cz - sx * sy * sz), (-sx * cy), 0.0f);
+  j_ang.row(2).noalias() = Eigen::Vector4f((-sy * cz), sy * sz, cy, 0.0f);
+  j_ang.row(3).noalias() = Eigen::Vector4f(sx * cy * cz, (-sx * cy * sz), sx * sy, 0.0f);
+  j_ang.row(4).noalias() = Eigen::Vector4f((-cx * cy * cz), cx * cy * sz, (-cx * sy), 0.0f);
+  j_ang.row(5).noalias() = Eigen::Vector4f((-cy * sz), (-cy * cz), 0, 0.0f);
+  j_ang.row(6).noalias() = Eigen::Vector4f((cx * cz - sx * sy * sz), (-cx * sz - sx * sy * cz), 0, 0.0f);
+  j_ang.row(7).noalias() = Eigen::Vector4f((sx * cz + cx * sy * sz), (cx * sy * cz - sx * sz), 0, 0.0f);
 
-	if (compute_hessian)
-	{
-		// Precomputed angular hessian components. Letters correspond to Equation 6.21 and numbers correspond to row index [Magnusson 2009]
-		h_ang_a2_ << (-cx * sz - sx * sy * cz), (-cx * cz + sx * sy * sz), sx * cy;
-		h_ang_a3_ << (-sx * sz + cx * sy * cz), (-cx * sy * sz - sx * cz), (-cx * cy);
+  if(compute_hessian) {
+    // Precomputed angular hessian components. Letters correspond to Equation 6.21 and numbers correspond to row index [Magnusson 2009]
+    h_ang_a2_ << (-cx * sz - sx * sy * cz), (-cx * cz + sx * sy * sz), sx * cy;
+    h_ang_a3_ << (-sx * sz + cx * sy * cz), (-cx * sy * sz - sx * cz), (-cx * cy);
 
-		h_ang_b2_ << (cx * cy * cz), (-cx * cy * sz), (cx * sy);
-		h_ang_b3_ << (sx * cy * cz), (-sx * cy * sz), (sx * sy);
+    h_ang_b2_ << (cx * cy * cz), (-cx * cy * sz), (cx * sy);
+    h_ang_b3_ << (sx * cy * cz), (-sx * cy * sz), (sx * sy);
 
-		h_ang_c2_ << (-sx * cz - cx * sy * sz), (sx * sz - cx * sy * cz), 0;
-		h_ang_c3_ << (cx * cz - sx * sy * sz), (-sx * sy * cz - cx * sz), 0;
+    h_ang_c2_ << (-sx * cz - cx * sy * sz), (sx * sz - cx * sy * cz), 0;
+    h_ang_c3_ << (cx * cz - sx * sy * sz), (-sx * sy * cz - cx * sz), 0;
 
-		h_ang_d1_ << (-cy * cz), (cy * sz), (sy);
-		h_ang_d2_ << (-sx * sy * cz), (sx * sy * sz), (sx * cy);
-		h_ang_d3_ << (cx * sy * cz), (-cx * sy * sz), (-cx * cy);
+    h_ang_d1_ << (-cy * cz), (cy * sz), (sy);
+    h_ang_d2_ << (-sx * sy * cz), (sx * sy * sz), (sx * cy);
+    h_ang_d3_ << (cx * sy * cz), (-cx * sy * sz), (-cx * cy);
 
-		h_ang_e1_ << (sy * sz), (sy * cz), 0;
-		h_ang_e2_ << (-sx * cy * sz), (-sx * cy * cz), 0;
-		h_ang_e3_ << (cx * cy * sz), (cx * cy * cz), 0;
+    h_ang_e1_ << (sy * sz), (sy * cz), 0;
+    h_ang_e2_ << (-sx * cy * sz), (-sx * cy * cz), 0;
+    h_ang_e3_ << (cx * cy * sz), (cx * cy * cz), 0;
 
-		h_ang_f1_ << (-cy * cz), (cy * sz), 0;
-		h_ang_f2_ << (-cx * sz - sx * sy * cz), (-cx * cz + sx * sy * sz), 0;
-		h_ang_f3_ << (-sx * sz + cx * sy * cz), (-cx * sy * sz - sx * cz), 0;
+    h_ang_f1_ << (-cy * cz), (cy * sz), 0;
+    h_ang_f2_ << (-cx * sz - sx * sy * cz), (-cx * cz + sx * sy * sz), 0;
+    h_ang_f3_ << (-sx * sz + cx * sy * cz), (-cx * sy * sz - sx * cz), 0;
 
-		h_ang.setZero();
-		h_ang.row(0).noalias() = Eigen::Vector4f((-cx * sz - sx * sy * cz), (-cx * cz + sx * sy * sz), sx * cy, 0.0f);		// a2
-		h_ang.row(1).noalias() = Eigen::Vector4f((-sx * sz + cx * sy * cz), (-cx * sy * sz - sx * cz), (-cx * cy), 0.0f);	// a3
+    h_ang.setZero();
+    h_ang.row(0).noalias() = Eigen::Vector4f((-cx * sz - sx * sy * cz), (-cx * cz + sx * sy * sz), sx * cy, 0.0f);     // a2
+    h_ang.row(1).noalias() = Eigen::Vector4f((-sx * sz + cx * sy * cz), (-cx * sy * sz - sx * cz), (-cx * cy), 0.0f);  // a3
 
-		h_ang.row(2).noalias() = Eigen::Vector4f((cx * cy * cz), (-cx * cy * sz), (cx * sy), 0.0f);							// b2
-		h_ang.row(3).noalias() = Eigen::Vector4f((sx * cy * cz), (-sx * cy * sz), (sx * sy), 0.0f);							// b3
+    h_ang.row(2).noalias() = Eigen::Vector4f((cx * cy * cz), (-cx * cy * sz), (cx * sy), 0.0f);                        // b2
+    h_ang.row(3).noalias() = Eigen::Vector4f((sx * cy * cz), (-sx * cy * sz), (sx * sy), 0.0f);                        // b3
 
-		h_ang.row(4).noalias() = Eigen::Vector4f((-sx * cz - cx * sy * sz), (sx * sz - cx * sy * cz), 0, 0.0f);				// c2
-		h_ang.row(5).noalias() = Eigen::Vector4f((cx * cz - sx * sy * sz), (-sx * sy * cz - cx * sz), 0, 0.0f);				// c3
+    h_ang.row(4).noalias() = Eigen::Vector4f((-sx * cz - cx * sy * sz), (sx * sz - cx * sy * cz), 0, 0.0f);            // c2
+    h_ang.row(5).noalias() = Eigen::Vector4f((cx * cz - sx * sy * sz), (-sx * sy * cz - cx * sz), 0, 0.0f);            // c3
 
-		h_ang.row(6).noalias() = Eigen::Vector4f((-cy * cz), (cy * sz), (sy), 0.0f);										// d1
-		h_ang.row(7).noalias() = Eigen::Vector4f((-sx * sy * cz), (sx * sy * sz), (sx * cy), 0.0f);							// d2
-		h_ang.row(8).noalias() = Eigen::Vector4f((cx * sy * cz), (-cx * sy * sz), (-cx * cy), 0.0f);						// d3
+    h_ang.row(6).noalias() = Eigen::Vector4f((-cy * cz), (cy * sz), (sy), 0.0f);                                       // d1
+    h_ang.row(7).noalias() = Eigen::Vector4f((-sx * sy * cz), (sx * sy * sz), (sx * cy), 0.0f);                        // d2
+    h_ang.row(8).noalias() = Eigen::Vector4f((cx * sy * cz), (-cx * sy * sz), (-cx * cy), 0.0f);                       // d3
 
-		h_ang.row(9).noalias() = Eigen::Vector4f((sy * sz), (sy * cz), 0, 0.0f);											// e1
-		h_ang.row(10).noalias() = Eigen::Vector4f ((-sx * cy * sz), (-sx * cy * cz), 0, 0.0f);								// e2
-		h_ang.row(11).noalias() = Eigen::Vector4f ((cx * cy * sz), (cx * cy * cz), 0, 0.0f);								// e3
+    h_ang.row(9).noalias() = Eigen::Vector4f((sy * sz), (sy * cz), 0, 0.0f);                                           // e1
+    h_ang.row(10).noalias() = Eigen::Vector4f((-sx * cy * sz), (-sx * cy * cz), 0, 0.0f);                              // e2
+    h_ang.row(11).noalias() = Eigen::Vector4f((cx * cy * sz), (cx * cy * cz), 0, 0.0f);                                // e3
 
-		h_ang.row(12).noalias() = Eigen::Vector4f ((-cy * cz), (cy * sz), 0, 0.0f);											// f1
-		h_ang.row(13).noalias() = Eigen::Vector4f ((-cx * sz - sx * sy * cz), (-cx * cz + sx * sy * sz), 0, 0.0f);			// f2
-		h_ang.row(14).noalias() = Eigen::Vector4f ((-sx * sz + cx * sy * cz), (-cx * sy * sz - sx * cz), 0, 0.0f);			// f3
-	}
+    h_ang.row(12).noalias() = Eigen::Vector4f((-cy * cz), (cy * sz), 0, 0.0f);                                         // f1
+    h_ang.row(13).noalias() = Eigen::Vector4f((-cx * sz - sx * sy * cz), (-cx * cz + sx * sy * sz), 0, 0.0f);          // f2
+    h_ang.row(14).noalias() = Eigen::Vector4f((-sx * sz + cx * sy * cz), (-cx * sy * sz - sx * cz), 0, 0.0f);          // f3
+  }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget> void
-pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computePointDerivatives(Eigen::Vector3d &x, Eigen::Matrix<float, 4, 6>& point_gradient_, Eigen::Matrix<float, 24, 6>& point_hessian_, bool compute_hessian) const
-{
-	Eigen::Vector4f x4(x[0], x[1], x[2], 0.0f);
+template<typename PointSource, typename PointTarget>
+void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computePointDerivatives(Eigen::Vector3d &x, Eigen::Matrix<float, 4, 6> &point_gradient_, Eigen::Matrix<float, 24, 6> &point_hessian_, bool compute_hessian) const {
+  Eigen::Vector4f x4(x[0], x[1], x[2], 0.0f);
 
-	// Calculate first derivative of Transformation Equation 6.17 w.r.t. transform vector p.
-	// Derivative w.r.t. ith element of transform vector corresponds to column i, Equation 6.18 and 6.19 [Magnusson 2009]
-	Eigen::Matrix<float, 8, 1> x_j_ang = j_ang * x4;
+  // Calculate first derivative of Transformation Equation 6.17 w.r.t. transform vector p.
+  // Derivative w.r.t. ith element of transform vector corresponds to column i, Equation 6.18 and 6.19 [Magnusson 2009]
+  Eigen::Matrix<float, 8, 1> x_j_ang = j_ang * x4;
 
-	point_gradient_(1, 3) = x_j_ang[0];
-	point_gradient_(2, 3) = x_j_ang[1];
-	point_gradient_(0, 4) = x_j_ang[2];
-	point_gradient_(1, 4) = x_j_ang[3];
-	point_gradient_(2, 4) = x_j_ang[4];
-	point_gradient_(0, 5) = x_j_ang[5];
-	point_gradient_(1, 5) = x_j_ang[6];
-	point_gradient_(2, 5) = x_j_ang[7];
+  point_gradient_(1, 3) = x_j_ang[0];
+  point_gradient_(2, 3) = x_j_ang[1];
+  point_gradient_(0, 4) = x_j_ang[2];
+  point_gradient_(1, 4) = x_j_ang[3];
+  point_gradient_(2, 4) = x_j_ang[4];
+  point_gradient_(0, 5) = x_j_ang[5];
+  point_gradient_(1, 5) = x_j_ang[6];
+  point_gradient_(2, 5) = x_j_ang[7];
 
-	if (compute_hessian)
-	{
-		Eigen::Matrix<float, 16, 1> x_h_ang = h_ang * x4;
+  if(compute_hessian) {
+    Eigen::Matrix<float, 16, 1> x_h_ang = h_ang * x4;
 
-		// Vectors from Equation 6.21 [Magnusson 2009]
-		Eigen::Vector4f a (0, x_h_ang[0], x_h_ang[1], 0.0f);
-		Eigen::Vector4f b (0, x_h_ang[2], x_h_ang[3], 0.0f);
-		Eigen::Vector4f c (0, x_h_ang[4], x_h_ang[5], 0.0f);
-		Eigen::Vector4f d (x_h_ang[6], x_h_ang[7], x_h_ang[8], 0.0f);
-		Eigen::Vector4f e (x_h_ang[9], x_h_ang[10], x_h_ang[11], 0.0f);
-		Eigen::Vector4f f (x_h_ang[12], x_h_ang[13], x_h_ang[14], 0.0f);
+    // Vectors from Equation 6.21 [Magnusson 2009]
+    Eigen::Vector4f a(0, x_h_ang[0], x_h_ang[1], 0.0f);
+    Eigen::Vector4f b(0, x_h_ang[2], x_h_ang[3], 0.0f);
+    Eigen::Vector4f c(0, x_h_ang[4], x_h_ang[5], 0.0f);
+    Eigen::Vector4f d(x_h_ang[6], x_h_ang[7], x_h_ang[8], 0.0f);
+    Eigen::Vector4f e(x_h_ang[9], x_h_ang[10], x_h_ang[11], 0.0f);
+    Eigen::Vector4f f(x_h_ang[12], x_h_ang[13], x_h_ang[14], 0.0f);
 
-		// Calculate second derivative of Transformation Equation 6.17 w.r.t. transform vector p.
-		// Derivative w.r.t. ith and jth elements of transform vector corresponds to the 3x1 block matrix starting at (3i,j), Equation 6.20 and 6.21 [Magnusson 2009]
-		point_hessian_.block<4, 1>((9/3)*4, 3) = a;
-		point_hessian_.block<4, 1>((12/3)*4, 3) = b;
-		point_hessian_.block<4, 1>((15/3)*4, 3) = c;
-		point_hessian_.block<4, 1>((9/3)*4, 4) = b;
-		point_hessian_.block<4, 1>((12/3)*4, 4) = d;
-		point_hessian_.block<4, 1>((15/3)*4, 4) = e;
-		point_hessian_.block<4, 1>((9/3)*4, 5) = c;
-		point_hessian_.block<4, 1>((12/3)*4, 5) = e;
-		point_hessian_.block<4, 1>((15/3)*4, 5) = f;
-	}
+    // Calculate second derivative of Transformation Equation 6.17 w.r.t. transform vector p.
+    // Derivative w.r.t. ith and jth elements of transform vector corresponds to the 3x1 block matrix starting at (3i,j), Equation 6.20 and 6.21 [Magnusson 2009]
+    point_hessian_.block<4, 1>((9 / 3) * 4, 3) = a;
+    point_hessian_.block<4, 1>((12 / 3) * 4, 3) = b;
+    point_hessian_.block<4, 1>((15 / 3) * 4, 3) = c;
+    point_hessian_.block<4, 1>((9 / 3) * 4, 4) = b;
+    point_hessian_.block<4, 1>((12 / 3) * 4, 4) = d;
+    point_hessian_.block<4, 1>((15 / 3) * 4, 4) = e;
+    point_hessian_.block<4, 1>((9 / 3) * 4, 5) = c;
+    point_hessian_.block<4, 1>((12 / 3) * 4, 5) = e;
+    point_hessian_.block<4, 1>((15 / 3) * 4, 5) = f;
+  }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget> void
-pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computePointDerivatives(Eigen::Vector3d &x, Eigen::Matrix<double, 3, 6>& point_gradient_, Eigen::Matrix<double, 18, 6>& point_hessian_, bool compute_hessian) const
-{
-	// Calculate first derivative of Transformation Equation 6.17 w.r.t. transform vector p.
-	// Derivative w.r.t. ith element of transform vector corresponds to column i, Equation 6.18 and 6.19 [Magnusson 2009]
-	point_gradient_(1, 3) = x.dot(j_ang_a_);
-	point_gradient_(2, 3) = x.dot(j_ang_b_);
-	point_gradient_(0, 4) = x.dot(j_ang_c_);
-	point_gradient_(1, 4) = x.dot(j_ang_d_);
-	point_gradient_(2, 4) = x.dot(j_ang_e_);
-	point_gradient_(0, 5) = x.dot(j_ang_f_);
-	point_gradient_(1, 5) = x.dot(j_ang_g_);
-	point_gradient_(2, 5) = x.dot(j_ang_h_);
+template<typename PointSource, typename PointTarget>
+void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computePointDerivatives(Eigen::Vector3d &x, Eigen::Matrix<double, 3, 6> &point_gradient_, Eigen::Matrix<double, 18, 6> &point_hessian_, bool compute_hessian) const {
+  // Calculate first derivative of Transformation Equation 6.17 w.r.t. transform vector p.
+  // Derivative w.r.t. ith element of transform vector corresponds to column i, Equation 6.18 and 6.19 [Magnusson 2009]
+  point_gradient_(1, 3) = x.dot(j_ang_a_);
+  point_gradient_(2, 3) = x.dot(j_ang_b_);
+  point_gradient_(0, 4) = x.dot(j_ang_c_);
+  point_gradient_(1, 4) = x.dot(j_ang_d_);
+  point_gradient_(2, 4) = x.dot(j_ang_e_);
+  point_gradient_(0, 5) = x.dot(j_ang_f_);
+  point_gradient_(1, 5) = x.dot(j_ang_g_);
+  point_gradient_(2, 5) = x.dot(j_ang_h_);
 
-	if (compute_hessian)
-	{
-		// Vectors from Equation 6.21 [Magnusson 2009]
-		Eigen::Vector3d a, b, c, d, e, f;
+  if(compute_hessian) {
+    // Vectors from Equation 6.21 [Magnusson 2009]
+    Eigen::Vector3d a, b, c, d, e, f;
 
-		a << 0, x.dot(h_ang_a2_), x.dot(h_ang_a3_);
-		b << 0, x.dot(h_ang_b2_), x.dot(h_ang_b3_);
-		c << 0, x.dot(h_ang_c2_), x.dot(h_ang_c3_);
-		d << x.dot(h_ang_d1_), x.dot(h_ang_d2_), x.dot(h_ang_d3_);
-		e << x.dot(h_ang_e1_), x.dot(h_ang_e2_), x.dot(h_ang_e3_);
-		f << x.dot(h_ang_f1_), x.dot(h_ang_f2_), x.dot(h_ang_f3_);
+    a << 0, x.dot(h_ang_a2_), x.dot(h_ang_a3_);
+    b << 0, x.dot(h_ang_b2_), x.dot(h_ang_b3_);
+    c << 0, x.dot(h_ang_c2_), x.dot(h_ang_c3_);
+    d << x.dot(h_ang_d1_), x.dot(h_ang_d2_), x.dot(h_ang_d3_);
+    e << x.dot(h_ang_e1_), x.dot(h_ang_e2_), x.dot(h_ang_e3_);
+    f << x.dot(h_ang_f1_), x.dot(h_ang_f2_), x.dot(h_ang_f3_);
 
-		// Calculate second derivative of Transformation Equation 6.17 w.r.t. transform vector p.
-		// Derivative w.r.t. ith and jth elements of transform vector corresponds to the 3x1 block matrix starting at (3i,j), Equation 6.20 and 6.21 [Magnusson 2009]
-		point_hessian_.block<3, 1>(9, 3) = a;
-		point_hessian_.block<3, 1>(12, 3) = b;
-		point_hessian_.block<3, 1>(15, 3) = c;
-		point_hessian_.block<3, 1>(9, 4) = b;
-		point_hessian_.block<3, 1>(12, 4) = d;
-		point_hessian_.block<3, 1>(15, 4) = e;
-		point_hessian_.block<3, 1>(9, 5) = c;
-		point_hessian_.block<3, 1>(12, 5) = e;
-		point_hessian_.block<3, 1>(15, 5) = f;
-	}
+    // Calculate second derivative of Transformation Equation 6.17 w.r.t. transform vector p.
+    // Derivative w.r.t. ith and jth elements of transform vector corresponds to the 3x1 block matrix starting at (3i,j), Equation 6.20 and 6.21 [Magnusson 2009]
+    point_hessian_.block<3, 1>(9, 3) = a;
+    point_hessian_.block<3, 1>(12, 3) = b;
+    point_hessian_.block<3, 1>(15, 3) = c;
+    point_hessian_.block<3, 1>(9, 4) = b;
+    point_hessian_.block<3, 1>(12, 4) = d;
+    point_hessian_.block<3, 1>(15, 4) = e;
+    point_hessian_.block<3, 1>(9, 5) = c;
+    point_hessian_.block<3, 1>(12, 5) = e;
+    point_hessian_.block<3, 1>(15, 5) = f;
+  }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget> double
-pclomp::NormalDistributionsTransform<PointSource, PointTarget>::updateDerivatives(Eigen::Matrix<double, 6, 1> &score_gradient,
-	Eigen::Matrix<double, 6, 6> &hessian,
-	const Eigen::Matrix<float, 4, 6> &point_gradient4,
-	const Eigen::Matrix<float, 24, 6> &point_hessian_,
-	const Eigen::Vector3d &x_trans, const Eigen::Matrix3d &c_inv,
-	bool compute_hessian) const
-{
-	Eigen::Matrix<float, 1, 4> x_trans4( x_trans[0], x_trans[1], x_trans[2], 0.0f );
-	Eigen::Matrix4f c_inv4 = Eigen::Matrix4f::Zero();
-	c_inv4.topLeftCorner(3, 3) = c_inv.cast<float>();
+template<typename PointSource, typename PointTarget>
+double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::updateDerivatives(Eigen::Matrix<double, 6, 1> &score_gradient, Eigen::Matrix<double, 6, 6> &hessian, const Eigen::Matrix<float, 4, 6> &point_gradient4, const Eigen::Matrix<float, 24, 6> &point_hessian_, const Eigen::Vector3d &x_trans, const Eigen::Matrix3d &c_inv, bool compute_hessian) const {
+  Eigen::Matrix<float, 1, 4> x_trans4(x_trans[0], x_trans[1], x_trans[2], 0.0f);
+  Eigen::Matrix4f c_inv4 = Eigen::Matrix4f::Zero();
+  c_inv4.topLeftCorner(3, 3) = c_inv.cast<float>();
 
-	float gauss_d2 = gauss_d2_;
+  float gauss_d2 = gauss_d2_;
 
-	// e^(-d_2/2 * (x_k - mu_k)^T Sigma_k^-1 (x_k - mu_k)) Equation 6.9 [Magnusson 2009]
-	float e_x_cov_x = exp(-gauss_d2 * x_trans4.dot(x_trans4 * c_inv4) * 0.5f);
-	// Calculate probability of transformed points existence, Equation 6.9 [Magnusson 2009]
-	float score_inc = -gauss_d1_ * e_x_cov_x;
+  // e^(-d_2/2 * (x_k - mu_k)^T Sigma_k^-1 (x_k - mu_k)) Equation 6.9 [Magnusson 2009]
+  float e_x_cov_x = exp(-gauss_d2 * x_trans4.dot(x_trans4 * c_inv4) * 0.5f);
+  // Calculate probability of transformed points existence, Equation 6.9 [Magnusson 2009]
+  float score_inc = -gauss_d1_ * e_x_cov_x;
 
-	e_x_cov_x = gauss_d2 * e_x_cov_x;
+  e_x_cov_x = gauss_d2 * e_x_cov_x;
 
-	// Error checking for invalid values.
-	if (e_x_cov_x > 1 || e_x_cov_x < 0 || e_x_cov_x != e_x_cov_x)
-		return (0);
+  // Error checking for invalid values.
+  if(e_x_cov_x > 1 || e_x_cov_x < 0 || e_x_cov_x != e_x_cov_x) return (0);
 
-	// Reusable portion of Equation 6.12 and 6.13 [Magnusson 2009]
-	e_x_cov_x *= gauss_d1_;
+  // Reusable portion of Equation 6.12 and 6.13 [Magnusson 2009]
+  e_x_cov_x *= gauss_d1_;
 
-	Eigen::Matrix<float, 4, 6> c_inv4_x_point_gradient4 = c_inv4 * point_gradient4;
-	Eigen::Matrix<float, 6, 1> x_trans4_dot_c_inv4_x_point_gradient4 = x_trans4 * c_inv4_x_point_gradient4;
+  Eigen::Matrix<float, 4, 6> c_inv4_x_point_gradient4 = c_inv4 * point_gradient4;
+  Eigen::Matrix<float, 6, 1> x_trans4_dot_c_inv4_x_point_gradient4 = x_trans4 * c_inv4_x_point_gradient4;
 
-	score_gradient.noalias() += (e_x_cov_x * x_trans4_dot_c_inv4_x_point_gradient4).cast<double>();
+  score_gradient.noalias() += (e_x_cov_x * x_trans4_dot_c_inv4_x_point_gradient4).cast<double>();
 
-	if (compute_hessian) {
-		Eigen::Matrix<float, 1, 4> x_trans4_x_c_inv4 = x_trans4 * c_inv4;
-		Eigen::Matrix<float, 6, 6> point_gradient4_colj_dot_c_inv4_x_point_gradient4_col_i = point_gradient4.transpose() * c_inv4_x_point_gradient4;
-		Eigen::Matrix<float, 6, 1> x_trans4_dot_c_inv4_x_ext_point_hessian_4ij;
+  if(compute_hessian) {
+    Eigen::Matrix<float, 1, 4> x_trans4_x_c_inv4 = x_trans4 * c_inv4;
+    Eigen::Matrix<float, 6, 6> point_gradient4_colj_dot_c_inv4_x_point_gradient4_col_i = point_gradient4.transpose() * c_inv4_x_point_gradient4;
+    Eigen::Matrix<float, 6, 1> x_trans4_dot_c_inv4_x_ext_point_hessian_4ij;
 
-		for (int i = 0; i < 6; i++) {
-			// Sigma_k^-1 d(T(x,p))/dpi, Reusable portion of Equation 6.12 and 6.13 [Magnusson 2009]
-			// Update gradient, Equation 6.12 [Magnusson 2009]
-			x_trans4_dot_c_inv4_x_ext_point_hessian_4ij.noalias() = x_trans4_x_c_inv4 * point_hessian_.block<4, 6>(i * 4, 0);
+    for(int i = 0; i < 6; i++) {
+      // Sigma_k^-1 d(T(x,p))/dpi, Reusable portion of Equation 6.12 and 6.13 [Magnusson 2009]
+      // Update gradient, Equation 6.12 [Magnusson 2009]
+      x_trans4_dot_c_inv4_x_ext_point_hessian_4ij.noalias() = x_trans4_x_c_inv4 * point_hessian_.block<4, 6>(i * 4, 0);
 
-			for (int j = 0; j < hessian.cols(); j++) {
-				// Update hessian, Equation 6.13 [Magnusson 2009]
-				hessian(i, j) += e_x_cov_x * (-gauss_d2 * x_trans4_dot_c_inv4_x_point_gradient4(i) * x_trans4_dot_c_inv4_x_point_gradient4(j) +
-					x_trans4_dot_c_inv4_x_ext_point_hessian_4ij(j) +
-					point_gradient4_colj_dot_c_inv4_x_point_gradient4_col_i(j, i));
-			}
-		}
-	}
+      for(int j = 0; j < hessian.cols(); j++) {
+        // Update hessian, Equation 6.13 [Magnusson 2009]
+        hessian(i, j) += e_x_cov_x * (-gauss_d2 * x_trans4_dot_c_inv4_x_point_gradient4(i) * x_trans4_dot_c_inv4_x_point_gradient4(j) + x_trans4_dot_c_inv4_x_ext_point_hessian_4ij(j) + point_gradient4_colj_dot_c_inv4_x_point_gradient4_col_i(j, i));
+      }
+    }
+  }
 
-	return (score_inc);
+  return (score_inc);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget> void
-pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeHessian (Eigen::Matrix<double, 6, 6> &hessian,
-                                                                             PointCloudSource &trans_cloud, Eigen::Matrix<double, 6, 1> &)
-{
+template<typename PointSource, typename PointTarget>
+void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeHessian(Eigen::Matrix<double, 6, 6> &hessian, PointCloudSource &trans_cloud, Eigen::Matrix<double, 6, 1> &) {
   // Original Point and Transformed Point
   PointSource x_pt, x_trans_pt;
   // Original Point and Transformed Point (for math)
@@ -639,120 +581,99 @@ pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeHessian (
   point_gradient_.block<3, 3>(0, 0).setIdentity();
   point_hessian_.setZero();
 
-  hessian.setZero ();
+  hessian.setZero();
 
   // Precompute Angular Derivatives unnecessary because only used after regular derivative calculation
 
   // Update hessian for each point, line 17 in Algorithm 2 [Magnusson 2009]
-  for (size_t idx = 0; idx < input_->points.size (); idx++)
-  {
+  for(size_t idx = 0; idx < input_->points.size(); idx++) {
     x_trans_pt = trans_cloud.points[idx];
 
     // Find neighbors (Radius search has been experimentally faster than direct neighbor checking.
     std::vector<TargetGridLeafConstPtr> neighborhood;
     std::vector<float> distances;
-		switch (search_method) {
-		case KDTREE:
-			target_cells_.radiusSearch(x_trans_pt, resolution_, neighborhood, distances);
-			break;
-		case DIRECT26:
-			target_cells_.getNeighborhoodAtPoint(x_trans_pt, neighborhood);
-			break;
-		default:
-		case DIRECT7:
-			target_cells_.getNeighborhoodAtPoint7(x_trans_pt, neighborhood);
-			break;
-		case DIRECT1:
-			target_cells_.getNeighborhoodAtPoint1(x_trans_pt, neighborhood);
-			break;
-		}
+    switch(search_method) {
+      case KDTREE:
+        target_cells_.radiusSearch(x_trans_pt, resolution_, neighborhood, distances);
+        break;
+      case DIRECT26:
+        target_cells_.getNeighborhoodAtPoint(x_trans_pt, neighborhood);
+        break;
+      default:
+      case DIRECT7:
+        target_cells_.getNeighborhoodAtPoint7(x_trans_pt, neighborhood);
+        break;
+      case DIRECT1:
+        target_cells_.getNeighborhoodAtPoint1(x_trans_pt, neighborhood);
+        break;
+    }
 
-    for (typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it = neighborhood.begin (); neighborhood_it != neighborhood.end (); neighborhood_it++)
-    {
+    for(typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it = neighborhood.begin(); neighborhood_it != neighborhood.end(); neighborhood_it++) {
       cell = *neighborhood_it;
 
       {
         x_pt = input_->points[idx];
-        x = Eigen::Vector3d (x_pt.x, x_pt.y, x_pt.z);
+        x = Eigen::Vector3d(x_pt.x, x_pt.y, x_pt.z);
 
-        x_trans = Eigen::Vector3d (x_trans_pt.x, x_trans_pt.y, x_trans_pt.z);
+        x_trans = Eigen::Vector3d(x_trans_pt.x, x_trans_pt.y, x_trans_pt.z);
 
         // Denorm point, x_k' in Equations 6.12 and 6.13 [Magnusson 2009]
-        x_trans -= cell->getMean ();
+        x_trans -= cell->getMean();
         // Uses precomputed covariance for speed.
-        c_inv = cell->getInverseCov ();
+        c_inv = cell->getInverseCov();
 
         // Compute derivative of transform function w.r.t. transform vector, J_E and H_E in Equations 6.18 and 6.20 [Magnusson 2009]
-        computePointDerivatives (x, point_gradient_, point_hessian_);
+        computePointDerivatives(x, point_gradient_, point_hessian_);
         // Update hessian, lines 21 in Algorithm 2, according to Equations 6.10, 6.12 and 6.13, respectively [Magnusson 2009]
-        updateHessian (hessian, point_gradient_, point_hessian_, x_trans, c_inv);
+        updateHessian(hessian, point_gradient_, point_hessian_, x_trans, c_inv);
       }
     }
   }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget> void
-pclomp::NormalDistributionsTransform<PointSource, PointTarget>::updateHessian (Eigen::Matrix<double, 6, 6> &hessian,
-	const Eigen::Matrix<double, 3, 6> &point_gradient_,
-	const Eigen::Matrix<double, 18, 6> &point_hessian_,
-	const Eigen::Vector3d &x_trans,
-	const Eigen::Matrix3d &c_inv) const
-{
+template<typename PointSource, typename PointTarget>
+void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::updateHessian(Eigen::Matrix<double, 6, 6> &hessian, const Eigen::Matrix<double, 3, 6> &point_gradient_, const Eigen::Matrix<double, 18, 6> &point_hessian_, const Eigen::Vector3d &x_trans, const Eigen::Matrix3d &c_inv) const {
   Eigen::Vector3d cov_dxd_pi;
   // e^(-d_2/2 * (x_k - mu_k)^T Sigma_k^-1 (x_k - mu_k)) Equation 6.9 [Magnusson 2009]
-  double e_x_cov_x = gauss_d2_ * exp (-gauss_d2_ * x_trans.dot (c_inv * x_trans) / 2);
+  double e_x_cov_x = gauss_d2_ * exp(-gauss_d2_ * x_trans.dot(c_inv * x_trans) / 2);
 
   // Error checking for invalid values.
-  if (e_x_cov_x > 1 || e_x_cov_x < 0 || e_x_cov_x != e_x_cov_x)
-    return;
+  if(e_x_cov_x > 1 || e_x_cov_x < 0 || e_x_cov_x != e_x_cov_x) return;
 
   // Reusable portion of Equation 6.12 and 6.13 [Magnusson 2009]
   e_x_cov_x *= gauss_d1_;
 
-  for (int i = 0; i < 6; i++)
-  {
+  for(int i = 0; i < 6; i++) {
     // Sigma_k^-1 d(T(x,p))/dpi, Reusable portion of Equation 6.12 and 6.13 [Magnusson 2009]
-    cov_dxd_pi = c_inv * point_gradient_.col (i);
+    cov_dxd_pi = c_inv * point_gradient_.col(i);
 
-    for (int j = 0; j < hessian.cols (); j++)
-    {
+    for(int j = 0; j < hessian.cols(); j++) {
       // Update hessian, Equation 6.13 [Magnusson 2009]
-      hessian (i, j) += e_x_cov_x * (-gauss_d2_ * x_trans.dot (cov_dxd_pi) * x_trans.dot (c_inv * point_gradient_.col (j)) +
-                                  x_trans.dot (c_inv * point_hessian_.block<3, 1>(3 * i, j)) +
-                                  point_gradient_.col (j).dot (cov_dxd_pi) );
+      hessian(i, j) += e_x_cov_x * (-gauss_d2_ * x_trans.dot(cov_dxd_pi) * x_trans.dot(c_inv * point_gradient_.col(j)) + x_trans.dot(c_inv * point_hessian_.block<3, 1>(3 * i, j)) + point_gradient_.col(j).dot(cov_dxd_pi));
     }
   }
-
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget> bool
-pclomp::NormalDistributionsTransform<PointSource, PointTarget>::updateIntervalMT (double &a_l, double &f_l, double &g_l,
-                                                                               double &a_u, double &f_u, double &g_u,
-                                                                               double a_t, double f_t, double g_t)
-{
+template<typename PointSource, typename PointTarget>
+bool pclomp::NormalDistributionsTransform<PointSource, PointTarget>::updateIntervalMT(double &a_l, double &f_l, double &g_l, double &a_u, double &f_u, double &g_u, double a_t, double f_t, double g_t) {
   // Case U1 in Update Algorithm and Case a in Modified Update Algorithm [More, Thuente 1994]
-  if (f_t > f_l)
-  {
+  if(f_t > f_l) {
     a_u = a_t;
     f_u = f_t;
     g_u = g_t;
     return (false);
   }
   // Case U2 in Update Algorithm and Case b in Modified Update Algorithm [More, Thuente 1994]
-  else
-  if (g_t * (a_l - a_t) > 0)
-  {
+  else if(g_t * (a_l - a_t) > 0) {
     a_l = a_t;
     f_l = f_t;
     g_l = g_t;
     return (false);
   }
   // Case U3 in Update Algorithm and Case c in Modified Update Algorithm [More, Thuente 1994]
-  else
-  if (g_t * (a_l - a_t) < 0)
-  {
+  else if(g_t * (a_l - a_t) < 0) {
     a_u = a_l;
     f_u = f_l;
     g_u = g_l;
@@ -768,18 +689,14 @@ pclomp::NormalDistributionsTransform<PointSource, PointTarget>::updateIntervalMT
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget> double
-pclomp::NormalDistributionsTransform<PointSource, PointTarget>::trialValueSelectionMT (double a_l, double f_l, double g_l,
-                                                                                    double a_u, double f_u, double g_u,
-                                                                                    double a_t, double f_t, double g_t)
-{
+template<typename PointSource, typename PointTarget>
+double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::trialValueSelectionMT(double a_l, double f_l, double g_l, double a_u, double f_u, double g_u, double a_t, double f_t, double g_t) {
   // Case 1 in Trial Value Selection [More, Thuente 1994]
-  if (f_t > f_l)
-  {
+  if(f_t > f_l) {
     // Calculate the minimizer of the cubic that interpolates f_l, f_t, g_l and g_t
     // Equation 2.4.52 [Sun, Yuan 2006]
     double z = 3 * (f_t - f_l) / (a_t - a_l) - g_t - g_l;
-    double w = std::sqrt (z * z - g_t * g_l);
+    double w = std::sqrt(z * z - g_t * g_l);
     // Equation 2.4.56 [Sun, Yuan 2006]
     double a_c = a_l + (a_t - a_l) * (w - g_l - z) / (g_t - g_l + 2 * w);
 
@@ -787,19 +704,17 @@ pclomp::NormalDistributionsTransform<PointSource, PointTarget>::trialValueSelect
     // Equation 2.4.2 [Sun, Yuan 2006]
     double a_q = a_l - 0.5 * (a_l - a_t) * g_l / (g_l - (f_l - f_t) / (a_l - a_t));
 
-    if (std::fabs (a_c - a_l) < std::fabs (a_q - a_l))
+    if(std::fabs(a_c - a_l) < std::fabs(a_q - a_l))
       return (a_c);
     else
       return (0.5 * (a_q + a_c));
   }
   // Case 2 in Trial Value Selection [More, Thuente 1994]
-  else
-  if (g_t * g_l < 0)
-  {
+  else if(g_t * g_l < 0) {
     // Calculate the minimizer of the cubic that interpolates f_l, f_t, g_l and g_t
     // Equation 2.4.52 [Sun, Yuan 2006]
     double z = 3 * (f_t - f_l) / (a_t - a_l) - g_t - g_l;
-    double w = std::sqrt (z * z - g_t * g_l);
+    double w = std::sqrt(z * z - g_t * g_l);
     // Equation 2.4.56 [Sun, Yuan 2006]
     double a_c = a_l + (a_t - a_l) * (w - g_l - z) / (g_t - g_l + 2 * w);
 
@@ -807,19 +722,17 @@ pclomp::NormalDistributionsTransform<PointSource, PointTarget>::trialValueSelect
     // Equation 2.4.5 [Sun, Yuan 2006]
     double a_s = a_l - (a_l - a_t) / (g_l - g_t) * g_l;
 
-    if (std::fabs (a_c - a_t) >= std::fabs (a_s - a_t))
+    if(std::fabs(a_c - a_t) >= std::fabs(a_s - a_t))
       return (a_c);
     else
       return (a_s);
   }
   // Case 3 in Trial Value Selection [More, Thuente 1994]
-  else
-  if (std::fabs (g_t) <= std::fabs (g_l))
-  {
+  else if(std::fabs(g_t) <= std::fabs(g_l)) {
     // Calculate the minimizer of the cubic that interpolates f_l, f_t, g_l and g_t
     // Equation 2.4.52 [Sun, Yuan 2006]
     double z = 3 * (f_t - f_l) / (a_t - a_l) - g_t - g_l;
-    double w = std::sqrt (z * z - g_t * g_l);
+    double w = std::sqrt(z * z - g_t * g_l);
     double a_c = a_l + (a_t - a_l) * (w - g_l - z) / (g_t - g_l + 2 * w);
 
     // Calculate the minimizer of the quadratic that interpolates g_l and g_t
@@ -828,52 +741,45 @@ pclomp::NormalDistributionsTransform<PointSource, PointTarget>::trialValueSelect
 
     double a_t_next;
 
-    if (std::fabs (a_c - a_t) < std::fabs (a_s - a_t))
+    if(std::fabs(a_c - a_t) < std::fabs(a_s - a_t))
       a_t_next = a_c;
     else
       a_t_next = a_s;
 
-    if (a_t > a_l)
-      return (std::min (a_t + 0.66 * (a_u - a_t), a_t_next));
+    if(a_t > a_l)
+      return (std::min(a_t + 0.66 * (a_u - a_t), a_t_next));
     else
-      return (std::max (a_t + 0.66 * (a_u - a_t), a_t_next));
+      return (std::max(a_t + 0.66 * (a_u - a_t), a_t_next));
   }
   // Case 4 in Trial Value Selection [More, Thuente 1994]
-  else
-  {
+  else {
     // Calculate the minimizer of the cubic that interpolates f_u, f_t, g_u and g_t
     // Equation 2.4.52 [Sun, Yuan 2006]
     double z = 3 * (f_t - f_u) / (a_t - a_u) - g_t - g_u;
-    double w = std::sqrt (z * z - g_t * g_u);
+    double w = std::sqrt(z * z - g_t * g_u);
     // Equation 2.4.56 [Sun, Yuan 2006]
     return (a_u + (a_t - a_u) * (w - g_u - z) / (g_t - g_u + 2 * w));
   }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget> double
-pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeStepLengthMT (const Eigen::Matrix<double, 6, 1> &x, Eigen::Matrix<double, 6, 1> &step_dir, double step_init, double step_max,
-                                                                                  double step_min, double &score, Eigen::Matrix<double, 6, 1> &score_gradient, Eigen::Matrix<double, 6, 6> &hessian,
-                                                                                  PointCloudSource &trans_cloud)
-{
+template<typename PointSource, typename PointTarget>
+double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeStepLengthMT(const Eigen::Matrix<double, 6, 1> &x, Eigen::Matrix<double, 6, 1> &step_dir, double step_init, double step_max, double step_min, double &score, Eigen::Matrix<double, 6, 1> &score_gradient, Eigen::Matrix<double, 6, 6> &hessian, PointCloudSource &trans_cloud) {
   // Set the value of phi(0), Equation 1.3 [More, Thuente 1994]
   double phi_0 = -score;
   // Set the value of phi'(0), Equation 1.3 [More, Thuente 1994]
-  double d_phi_0 = -(score_gradient.dot (step_dir));
+  double d_phi_0 = -(score_gradient.dot(step_dir));
 
-  Eigen::Matrix<double, 6, 1>  x_t;
+  Eigen::Matrix<double, 6, 1> x_t;
 
-  if (d_phi_0 >= 0)
-  {
+  if(d_phi_0 >= 0) {
     // Not a decent direction
-    if (d_phi_0 == 0)
+    if(d_phi_0 == 0)
       return 0;
-    else
-    {
+    else {
       // Reverse step direction and calculate optimal step.
       d_phi_0 *= -1;
       step_dir *= -1;
-
     }
   }
 
@@ -891,32 +797,30 @@ pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeStepLengt
   double a_l = 0, a_u = 0;
 
   // Auxiliary function psi is used until I is determined ot be a closed interval, Equation 2.1 [More, Thuente 1994]
-  double f_l = auxiliaryFunction_PsiMT (a_l, phi_0, phi_0, d_phi_0, mu);
-  double g_l = auxiliaryFunction_dPsiMT (d_phi_0, d_phi_0, mu);
+  double f_l = auxiliaryFunction_PsiMT(a_l, phi_0, phi_0, d_phi_0, mu);
+  double g_l = auxiliaryFunction_dPsiMT(d_phi_0, d_phi_0, mu);
 
-  double f_u = auxiliaryFunction_PsiMT (a_u, phi_0, phi_0, d_phi_0, mu);
-  double g_u = auxiliaryFunction_dPsiMT (d_phi_0, d_phi_0, mu);
+  double f_u = auxiliaryFunction_PsiMT(a_u, phi_0, phi_0, d_phi_0, mu);
+  double g_u = auxiliaryFunction_dPsiMT(d_phi_0, d_phi_0, mu);
 
   // Check used to allow More-Thuente step length calculation to be skipped by making step_min == step_max
   bool interval_converged = (step_max - step_min) < 0, open_interval = true;
 
   double a_t = step_init;
-  a_t = std::min (a_t, step_max);
-  a_t = std::max (a_t, step_min);
+  a_t = std::min(a_t, step_max);
+  a_t = std::max(a_t, step_min);
 
   x_t = x + step_dir * a_t;
 
-  final_transformation_ = (Eigen::Translation<float, 3>(static_cast<float> (x_t (0)), static_cast<float> (x_t (1)), static_cast<float> (x_t (2))) *
-                           Eigen::AngleAxis<float> (static_cast<float> (x_t (3)), Eigen::Vector3f::UnitX ()) *
-                           Eigen::AngleAxis<float> (static_cast<float> (x_t (4)), Eigen::Vector3f::UnitY ()) *
-                           Eigen::AngleAxis<float> (static_cast<float> (x_t (5)), Eigen::Vector3f::UnitZ ())).matrix ();
+  final_transformation_ = (Eigen::Translation<float, 3>(static_cast<float>(x_t(0)), static_cast<float>(x_t(1)), static_cast<float>(x_t(2))) * Eigen::AngleAxis<float>(static_cast<float>(x_t(3)), Eigen::Vector3f::UnitX()) * Eigen::AngleAxis<float>(static_cast<float>(x_t(4)), Eigen::Vector3f::UnitY()) * Eigen::AngleAxis<float>(static_cast<float>(x_t(5)), Eigen::Vector3f::UnitZ()))
+                              .matrix();
 
   // New transformed point cloud
-  transformPointCloud (*input_, trans_cloud, final_transformation_);
+  transformPointCloud(*input_, trans_cloud, final_transformation_);
 
   // Updates score, gradient and hessian.  Hessian calculation is unnecessary but testing showed that most step calculations use the
   // initial step suggestion and recalculation the reusable portions of the hessian would intail more computation time.
-  score = computeDerivatives (score_gradient, hessian, trans_cloud, x_t, true);
+  score = computeDerivatives(score_gradient, hessian, trans_cloud, x_t, true);
 
   // --------------------------------------------------------------------------------------------------------------------------------
   // FIXME(YamatoAndo):
@@ -1016,185 +920,174 @@ pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeStepLengt
   // If inner loop was run then hessian needs to be calculated.
   // Hessian is unnecessary for step length determination but gradients are required
   // so derivative and transform data is stored for the next iteration.
-  if (step_iterations)
-    computeHessian (hessian, trans_cloud, x_t);
+  if(step_iterations) computeHessian(hessian, trans_cloud, x_t);
 
   return (a_t);
 }
 
 template<typename PointSource, typename PointTarget>
-double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::calculateScore(const PointCloudSource & trans_cloud) const
-{
-	double score = 0;
+double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::calculateScore(const PointCloudSource &trans_cloud) const {
+  double score = 0;
 
-	for (std::size_t idx = 0; idx < trans_cloud.points.size(); idx++)
-	{
-		PointSource x_trans_pt = trans_cloud.points[idx];
+  for(std::size_t idx = 0; idx < trans_cloud.points.size(); idx++) {
+    PointSource x_trans_pt = trans_cloud.points[idx];
 
-		// Find neighbors (Radius search has been experimentally faster than direct neighbor checking.
-		std::vector<TargetGridLeafConstPtr> neighborhood;
-		std::vector<float> distances;
-		switch (search_method) {
-		case KDTREE:
-			target_cells_.radiusSearch(x_trans_pt, resolution_, neighborhood, distances);
-			break;
-		case DIRECT26:
-			target_cells_.getNeighborhoodAtPoint(x_trans_pt, neighborhood);
-			break;
-		default:
-		case DIRECT7:
-			target_cells_.getNeighborhoodAtPoint7(x_trans_pt, neighborhood);
-			break;
-		case DIRECT1:
-			target_cells_.getNeighborhoodAtPoint1(x_trans_pt, neighborhood);
-			break;
-		}
-
-		for (typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it = neighborhood.begin(); neighborhood_it != neighborhood.end(); neighborhood_it++)
-		{
-			TargetGridLeafConstPtr cell = *neighborhood_it;
-
-			Eigen::Vector3d x_trans = Eigen::Vector3d(x_trans_pt.x, x_trans_pt.y, x_trans_pt.z);
-
-			// Denorm point, x_k' in Equations 6.12 and 6.13 [Magnusson 2009]
-			x_trans -= cell->getMean();
-			// Uses precomputed covariance for speed.
-			Eigen::Matrix3d c_inv = cell->getInverseCov();
-
-			// e^(-d_2/2 * (x_k - mu_k)^T Sigma_k^-1 (x_k - mu_k)) Equation 6.9 [Magnusson 2009]
-			double e_x_cov_x = exp(-gauss_d2_ * x_trans.dot(c_inv * x_trans) / 2);
-			// Calculate probability of transformed points existence, Equation 6.9 [Magnusson 2009]
-			double score_inc = -gauss_d1_ * e_x_cov_x - gauss_d3_;
-
-			score += score_inc / neighborhood.size();
-		}
-	}
-
-  double output_score = 0;
-  if (!trans_cloud.points.empty()) {
-    output_score = (score) / static_cast<double> (trans_cloud.size());
-  }
-	return output_score;
-}
-
-template<typename PointSource, typename PointTarget>
-double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::calculateTransformationProbability(const PointCloudSource & trans_cloud) const
-{
-	double score = 0;
-
-	for (std::size_t idx = 0; idx < trans_cloud.points.size(); idx++)
-	{
-		PointSource x_trans_pt = trans_cloud.points[idx];
-
-		// Find neighbors (Radius search has been experimentally faster than direct neighbor checking.
-		std::vector<TargetGridLeafConstPtr> neighborhood;
-		std::vector<float> distances;
-		switch (search_method) {
-		case KDTREE:
-			target_cells_.radiusSearch(x_trans_pt, resolution_, neighborhood, distances);
-			break;
-		case DIRECT26:
-			target_cells_.getNeighborhoodAtPoint(x_trans_pt, neighborhood);
-			break;
-		default:
-		case DIRECT7:
-			target_cells_.getNeighborhoodAtPoint7(x_trans_pt, neighborhood);
-			break;
-		case DIRECT1:
-			target_cells_.getNeighborhoodAtPoint1(x_trans_pt, neighborhood);
-			break;
-		}
-
-		for (typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it = neighborhood.begin(); neighborhood_it != neighborhood.end(); neighborhood_it++)
-		{
-			TargetGridLeafConstPtr cell = *neighborhood_it;
-
-			Eigen::Vector3d x_trans = Eigen::Vector3d(x_trans_pt.x, x_trans_pt.y, x_trans_pt.z);
-
-			// Denorm point, x_k' in Equations 6.12 and 6.13 [Magnusson 2009]
-			x_trans -= cell->getMean();
-			// Uses precomputed covariance for speed.
-			Eigen::Matrix3d c_inv = cell->getInverseCov();
-
-			// e^(-d_2/2 * (x_k - mu_k)^T Sigma_k^-1 (x_k - mu_k)) Equation 6.9 [Magnusson 2009]
-			double e_x_cov_x = exp(-gauss_d2_ * x_trans.dot(c_inv * x_trans) / 2);
-			// Calculate probability of transformed points existence, Equation 6.9 [Magnusson 2009]
-			double score_inc = -gauss_d1_ * e_x_cov_x;
-
-      score += score_inc;
-		}
-	}
-
-  double output_score = 0;
-  if (!trans_cloud.points.empty()) {
-    output_score = (score) / static_cast<double> (trans_cloud.points.size());
-  }
-	return output_score;
-}
-
-template<typename PointSource, typename PointTarget>
-double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::calculateNearestVoxelTransformationLikelihood(const PointCloudSource & trans_cloud) const
-{
-  double nearest_voxel_score = 0;
-  size_t found_neigborhood_voxel_num = 0;
-
-	for (std::size_t idx = 0; idx < trans_cloud.points.size(); idx++)
-	{
-    double nearest_voxel_score_pt = 0;
-		PointSource x_trans_pt = trans_cloud.points[idx];
-
-		// Find neighbors (Radius search has been experimentally faster than direct neighbor checking.
-		std::vector<TargetGridLeafConstPtr> neighborhood;
-		std::vector<float> distances;
-		switch (search_method) {
-		case KDTREE:
-			target_cells_.radiusSearch(x_trans_pt, resolution_, neighborhood, distances);
-			break;
-		case DIRECT26:
-			target_cells_.getNeighborhoodAtPoint(x_trans_pt, neighborhood);
-			break;
-		default:
-		case DIRECT7:
-			target_cells_.getNeighborhoodAtPoint7(x_trans_pt, neighborhood);
-			break;
-		case DIRECT1:
-			target_cells_.getNeighborhoodAtPoint1(x_trans_pt, neighborhood);
-			break;
-		}
-
-		for (typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it = neighborhood.begin(); neighborhood_it != neighborhood.end(); neighborhood_it++)
-		{
-			TargetGridLeafConstPtr cell = *neighborhood_it;
-
-			Eigen::Vector3d x_trans = Eigen::Vector3d(x_trans_pt.x, x_trans_pt.y, x_trans_pt.z);
-
-			// Denorm point, x_k' in Equations 6.12 and 6.13 [Magnusson 2009]
-			x_trans -= cell->getMean();
-			// Uses precomputed covariance for speed.
-			Eigen::Matrix3d c_inv = cell->getInverseCov();
-
-			// e^(-d_2/2 * (x_k - mu_k)^T Sigma_k^-1 (x_k - mu_k)) Equation 6.9 [Magnusson 2009]
-			double e_x_cov_x = exp(-gauss_d2_ * x_trans.dot(c_inv * x_trans) / 2);
-			// Calculate probability of transformed points existence, Equation 6.9 [Magnusson 2009]
-			double score_inc = -gauss_d1_ * e_x_cov_x;
-
-      if (score_inc > nearest_voxel_score_pt) {
-        nearest_voxel_score_pt = score_inc;
-      }
-		}
-
-    if (!neighborhood.empty()) {
-      ++found_neigborhood_voxel_num;
-      nearest_voxel_score += nearest_voxel_score_pt;
+    // Find neighbors (Radius search has been experimentally faster than direct neighbor checking.
+    std::vector<TargetGridLeafConstPtr> neighborhood;
+    std::vector<float> distances;
+    switch(search_method) {
+      case KDTREE:
+        target_cells_.radiusSearch(x_trans_pt, resolution_, neighborhood, distances);
+        break;
+      case DIRECT26:
+        target_cells_.getNeighborhoodAtPoint(x_trans_pt, neighborhood);
+        break;
+      default:
+      case DIRECT7:
+        target_cells_.getNeighborhoodAtPoint7(x_trans_pt, neighborhood);
+        break;
+      case DIRECT1:
+        target_cells_.getNeighborhoodAtPoint1(x_trans_pt, neighborhood);
+        break;
     }
 
-	}
+    for(typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it = neighborhood.begin(); neighborhood_it != neighborhood.end(); neighborhood_it++) {
+      TargetGridLeafConstPtr cell = *neighborhood_it;
+
+      Eigen::Vector3d x_trans = Eigen::Vector3d(x_trans_pt.x, x_trans_pt.y, x_trans_pt.z);
+
+      // Denorm point, x_k' in Equations 6.12 and 6.13 [Magnusson 2009]
+      x_trans -= cell->getMean();
+      // Uses precomputed covariance for speed.
+      Eigen::Matrix3d c_inv = cell->getInverseCov();
+
+      // e^(-d_2/2 * (x_k - mu_k)^T Sigma_k^-1 (x_k - mu_k)) Equation 6.9 [Magnusson 2009]
+      double e_x_cov_x = exp(-gauss_d2_ * x_trans.dot(c_inv * x_trans) / 2);
+      // Calculate probability of transformed points existence, Equation 6.9 [Magnusson 2009]
+      double score_inc = -gauss_d1_ * e_x_cov_x - gauss_d3_;
+
+      score += score_inc / neighborhood.size();
+    }
+  }
 
   double output_score = 0;
-  if (found_neigborhood_voxel_num != 0) {
-    output_score =  nearest_voxel_score / static_cast<double> (found_neigborhood_voxel_num);
+  if(!trans_cloud.points.empty()) {
+    output_score = (score) / static_cast<double>(trans_cloud.size());
   }
   return output_score;
 }
 
-#endif // PCL_REGISTRATION_NDT_IMPL_H_
+template<typename PointSource, typename PointTarget>
+double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::calculateTransformationProbability(const PointCloudSource &trans_cloud) const {
+  double score = 0;
+
+  for(std::size_t idx = 0; idx < trans_cloud.points.size(); idx++) {
+    PointSource x_trans_pt = trans_cloud.points[idx];
+
+    // Find neighbors (Radius search has been experimentally faster than direct neighbor checking.
+    std::vector<TargetGridLeafConstPtr> neighborhood;
+    std::vector<float> distances;
+    switch(search_method) {
+      case KDTREE:
+        target_cells_.radiusSearch(x_trans_pt, resolution_, neighborhood, distances);
+        break;
+      case DIRECT26:
+        target_cells_.getNeighborhoodAtPoint(x_trans_pt, neighborhood);
+        break;
+      default:
+      case DIRECT7:
+        target_cells_.getNeighborhoodAtPoint7(x_trans_pt, neighborhood);
+        break;
+      case DIRECT1:
+        target_cells_.getNeighborhoodAtPoint1(x_trans_pt, neighborhood);
+        break;
+    }
+
+    for(typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it = neighborhood.begin(); neighborhood_it != neighborhood.end(); neighborhood_it++) {
+      TargetGridLeafConstPtr cell = *neighborhood_it;
+
+      Eigen::Vector3d x_trans = Eigen::Vector3d(x_trans_pt.x, x_trans_pt.y, x_trans_pt.z);
+
+      // Denorm point, x_k' in Equations 6.12 and 6.13 [Magnusson 2009]
+      x_trans -= cell->getMean();
+      // Uses precomputed covariance for speed.
+      Eigen::Matrix3d c_inv = cell->getInverseCov();
+
+      // e^(-d_2/2 * (x_k - mu_k)^T Sigma_k^-1 (x_k - mu_k)) Equation 6.9 [Magnusson 2009]
+      double e_x_cov_x = exp(-gauss_d2_ * x_trans.dot(c_inv * x_trans) / 2);
+      // Calculate probability of transformed points existence, Equation 6.9 [Magnusson 2009]
+      double score_inc = -gauss_d1_ * e_x_cov_x;
+
+      score += score_inc;
+    }
+  }
+
+  double output_score = 0;
+  if(!trans_cloud.points.empty()) {
+    output_score = (score) / static_cast<double>(trans_cloud.points.size());
+  }
+  return output_score;
+}
+
+template<typename PointSource, typename PointTarget>
+double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::calculateNearestVoxelTransformationLikelihood(const PointCloudSource &trans_cloud) const {
+  double nearest_voxel_score = 0;
+  size_t found_neigborhood_voxel_num = 0;
+
+  for(std::size_t idx = 0; idx < trans_cloud.points.size(); idx++) {
+    double nearest_voxel_score_pt = 0;
+    PointSource x_trans_pt = trans_cloud.points[idx];
+
+    // Find neighbors (Radius search has been experimentally faster than direct neighbor checking.
+    std::vector<TargetGridLeafConstPtr> neighborhood;
+    std::vector<float> distances;
+    switch(search_method) {
+      case KDTREE:
+        target_cells_.radiusSearch(x_trans_pt, resolution_, neighborhood, distances);
+        break;
+      case DIRECT26:
+        target_cells_.getNeighborhoodAtPoint(x_trans_pt, neighborhood);
+        break;
+      default:
+      case DIRECT7:
+        target_cells_.getNeighborhoodAtPoint7(x_trans_pt, neighborhood);
+        break;
+      case DIRECT1:
+        target_cells_.getNeighborhoodAtPoint1(x_trans_pt, neighborhood);
+        break;
+    }
+
+    for(typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it = neighborhood.begin(); neighborhood_it != neighborhood.end(); neighborhood_it++) {
+      TargetGridLeafConstPtr cell = *neighborhood_it;
+
+      Eigen::Vector3d x_trans = Eigen::Vector3d(x_trans_pt.x, x_trans_pt.y, x_trans_pt.z);
+
+      // Denorm point, x_k' in Equations 6.12 and 6.13 [Magnusson 2009]
+      x_trans -= cell->getMean();
+      // Uses precomputed covariance for speed.
+      Eigen::Matrix3d c_inv = cell->getInverseCov();
+
+      // e^(-d_2/2 * (x_k - mu_k)^T Sigma_k^-1 (x_k - mu_k)) Equation 6.9 [Magnusson 2009]
+      double e_x_cov_x = exp(-gauss_d2_ * x_trans.dot(c_inv * x_trans) / 2);
+      // Calculate probability of transformed points existence, Equation 6.9 [Magnusson 2009]
+      double score_inc = -gauss_d1_ * e_x_cov_x;
+
+      if(score_inc > nearest_voxel_score_pt) {
+        nearest_voxel_score_pt = score_inc;
+      }
+    }
+
+    if(!neighborhood.empty()) {
+      ++found_neigborhood_voxel_num;
+      nearest_voxel_score += nearest_voxel_score_pt;
+    }
+  }
+
+  double output_score = 0;
+  if(found_neigborhood_voxel_num != 0) {
+    output_score = nearest_voxel_score / static_cast<double>(found_neigborhood_voxel_num);
+  }
+  return output_score;
+}
+
+#endif  // PCL_REGISTRATION_NDT_IMPL_H_

--- a/include/pclomp/voxel_grid_covariance_omp.h
+++ b/include/pclomp/voxel_grid_covariance_omp.h
@@ -46,512 +46,420 @@
 #include <pcl/point_types.h>
 #include <pcl/kdtree/kdtree_flann.h>
 
-namespace pclomp
-{
-  /** \brief A searchable voxel structure containing the mean and covariance of the data.
-    * \note For more information please see
-    * <b>Magnusson, M. (2009). The Three-Dimensional Normal-Distributions Transform —
-    * an Efficient Representation for Registration, Surface Analysis, and Loop Detection.
-    * PhD thesis, Orebro University. Orebro Studies in Technology 36</b>
-    * \author Brian Okorn (Space and Naval Warfare Systems Center Pacific)
-    */
-  template<typename PointT>
-  class VoxelGridCovariance : public pcl::VoxelGrid<PointT>
-  {
-    protected:
-      using pcl::VoxelGrid<PointT>::filter_name_;
-      using pcl::VoxelGrid<PointT>::getClassName;
-      using pcl::VoxelGrid<PointT>::input_;
-      using pcl::VoxelGrid<PointT>::indices_;
-      using pcl::VoxelGrid<PointT>::filter_limit_negative_;
-      using pcl::VoxelGrid<PointT>::filter_limit_min_;
-      using pcl::VoxelGrid<PointT>::filter_limit_max_;
-      using pcl::VoxelGrid<PointT>::filter_field_name_;
+namespace pclomp {
+/** \brief A searchable voxel structure containing the mean and covariance of the data.
+ * \note For more information please see
+ * <b>Magnusson, M. (2009). The Three-Dimensional Normal-Distributions Transform —
+ * an Efficient Representation for Registration, Surface Analysis, and Loop Detection.
+ * PhD thesis, Orebro University. Orebro Studies in Technology 36</b>
+ * \author Brian Okorn (Space and Naval Warfare Systems Center Pacific)
+ */
+template<typename PointT>
+class VoxelGridCovariance : public pcl::VoxelGrid<PointT> {
+protected:
+  using pcl::VoxelGrid<PointT>::filter_name_;
+  using pcl::VoxelGrid<PointT>::getClassName;
+  using pcl::VoxelGrid<PointT>::input_;
+  using pcl::VoxelGrid<PointT>::indices_;
+  using pcl::VoxelGrid<PointT>::filter_limit_negative_;
+  using pcl::VoxelGrid<PointT>::filter_limit_min_;
+  using pcl::VoxelGrid<PointT>::filter_limit_max_;
+  using pcl::VoxelGrid<PointT>::filter_field_name_;
 
-      using pcl::VoxelGrid<PointT>::downsample_all_data_;
-      using pcl::VoxelGrid<PointT>::leaf_layout_;
-      using pcl::VoxelGrid<PointT>::save_leaf_layout_;
-      using pcl::VoxelGrid<PointT>::leaf_size_;
-      using pcl::VoxelGrid<PointT>::min_b_;
-      using pcl::VoxelGrid<PointT>::max_b_;
-      using pcl::VoxelGrid<PointT>::inverse_leaf_size_;
-      using pcl::VoxelGrid<PointT>::div_b_;
-      using pcl::VoxelGrid<PointT>::divb_mul_;
+  using pcl::VoxelGrid<PointT>::downsample_all_data_;
+  using pcl::VoxelGrid<PointT>::leaf_layout_;
+  using pcl::VoxelGrid<PointT>::save_leaf_layout_;
+  using pcl::VoxelGrid<PointT>::leaf_size_;
+  using pcl::VoxelGrid<PointT>::min_b_;
+  using pcl::VoxelGrid<PointT>::max_b_;
+  using pcl::VoxelGrid<PointT>::inverse_leaf_size_;
+  using pcl::VoxelGrid<PointT>::div_b_;
+  using pcl::VoxelGrid<PointT>::divb_mul_;
 
-      typedef typename pcl::traits::fieldList<PointT>::type FieldList;
-      typedef typename pcl::Filter<PointT>::PointCloud PointCloud;
-      typedef typename PointCloud::Ptr PointCloudPtr;
-      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+  typedef typename pcl::traits::fieldList<PointT>::type FieldList;
+  typedef typename pcl::Filter<PointT>::PointCloud PointCloud;
+  typedef typename PointCloud::Ptr PointCloudPtr;
+  typedef typename PointCloud::ConstPtr PointCloudConstPtr;
 
-    public:
-
+public:
 #if PCL_VERSION >= PCL_VERSION_CALC(1, 10, 0)
-      typedef pcl::shared_ptr< pcl::VoxelGrid<PointT> > Ptr;
-      typedef pcl::shared_ptr< const pcl::VoxelGrid<PointT> > ConstPtr;
+  typedef pcl::shared_ptr<pcl::VoxelGrid<PointT> > Ptr;
+  typedef pcl::shared_ptr<const pcl::VoxelGrid<PointT> > ConstPtr;
 #else
-      typedef boost::shared_ptr< pcl::VoxelGrid<PointT> > Ptr;
-      typedef boost::shared_ptr< const pcl::VoxelGrid<PointT> > ConstPtr;
+  typedef boost::shared_ptr<pcl::VoxelGrid<PointT> > Ptr;
+  typedef boost::shared_ptr<const pcl::VoxelGrid<PointT> > ConstPtr;
 #endif
 
-      /** \brief Simple structure to hold a centroid, covariance and the number of points in a leaf.
-        * Inverse covariance, eigen vectors and eigen values are precomputed. */
-      struct Leaf
-      {
-        /** \brief Constructor.
-         * Sets \ref nr_points, \ref icov_, \ref mean_ and \ref evals_ to 0 and \ref cov_ and \ref evecs_ to the identity matrix
-         */
-        Leaf () :
-          nr_points (0),
-          mean_ (Eigen::Vector3d::Zero ()),
-          centroid (),
-          cov_ (Eigen::Matrix3d::Identity ()),
-          icov_ (Eigen::Matrix3d::Zero ()),
-          evecs_ (Eigen::Matrix3d::Identity ()),
-          evals_ (Eigen::Vector3d::Zero ())
-        {
-        }
+  /** \brief Simple structure to hold a centroid, covariance and the number of points in a leaf.
+   * Inverse covariance, eigen vectors and eigen values are precomputed. */
+  struct Leaf {
+    /** \brief Constructor.
+     * Sets \ref nr_points, \ref icov_, \ref mean_ and \ref evals_ to 0 and \ref cov_ and \ref evecs_ to the identity matrix
+     */
+    Leaf() : nr_points(0), mean_(Eigen::Vector3d::Zero()), centroid(), cov_(Eigen::Matrix3d::Identity()), icov_(Eigen::Matrix3d::Zero()), evecs_(Eigen::Matrix3d::Identity()), evals_(Eigen::Vector3d::Zero()) {}
 
-        /** \brief Get the voxel covariance.
-          * \return covariance matrix
-          */
-        Eigen::Matrix3d
-        getCov () const
-        {
-          return (cov_);
-        }
+    /** \brief Get the voxel covariance.
+     * \return covariance matrix
+     */
+    Eigen::Matrix3d getCov() const {
+      return (cov_);
+    }
 
-        /** \brief Get the inverse of the voxel covariance.
-          * \return inverse covariance matrix
-          */
-        Eigen::Matrix3d
-        getInverseCov () const
-        {
-          return (icov_);
-        }
+    /** \brief Get the inverse of the voxel covariance.
+     * \return inverse covariance matrix
+     */
+    Eigen::Matrix3d getInverseCov() const {
+      return (icov_);
+    }
 
-        /** \brief Get the voxel centroid.
-          * \return centroid
-          */
-        Eigen::Vector3d
-        getMean () const
-        {
-          return (mean_);
-        }
+    /** \brief Get the voxel centroid.
+     * \return centroid
+     */
+    Eigen::Vector3d getMean() const {
+      return (mean_);
+    }
 
-        /** \brief Get the eigen vectors of the voxel covariance.
-          * \note Order corresponds with \ref getEvals
-          * \return matrix whose columns contain eigen vectors
-          */
-        Eigen::Matrix3d
-        getEvecs () const
-        {
-          return (evecs_);
-        }
+    /** \brief Get the eigen vectors of the voxel covariance.
+     * \note Order corresponds with \ref getEvals
+     * \return matrix whose columns contain eigen vectors
+     */
+    Eigen::Matrix3d getEvecs() const {
+      return (evecs_);
+    }
 
-        /** \brief Get the eigen values of the voxel covariance.
-          * \note Order corresponds with \ref getEvecs
-          * \return vector of eigen values
-          */
-        Eigen::Vector3d
-        getEvals () const
-        {
-          return (evals_);
-        }
+    /** \brief Get the eigen values of the voxel covariance.
+     * \note Order corresponds with \ref getEvecs
+     * \return vector of eigen values
+     */
+    Eigen::Vector3d getEvals() const {
+      return (evals_);
+    }
 
-        /** \brief Get the number of points contained by this voxel.
-          * \return number of points
-          */
-        int
-        getPointCount () const
-        {
-          return (nr_points);
-        }
+    /** \brief Get the number of points contained by this voxel.
+     * \return number of points
+     */
+    int getPointCount() const {
+      return (nr_points);
+    }
 
-        /** \brief Number of points contained by voxel */
-        int nr_points;
+    /** \brief Number of points contained by voxel */
+    int nr_points;
 
-        /** \brief 3D voxel centroid */
-        Eigen::Vector3d mean_;
+    /** \brief 3D voxel centroid */
+    Eigen::Vector3d mean_;
 
-        /** \brief Nd voxel centroid
-         * \note Differs from \ref mean_ when color data is used
-         */
-        Eigen::VectorXf centroid;
+    /** \brief Nd voxel centroid
+     * \note Differs from \ref mean_ when color data is used
+     */
+    Eigen::VectorXf centroid;
 
-        /** \brief Voxel covariance matrix */
-        Eigen::Matrix3d cov_;
+    /** \brief Voxel covariance matrix */
+    Eigen::Matrix3d cov_;
 
-        /** \brief Inverse of voxel covariance matrix */
-        Eigen::Matrix3d icov_;
+    /** \brief Inverse of voxel covariance matrix */
+    Eigen::Matrix3d icov_;
 
-        /** \brief Eigen vectors of voxel covariance matrix */
-        Eigen::Matrix3d evecs_;
+    /** \brief Eigen vectors of voxel covariance matrix */
+    Eigen::Matrix3d evecs_;
 
-        /** \brief Eigen values of voxel covariance matrix */
-        Eigen::Vector3d evals_;
-
-      };
-
-      /** \brief Pointer to VoxelGridCovariance leaf structure */
-      typedef Leaf* LeafPtr;
-
-      /** \brief Const pointer to VoxelGridCovariance leaf structure */
-      typedef const Leaf* LeafConstPtr;
-
-    typedef std::map<size_t, Leaf> Map;
-
-    public:
-
-      /** \brief Constructor.
-       * Sets \ref leaf_size_ to 0 and \ref searchable_ to false.
-       */
-      VoxelGridCovariance () :
-        searchable_ (true),
-        min_points_per_voxel_ (6),
-        min_covar_eigvalue_mult_ (0.01),
-        leaves_ (),
-        voxel_centroids_ (),
-        voxel_centroids_leaf_indices_ (),
-        kdtree_ ()
-      {
-        downsample_all_data_ = false;
-        save_leaf_layout_ = false;
-        leaf_size_.setZero ();
-        min_b_.setZero ();
-        max_b_.setZero ();
-        filter_name_ = "VoxelGridCovariance";
-      }
-
-      /** \brief Set the minimum number of points required for a cell to be used (must be 3 or greater for covariance calculation).
-        * \param[in] min_points_per_voxel the minimum number of points for required for a voxel to be used
-        */
-      inline void
-      setMinPointPerVoxel (int min_points_per_voxel)
-      {
-        if(min_points_per_voxel > 2)
-        {
-          min_points_per_voxel_ = min_points_per_voxel;
-        }
-        else
-        {
-          PCL_WARN ("%s: Covariance calculation requires at least 3 points, setting Min Point per Voxel to 3 ", this->getClassName ().c_str ());
-          min_points_per_voxel_ = 3;
-        }
-      }
-
-      /** \brief Get the minimum number of points required for a cell to be used.
-        * \return the minimum number of points for required for a voxel to be used
-        */
-      inline int
-      getMinPointPerVoxel ()
-      {
-        return min_points_per_voxel_;
-      }
-
-      /** \brief Set the minimum allowable ratio between eigenvalues to prevent singular covariance matrices.
-        * \param[in] min_covar_eigvalue_mult the minimum allowable ratio between eigenvalues
-        */
-      inline void
-      setCovEigValueInflationRatio (double min_covar_eigvalue_mult)
-      {
-        min_covar_eigvalue_mult_ = min_covar_eigvalue_mult;
-      }
-
-      /** \brief Get the minimum allowable ratio between eigenvalues to prevent singular covariance matrices.
-        * \return the minimum allowable ratio between eigenvalues
-        */
-      inline double
-      getCovEigValueInflationRatio ()
-      {
-        return min_covar_eigvalue_mult_;
-      }
-
-      /** \brief Filter cloud and initializes voxel structure.
-       * \param[out] output cloud containing centroids of voxels containing a sufficient number of points
-       * \param[in] searchable flag if voxel structure is searchable, if true then kdtree is built
-       */
-      inline void
-      filter (PointCloud &output, bool searchable = false)
-      {
-        searchable_ = searchable;
-        applyFilter (output);
-
-        voxel_centroids_ = PointCloudPtr (new PointCloud (output));
-
-        if (searchable_ && voxel_centroids_->size() > 0)
-        {
-          // Initiates kdtree of the centroids of voxels containing a sufficient number of points
-          kdtree_.setInputCloud (voxel_centroids_);
-        }
-      }
-
-      /** \brief Initializes voxel structure.
-       * \param[in] searchable flag if voxel structure is searchable, if true then kdtree is built
-       */
-      inline void
-      filter (bool searchable = false)
-      {
-        searchable_ = searchable;
-        voxel_centroids_ = PointCloudPtr (new PointCloud);
-        applyFilter (*voxel_centroids_);
-
-        if (searchable_ && voxel_centroids_->size() > 0)
-        {
-          // Initiates kdtree of the centroids of voxels containing a sufficient number of points
-          kdtree_.setInputCloud (voxel_centroids_);
-        }
-      }
-
-      /** \brief Get the voxel containing point p.
-       * \param[in] index the index of the leaf structure node
-       * \return const pointer to leaf structure
-       */
-      inline LeafConstPtr
-      getLeaf (int index)
-      {
-        auto leaf_iter = leaves_.find (index);
-        if (leaf_iter != leaves_.end ())
-        {
-          LeafConstPtr ret (&(leaf_iter->second));
-          return ret;
-        }
-        else
-          return NULL;
-      }
-
-      /** \brief Get the voxel containing point p.
-       * \param[in] p the point to get the leaf structure at
-       * \return const pointer to leaf structure
-       */
-      inline LeafConstPtr
-      getLeaf (PointT &p)
-      {
-        // Generate index associated with p
-        int ijk0 = static_cast<int> (floor (p.x * inverse_leaf_size_[0]) - min_b_[0]);
-        int ijk1 = static_cast<int> (floor (p.y * inverse_leaf_size_[1]) - min_b_[1]);
-        int ijk2 = static_cast<int> (floor (p.z * inverse_leaf_size_[2]) - min_b_[2]);
-
-        // Compute the centroid leaf index
-        int idx = ijk0 * divb_mul_[0] + ijk1 * divb_mul_[1] + ijk2 * divb_mul_[2];
-
-        // Find leaf associated with index
-        auto leaf_iter = leaves_.find (idx);
-        if (leaf_iter != leaves_.end ())
-        {
-          // If such a leaf exists return the pointer to the leaf structure
-          LeafConstPtr ret (&(leaf_iter->second));
-          return ret;
-        }
-        else
-          return NULL;
-      }
-
-      /** \brief Get the voxel containing point p.
-       * \param[in] p the point to get the leaf structure at
-       * \return const pointer to leaf structure
-       */
-      inline LeafConstPtr
-      getLeaf (Eigen::Vector3f &p)
-      {
-        // Generate index associated with p
-        int ijk0 = static_cast<int> (floor (p[0] * inverse_leaf_size_[0]) - min_b_[0]);
-        int ijk1 = static_cast<int> (floor (p[1] * inverse_leaf_size_[1]) - min_b_[1]);
-        int ijk2 = static_cast<int> (floor (p[2] * inverse_leaf_size_[2]) - min_b_[2]);
-
-        // Compute the centroid leaf index
-        int idx = ijk0 * divb_mul_[0] + ijk1 * divb_mul_[1] + ijk2 * divb_mul_[2];
-
-        // Find leaf associated with index
-        auto leaf_iter = leaves_.find (idx);
-        if (leaf_iter != leaves_.end ())
-        {
-          // If such a leaf exists return the pointer to the leaf structure
-          LeafConstPtr ret (&(leaf_iter->second));
-          return ret;
-        }
-        else
-          return NULL;
-
-      }
-
-      /** \brief Get the voxels surrounding point p, not including the voxel containing point p.
-       * \note Only voxels containing a sufficient number of points are used (slower than radius search in practice).
-       * \param[in] reference_point the point to get the leaf structure at
-       * \param[out] neighbors
-       * \return number of neighbors found
-       */
-	  int getNeighborhoodAtPoint(const Eigen::MatrixXi&, const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const ;
-	  int getNeighborhoodAtPoint(const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const ;
-	  int getNeighborhoodAtPoint7(const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const ;
-	  int getNeighborhoodAtPoint1(const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const ;
-
-      /** \brief Get the leaf structure map
-       * \return a map containing all leaves
-       */
-      inline const Map&
-      getLeaves ()
-      {
-        return leaves_;
-      }
-
-      /** \brief Get a pointcloud containing the voxel centroids
-       * \note Only voxels containing a sufficient number of points are used.
-       * \return a map containing all leaves
-       */
-      inline PointCloudPtr
-      getCentroids ()
-      {
-        return voxel_centroids_;
-      }
-
-
-      /** \brief Get a cloud to visualize each voxels normal distribution.
-       * \param[out] cell_cloud a cloud created by sampling the normal distributions of each voxel
-       */
-      void
-      getDisplayCloud (pcl::PointCloud<pcl::PointXYZ>& cell_cloud);
-
-      /** \brief Search for the k-nearest occupied voxels for the given query point.
-       * \note Only voxels containing a sufficient number of points are used.
-       * \param[in] point the given query point
-       * \param[in] k the number of neighbors to search for
-       * \param[out] k_leaves the resultant leaves of the neighboring points
-       * \param[out] k_sqr_distances the resultant squared distances to the neighboring points
-       * \return number of neighbors found
-       */
-      int
-      nearestKSearch (const PointT &point, int k,
-                      std::vector<LeafConstPtr> &k_leaves, std::vector<float> &k_sqr_distances)
-      {
-        k_leaves.clear ();
-
-        // Check if kdtree has been built
-        if (!searchable_)
-        {
-          PCL_WARN ("%s: Not Searchable", this->getClassName ().c_str ());
-          return 0;
-        }
-
-        // Find k-nearest neighbors in the occupied voxel centroid cloud
-        std::vector<int> k_indices;
-        k = kdtree_.nearestKSearch (point, k, k_indices, k_sqr_distances);
-
-        // Find leaves corresponding to neighbors
-        k_leaves.reserve (k);
-        for (std::vector<int>::iterator iter = k_indices.begin (); iter != k_indices.end (); iter++)
-        {
-          k_leaves.push_back (&leaves_[voxel_centroids_leaf_indices_[*iter]]);
-        }
-        return k;
-      }
-
-      /** \brief Search for the k-nearest occupied voxels for the given query point.
-       * \note Only voxels containing a sufficient number of points are used.
-       * \param[in] cloud the given query point
-       * \param[in] index the index
-       * \param[in] k the number of neighbors to search for
-       * \param[out] k_leaves the resultant leaves of the neighboring points
-       * \param[out] k_sqr_distances the resultant squared distances to the neighboring points
-       * \return number of neighbors found
-       */
-      inline int
-      nearestKSearch (const PointCloud &cloud, int index, int k,
-                      std::vector<LeafConstPtr> &k_leaves, std::vector<float> &k_sqr_distances)
-      {
-        if (index >= static_cast<int> (cloud.points.size ()) || index < 0)
-          return (0);
-        return (nearestKSearch (cloud.points[index], k, k_leaves, k_sqr_distances));
-      }
-
-
-      /** \brief Search for all the nearest occupied voxels of the query point in a given radius.
-       * \note Only voxels containing a sufficient number of points are used.
-       * \param[in] point the given query point
-       * \param[in] radius the radius of the sphere bounding all of p_q's neighbors
-       * \param[out] k_leaves the resultant leaves of the neighboring points
-       * \param[out] k_sqr_distances the resultant squared distances to the neighboring points
-       * \param[in] max_nn
-       * \return number of neighbors found
-       */
-      int
-      radiusSearch (const PointT &point, double radius, std::vector<LeafConstPtr> &k_leaves,
-                    std::vector<float> &k_sqr_distances, unsigned int max_nn = 0) const
-      {
-        k_leaves.clear ();
-
-        // Check if kdtree has been built
-        if (!searchable_)
-        {
-          PCL_WARN ("%s: Not Searchable", this->getClassName ().c_str ());
-          return 0;
-        }
-
-        // Find neighbors within radius in the occupied voxel centroid cloud
-        std::vector<int> k_indices;
-        int k = kdtree_.radiusSearch (point, radius, k_indices, k_sqr_distances, max_nn);
-
-        // Find leaves corresponding to neighbors
-        k_leaves.reserve (k);
-        for (std::vector<int>::iterator iter = k_indices.begin (); iter != k_indices.end (); iter++)
-        {
-		  auto leaf = leaves_.find(voxel_centroids_leaf_indices_[*iter]);
-		  if (leaf == leaves_.end()) {
-			  std::cerr << "error : could not find the leaf corresponding to the voxel" << std::endl;
-			  std::cin.ignore(1);
-		  }
-          k_leaves.push_back (&(leaf->second));
-        }
-        return k;
-      }
-
-      /** \brief Search for all the nearest occupied voxels of the query point in a given radius.
-       * \note Only voxels containing a sufficient number of points are used.
-       * \param[in] cloud the given query point
-       * \param[in] index a valid index in cloud representing a valid (i.e., finite) query point
-       * \param[in] radius the radius of the sphere bounding all of p_q's neighbors
-       * \param[out] k_leaves the resultant leaves of the neighboring points
-       * \param[out] k_sqr_distances the resultant squared distances to the neighboring points
-       * \param[in] max_nn
-       * \return number of neighbors found
-       */
-      inline int
-      radiusSearch (const PointCloud &cloud, int index, double radius,
-                    std::vector<LeafConstPtr> &k_leaves, std::vector<float> &k_sqr_distances,
-                    unsigned int max_nn = 0) const
-      {
-        if (index >= static_cast<int> (cloud.points.size ()) || index < 0)
-          return (0);
-        return (radiusSearch (cloud.points[index], radius, k_leaves, k_sqr_distances, max_nn));
-      }
-
-    protected:
-
-      /** \brief Filter cloud and initializes voxel structure.
-       * \param[out] output cloud containing centroids of voxels containing a sufficient number of points
-       */
-      void applyFilter (PointCloud &output);
-
-      /** \brief Flag to determine if voxel structure is searchable. */
-      bool searchable_;
-
-      /** \brief Minimum points contained with in a voxel to allow it to be usable. */
-      int min_points_per_voxel_;
-
-      /** \brief Minimum allowable ratio between eigenvalues to prevent singular covariance matrices. */
-      double min_covar_eigvalue_mult_;
-
-      /** \brief Voxel structure containing all leaf nodes (includes voxels with less than a sufficient number of points). */
-	  Map leaves_;
-
-      /** \brief Point cloud containing centroids of voxels containing at least minimum number of points. */
-      PointCloudPtr voxel_centroids_;
-
-      /** \brief Indices of leaf structures associated with each point in \ref voxel_centroids_ (used for searching). */
-      std::vector<int> voxel_centroids_leaf_indices_;
-
-      /** \brief KdTree generated using \ref voxel_centroids_ (used for searching). */
-      pcl::KdTreeFLANN<PointT> kdtree_;
+    /** \brief Eigen values of voxel covariance matrix */
+    Eigen::Vector3d evals_;
   };
-}
 
-#endif  //#ifndef PCL_VOXEL_GRID_COVARIANCE_H_
+  /** \brief Pointer to VoxelGridCovariance leaf structure */
+  typedef Leaf *LeafPtr;
+
+  /** \brief Const pointer to VoxelGridCovariance leaf structure */
+  typedef const Leaf *LeafConstPtr;
+
+  typedef std::map<size_t, Leaf> Map;
+
+public:
+  /** \brief Constructor.
+   * Sets \ref leaf_size_ to 0 and \ref searchable_ to false.
+   */
+  VoxelGridCovariance() : searchable_(true), min_points_per_voxel_(6), min_covar_eigvalue_mult_(0.01), leaves_(), voxel_centroids_(), voxel_centroids_leaf_indices_(), kdtree_() {
+    downsample_all_data_ = false;
+    save_leaf_layout_ = false;
+    leaf_size_.setZero();
+    min_b_.setZero();
+    max_b_.setZero();
+    filter_name_ = "VoxelGridCovariance";
+  }
+
+  /** \brief Set the minimum number of points required for a cell to be used (must be 3 or greater for covariance calculation).
+   * \param[in] min_points_per_voxel the minimum number of points for required for a voxel to be used
+   */
+  inline void setMinPointPerVoxel(int min_points_per_voxel) {
+    if(min_points_per_voxel > 2) {
+      min_points_per_voxel_ = min_points_per_voxel;
+    } else {
+      PCL_WARN("%s: Covariance calculation requires at least 3 points, setting Min Point per Voxel to 3 ", this->getClassName().c_str());
+      min_points_per_voxel_ = 3;
+    }
+  }
+
+  /** \brief Get the minimum number of points required for a cell to be used.
+   * \return the minimum number of points for required for a voxel to be used
+   */
+  inline int getMinPointPerVoxel() {
+    return min_points_per_voxel_;
+  }
+
+  /** \brief Set the minimum allowable ratio between eigenvalues to prevent singular covariance matrices.
+   * \param[in] min_covar_eigvalue_mult the minimum allowable ratio between eigenvalues
+   */
+  inline void setCovEigValueInflationRatio(double min_covar_eigvalue_mult) {
+    min_covar_eigvalue_mult_ = min_covar_eigvalue_mult;
+  }
+
+  /** \brief Get the minimum allowable ratio between eigenvalues to prevent singular covariance matrices.
+   * \return the minimum allowable ratio between eigenvalues
+   */
+  inline double getCovEigValueInflationRatio() {
+    return min_covar_eigvalue_mult_;
+  }
+
+  /** \brief Filter cloud and initializes voxel structure.
+   * \param[out] output cloud containing centroids of voxels containing a sufficient number of points
+   * \param[in] searchable flag if voxel structure is searchable, if true then kdtree is built
+   */
+  inline void filter(PointCloud &output, bool searchable = false) {
+    searchable_ = searchable;
+    applyFilter(output);
+
+    voxel_centroids_ = PointCloudPtr(new PointCloud(output));
+
+    if(searchable_ && voxel_centroids_->size() > 0) {
+      // Initiates kdtree of the centroids of voxels containing a sufficient number of points
+      kdtree_.setInputCloud(voxel_centroids_);
+    }
+  }
+
+  /** \brief Initializes voxel structure.
+   * \param[in] searchable flag if voxel structure is searchable, if true then kdtree is built
+   */
+  inline void filter(bool searchable = false) {
+    searchable_ = searchable;
+    voxel_centroids_ = PointCloudPtr(new PointCloud);
+    applyFilter(*voxel_centroids_);
+
+    if(searchable_ && voxel_centroids_->size() > 0) {
+      // Initiates kdtree of the centroids of voxels containing a sufficient number of points
+      kdtree_.setInputCloud(voxel_centroids_);
+    }
+  }
+
+  /** \brief Get the voxel containing point p.
+   * \param[in] index the index of the leaf structure node
+   * \return const pointer to leaf structure
+   */
+  inline LeafConstPtr getLeaf(int index) {
+    auto leaf_iter = leaves_.find(index);
+    if(leaf_iter != leaves_.end()) {
+      LeafConstPtr ret(&(leaf_iter->second));
+      return ret;
+    } else
+      return NULL;
+  }
+
+  /** \brief Get the voxel containing point p.
+   * \param[in] p the point to get the leaf structure at
+   * \return const pointer to leaf structure
+   */
+  inline LeafConstPtr getLeaf(PointT &p) {
+    // Generate index associated with p
+    int ijk0 = static_cast<int>(floor(p.x * inverse_leaf_size_[0]) - min_b_[0]);
+    int ijk1 = static_cast<int>(floor(p.y * inverse_leaf_size_[1]) - min_b_[1]);
+    int ijk2 = static_cast<int>(floor(p.z * inverse_leaf_size_[2]) - min_b_[2]);
+
+    // Compute the centroid leaf index
+    int idx = ijk0 * divb_mul_[0] + ijk1 * divb_mul_[1] + ijk2 * divb_mul_[2];
+
+    // Find leaf associated with index
+    auto leaf_iter = leaves_.find(idx);
+    if(leaf_iter != leaves_.end()) {
+      // If such a leaf exists return the pointer to the leaf structure
+      LeafConstPtr ret(&(leaf_iter->second));
+      return ret;
+    } else
+      return NULL;
+  }
+
+  /** \brief Get the voxel containing point p.
+   * \param[in] p the point to get the leaf structure at
+   * \return const pointer to leaf structure
+   */
+  inline LeafConstPtr getLeaf(Eigen::Vector3f &p) {
+    // Generate index associated with p
+    int ijk0 = static_cast<int>(floor(p[0] * inverse_leaf_size_[0]) - min_b_[0]);
+    int ijk1 = static_cast<int>(floor(p[1] * inverse_leaf_size_[1]) - min_b_[1]);
+    int ijk2 = static_cast<int>(floor(p[2] * inverse_leaf_size_[2]) - min_b_[2]);
+
+    // Compute the centroid leaf index
+    int idx = ijk0 * divb_mul_[0] + ijk1 * divb_mul_[1] + ijk2 * divb_mul_[2];
+
+    // Find leaf associated with index
+    auto leaf_iter = leaves_.find(idx);
+    if(leaf_iter != leaves_.end()) {
+      // If such a leaf exists return the pointer to the leaf structure
+      LeafConstPtr ret(&(leaf_iter->second));
+      return ret;
+    } else
+      return NULL;
+  }
+
+  /** \brief Get the voxels surrounding point p, not including the voxel containing point p.
+   * \note Only voxels containing a sufficient number of points are used (slower than radius search in practice).
+   * \param[in] reference_point the point to get the leaf structure at
+   * \param[out] neighbors
+   * \return number of neighbors found
+   */
+  int getNeighborhoodAtPoint(const Eigen::MatrixXi &, const PointT &reference_point, std::vector<LeafConstPtr> &neighbors) const;
+  int getNeighborhoodAtPoint(const PointT &reference_point, std::vector<LeafConstPtr> &neighbors) const;
+  int getNeighborhoodAtPoint7(const PointT &reference_point, std::vector<LeafConstPtr> &neighbors) const;
+  int getNeighborhoodAtPoint1(const PointT &reference_point, std::vector<LeafConstPtr> &neighbors) const;
+
+  /** \brief Get the leaf structure map
+   * \return a map containing all leaves
+   */
+  inline const Map &getLeaves() {
+    return leaves_;
+  }
+
+  /** \brief Get a pointcloud containing the voxel centroids
+   * \note Only voxels containing a sufficient number of points are used.
+   * \return a map containing all leaves
+   */
+  inline PointCloudPtr getCentroids() {
+    return voxel_centroids_;
+  }
+
+  /** \brief Get a cloud to visualize each voxels normal distribution.
+   * \param[out] cell_cloud a cloud created by sampling the normal distributions of each voxel
+   */
+  void getDisplayCloud(pcl::PointCloud<pcl::PointXYZ> &cell_cloud);
+
+  /** \brief Search for the k-nearest occupied voxels for the given query point.
+   * \note Only voxels containing a sufficient number of points are used.
+   * \param[in] point the given query point
+   * \param[in] k the number of neighbors to search for
+   * \param[out] k_leaves the resultant leaves of the neighboring points
+   * \param[out] k_sqr_distances the resultant squared distances to the neighboring points
+   * \return number of neighbors found
+   */
+  int nearestKSearch(const PointT &point, int k, std::vector<LeafConstPtr> &k_leaves, std::vector<float> &k_sqr_distances) {
+    k_leaves.clear();
+
+    // Check if kdtree has been built
+    if(!searchable_) {
+      PCL_WARN("%s: Not Searchable", this->getClassName().c_str());
+      return 0;
+    }
+
+    // Find k-nearest neighbors in the occupied voxel centroid cloud
+    std::vector<int> k_indices;
+    k = kdtree_.nearestKSearch(point, k, k_indices, k_sqr_distances);
+
+    // Find leaves corresponding to neighbors
+    k_leaves.reserve(k);
+    for(std::vector<int>::iterator iter = k_indices.begin(); iter != k_indices.end(); iter++) {
+      k_leaves.push_back(&leaves_[voxel_centroids_leaf_indices_[*iter]]);
+    }
+    return k;
+  }
+
+  /** \brief Search for the k-nearest occupied voxels for the given query point.
+   * \note Only voxels containing a sufficient number of points are used.
+   * \param[in] cloud the given query point
+   * \param[in] index the index
+   * \param[in] k the number of neighbors to search for
+   * \param[out] k_leaves the resultant leaves of the neighboring points
+   * \param[out] k_sqr_distances the resultant squared distances to the neighboring points
+   * \return number of neighbors found
+   */
+  inline int nearestKSearch(const PointCloud &cloud, int index, int k, std::vector<LeafConstPtr> &k_leaves, std::vector<float> &k_sqr_distances) {
+    if(index >= static_cast<int>(cloud.points.size()) || index < 0) return (0);
+    return (nearestKSearch(cloud.points[index], k, k_leaves, k_sqr_distances));
+  }
+
+  /** \brief Search for all the nearest occupied voxels of the query point in a given radius.
+   * \note Only voxels containing a sufficient number of points are used.
+   * \param[in] point the given query point
+   * \param[in] radius the radius of the sphere bounding all of p_q's neighbors
+   * \param[out] k_leaves the resultant leaves of the neighboring points
+   * \param[out] k_sqr_distances the resultant squared distances to the neighboring points
+   * \param[in] max_nn
+   * \return number of neighbors found
+   */
+  int radiusSearch(const PointT &point, double radius, std::vector<LeafConstPtr> &k_leaves, std::vector<float> &k_sqr_distances, unsigned int max_nn = 0) const {
+    k_leaves.clear();
+
+    // Check if kdtree has been built
+    if(!searchable_) {
+      PCL_WARN("%s: Not Searchable", this->getClassName().c_str());
+      return 0;
+    }
+
+    // Find neighbors within radius in the occupied voxel centroid cloud
+    std::vector<int> k_indices;
+    int k = kdtree_.radiusSearch(point, radius, k_indices, k_sqr_distances, max_nn);
+
+    // Find leaves corresponding to neighbors
+    k_leaves.reserve(k);
+    for(std::vector<int>::iterator iter = k_indices.begin(); iter != k_indices.end(); iter++) {
+      auto leaf = leaves_.find(voxel_centroids_leaf_indices_[*iter]);
+      if(leaf == leaves_.end()) {
+        std::cerr << "error : could not find the leaf corresponding to the voxel" << std::endl;
+        std::cin.ignore(1);
+      }
+      k_leaves.push_back(&(leaf->second));
+    }
+    return k;
+  }
+
+  /** \brief Search for all the nearest occupied voxels of the query point in a given radius.
+   * \note Only voxels containing a sufficient number of points are used.
+   * \param[in] cloud the given query point
+   * \param[in] index a valid index in cloud representing a valid (i.e., finite) query point
+   * \param[in] radius the radius of the sphere bounding all of p_q's neighbors
+   * \param[out] k_leaves the resultant leaves of the neighboring points
+   * \param[out] k_sqr_distances the resultant squared distances to the neighboring points
+   * \param[in] max_nn
+   * \return number of neighbors found
+   */
+  inline int radiusSearch(const PointCloud &cloud, int index, double radius, std::vector<LeafConstPtr> &k_leaves, std::vector<float> &k_sqr_distances, unsigned int max_nn = 0) const {
+    if(index >= static_cast<int>(cloud.points.size()) || index < 0) return (0);
+    return (radiusSearch(cloud.points[index], radius, k_leaves, k_sqr_distances, max_nn));
+  }
+
+protected:
+  /** \brief Filter cloud and initializes voxel structure.
+   * \param[out] output cloud containing centroids of voxels containing a sufficient number of points
+   */
+  void applyFilter(PointCloud &output);
+
+  /** \brief Flag to determine if voxel structure is searchable. */
+  bool searchable_;
+
+  /** \brief Minimum points contained with in a voxel to allow it to be usable. */
+  int min_points_per_voxel_;
+
+  /** \brief Minimum allowable ratio between eigenvalues to prevent singular covariance matrices. */
+  double min_covar_eigvalue_mult_;
+
+  /** \brief Voxel structure containing all leaf nodes (includes voxels with less than a sufficient number of points). */
+  Map leaves_;
+
+  /** \brief Point cloud containing centroids of voxels containing at least minimum number of points. */
+  PointCloudPtr voxel_centroids_;
+
+  /** \brief Indices of leaf structures associated with each point in \ref voxel_centroids_ (used for searching). */
+  std::vector<int> voxel_centroids_leaf_indices_;
+
+  /** \brief KdTree generated using \ref voxel_centroids_ (used for searching). */
+  pcl::KdTreeFLANN<PointT> kdtree_;
+};
+}  // namespace pclomp
+
+#endif  // #ifndef PCL_VOXEL_GRID_COVARIANCE_H_

--- a/include/pclomp/voxel_grid_covariance_omp_impl.hpp
+++ b/include/pclomp/voxel_grid_covariance_omp_impl.hpp
@@ -45,218 +45,186 @@
 #include <Eigen/Cholesky>
 
 //////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointT> void
-pclomp::VoxelGridCovariance<PointT>::applyFilter (PointCloud &output)
-{
-  voxel_centroids_leaf_indices_.clear ();
+template<typename PointT>
+void pclomp::VoxelGridCovariance<PointT>::applyFilter(PointCloud& output) {
+  voxel_centroids_leaf_indices_.clear();
 
   // Has the input dataset been set already?
-  if (!input_)
-  {
-    PCL_WARN ("[pcl::%s::applyFilter] No input dataset given!\n", getClassName ().c_str ());
+  if(!input_) {
+    PCL_WARN("[pcl::%s::applyFilter] No input dataset given!\n", getClassName().c_str());
     output.width = output.height = 0;
-    output.points.clear ();
+    output.points.clear();
     return;
   }
 
   // Copy the header (and thus the frame_id) + allocate enough space for points
-  output.height = 1;                          // downsampling breaks the organized structure
-  output.is_dense = true;                     // we filter out invalid points
-  output.points.clear ();
+  output.height = 1;       // downsampling breaks the organized structure
+  output.is_dense = true;  // we filter out invalid points
+  output.points.clear();
 
   Eigen::Vector4f min_p, max_p;
   // Get the minimum and maximum dimensions
-  if (!filter_field_name_.empty ()) // If we don't want to process the entire cloud...
-      pcl::getMinMax3D<PointT> (input_, filter_field_name_, static_cast<float> (filter_limit_min_), static_cast<float> (filter_limit_max_), min_p, max_p, filter_limit_negative_);
+  if(!filter_field_name_.empty())  // If we don't want to process the entire cloud...
+    pcl::getMinMax3D<PointT>(input_, filter_field_name_, static_cast<float>(filter_limit_min_), static_cast<float>(filter_limit_max_), min_p, max_p, filter_limit_negative_);
   else
-	  pcl::getMinMax3D<PointT> (*input_, min_p, max_p);
+    pcl::getMinMax3D<PointT>(*input_, min_p, max_p);
 
   // Check that the leaf size is not too small, given the size of the data
-  int64_t dx = static_cast<int64_t>((max_p[0] - min_p[0]) * inverse_leaf_size_[0])+1;
-  int64_t dy = static_cast<int64_t>((max_p[1] - min_p[1]) * inverse_leaf_size_[1])+1;
-  int64_t dz = static_cast<int64_t>((max_p[2] - min_p[2]) * inverse_leaf_size_[2])+1;
+  int64_t dx = static_cast<int64_t>((max_p[0] - min_p[0]) * inverse_leaf_size_[0]) + 1;
+  int64_t dy = static_cast<int64_t>((max_p[1] - min_p[1]) * inverse_leaf_size_[1]) + 1;
+  int64_t dz = static_cast<int64_t>((max_p[2] - min_p[2]) * inverse_leaf_size_[2]) + 1;
 
-  if((dx*dy*dz) > std::numeric_limits<int32_t>::max())
-  {
+  if((dx * dy * dz) > std::numeric_limits<int32_t>::max()) {
     PCL_WARN("[pcl::%s::applyFilter] Leaf size is too small for the input dataset. Integer indices would overflow.", getClassName().c_str());
     output.clear();
     return;
   }
 
   // Compute the minimum and maximum bounding box values
-  min_b_[0] = static_cast<int> (floor (min_p[0] * inverse_leaf_size_[0]));
-  max_b_[0] = static_cast<int> (floor (max_p[0] * inverse_leaf_size_[0]));
-  min_b_[1] = static_cast<int> (floor (min_p[1] * inverse_leaf_size_[1]));
-  max_b_[1] = static_cast<int> (floor (max_p[1] * inverse_leaf_size_[1]));
-  min_b_[2] = static_cast<int> (floor (min_p[2] * inverse_leaf_size_[2]));
-  max_b_[2] = static_cast<int> (floor (max_p[2] * inverse_leaf_size_[2]));
+  min_b_[0] = static_cast<int>(floor(min_p[0] * inverse_leaf_size_[0]));
+  max_b_[0] = static_cast<int>(floor(max_p[0] * inverse_leaf_size_[0]));
+  min_b_[1] = static_cast<int>(floor(min_p[1] * inverse_leaf_size_[1]));
+  max_b_[1] = static_cast<int>(floor(max_p[1] * inverse_leaf_size_[1]));
+  min_b_[2] = static_cast<int>(floor(min_p[2] * inverse_leaf_size_[2]));
+  max_b_[2] = static_cast<int>(floor(max_p[2] * inverse_leaf_size_[2]));
 
   // Compute the number of divisions needed along all axis
-  div_b_ = max_b_ - min_b_ + Eigen::Vector4i::Ones ();
+  div_b_ = max_b_ - min_b_ + Eigen::Vector4i::Ones();
   div_b_[3] = 0;
 
   // Clear the leaves
-  leaves_.clear ();
-//  leaves_.reserve(8192);
+  leaves_.clear();
+  //  leaves_.reserve(8192);
 
   // Set up the division multiplier
-  divb_mul_ = Eigen::Vector4i (1, div_b_[0], div_b_[0] * div_b_[1], 0);
+  divb_mul_ = Eigen::Vector4i(1, div_b_[0], div_b_[0] * div_b_[1], 0);
 
   int centroid_size = 4;
 
-  if (downsample_all_data_)
-    centroid_size = boost::mpl::size<FieldList>::value;
+  if(downsample_all_data_) centroid_size = boost::mpl::size<FieldList>::value;
 
   // ---[ RGB special case
   std::vector<pcl::PCLPointField> fields;
   int rgba_index = -1;
-  rgba_index = pcl::getFieldIndex<PointT> ("rgb", fields);
-  if (rgba_index == -1)
-    rgba_index = pcl::getFieldIndex<PointT> ("rgba", fields);
-  if (rgba_index >= 0)
-  {
+  rgba_index = pcl::getFieldIndex<PointT>("rgb", fields);
+  if(rgba_index == -1) rgba_index = pcl::getFieldIndex<PointT>("rgba", fields);
+  if(rgba_index >= 0) {
     rgba_index = fields[rgba_index].offset;
     centroid_size += 3;
   }
 
   // If we don't want to process the entire cloud, but rather filter points far away from the viewpoint first...
-  if (!filter_field_name_.empty ())
-  {
+  if(!filter_field_name_.empty()) {
     // Get the distance field index
     std::vector<pcl::PCLPointField> fields;
-    int distance_idx = pcl::getFieldIndex<PointT> (filter_field_name_, fields);
-    if (distance_idx == -1)
-      PCL_WARN ("[pcl::%s::applyFilter] Invalid filter field name. Index is %d.\n", getClassName ().c_str (), distance_idx);
+    int distance_idx = pcl::getFieldIndex<PointT>(filter_field_name_, fields);
+    if(distance_idx == -1) PCL_WARN("[pcl::%s::applyFilter] Invalid filter field name. Index is %d.\n", getClassName().c_str(), distance_idx);
 
     // First pass: go over all points and insert them into the right leaf
-    for (size_t cp = 0; cp < input_->points.size (); ++cp)
-    {
-      if (!input_->is_dense)
+    for(size_t cp = 0; cp < input_->points.size(); ++cp) {
+      if(!input_->is_dense)
         // Check if the point is invalid
-        if (!std::isfinite (input_->points[cp].x) ||
-            !std::isfinite (input_->points[cp].y) ||
-            !std::isfinite (input_->points[cp].z))
-          continue;
+        if(!std::isfinite(input_->points[cp].x) || !std::isfinite(input_->points[cp].y) || !std::isfinite(input_->points[cp].z)) continue;
 
       // Get the distance value
-      const uint8_t* pt_data = reinterpret_cast<const uint8_t*> (&input_->points[cp]);
+      const uint8_t* pt_data = reinterpret_cast<const uint8_t*>(&input_->points[cp]);
       float distance_value = 0;
-      memcpy (&distance_value, pt_data + fields[distance_idx].offset, sizeof (float));
+      memcpy(&distance_value, pt_data + fields[distance_idx].offset, sizeof(float));
 
-      if (filter_limit_negative_)
-      {
+      if(filter_limit_negative_) {
         // Use a threshold for cutting out points which inside the interval
-        if ((distance_value < filter_limit_max_) && (distance_value > filter_limit_min_))
-          continue;
-      }
-      else
-      {
+        if((distance_value < filter_limit_max_) && (distance_value > filter_limit_min_)) continue;
+      } else {
         // Use a threshold for cutting out points which are too close/far away
-        if ((distance_value > filter_limit_max_) || (distance_value < filter_limit_min_))
-          continue;
+        if((distance_value > filter_limit_max_) || (distance_value < filter_limit_min_)) continue;
       }
 
-      int ijk0 = static_cast<int> (floor (input_->points[cp].x * inverse_leaf_size_[0]) - static_cast<float> (min_b_[0]));
-      int ijk1 = static_cast<int> (floor (input_->points[cp].y * inverse_leaf_size_[1]) - static_cast<float> (min_b_[1]));
-      int ijk2 = static_cast<int> (floor (input_->points[cp].z * inverse_leaf_size_[2]) - static_cast<float> (min_b_[2]));
+      int ijk0 = static_cast<int>(floor(input_->points[cp].x * inverse_leaf_size_[0]) - static_cast<float>(min_b_[0]));
+      int ijk1 = static_cast<int>(floor(input_->points[cp].y * inverse_leaf_size_[1]) - static_cast<float>(min_b_[1]));
+      int ijk2 = static_cast<int>(floor(input_->points[cp].z * inverse_leaf_size_[2]) - static_cast<float>(min_b_[2]));
 
       // Compute the centroid leaf index
       int idx = ijk0 * divb_mul_[0] + ijk1 * divb_mul_[1] + ijk2 * divb_mul_[2];
 
       Leaf& leaf = leaves_[idx];
-      if (leaf.nr_points == 0)
-      {
-        leaf.centroid.resize (centroid_size);
-        leaf.centroid.setZero ();
+      if(leaf.nr_points == 0) {
+        leaf.centroid.resize(centroid_size);
+        leaf.centroid.setZero();
       }
 
-      Eigen::Vector3d pt3d (input_->points[cp].x, input_->points[cp].y, input_->points[cp].z);
+      Eigen::Vector3d pt3d(input_->points[cp].x, input_->points[cp].y, input_->points[cp].z);
       // Accumulate point sum for centroid calculation
       leaf.mean_ += pt3d;
       // Accumulate x*xT for single pass covariance calculation
-      leaf.cov_ += pt3d * pt3d.transpose ();
+      leaf.cov_ += pt3d * pt3d.transpose();
 
       // Do we need to process all the fields?
-      if (!downsample_all_data_)
-      {
-        Eigen::Vector4f pt (input_->points[cp].x, input_->points[cp].y, input_->points[cp].z, 0);
-        leaf.centroid.template head<4> () += pt;
-      }
-      else
-      {
+      if(!downsample_all_data_) {
+        Eigen::Vector4f pt(input_->points[cp].x, input_->points[cp].y, input_->points[cp].z, 0);
+        leaf.centroid.template head<4>() += pt;
+      } else {
         // Copy all the fields
-        Eigen::VectorXf centroid = Eigen::VectorXf::Zero (centroid_size);
+        Eigen::VectorXf centroid = Eigen::VectorXf::Zero(centroid_size);
         // ---[ RGB special case
-        if (rgba_index >= 0)
-        {
+        if(rgba_index >= 0) {
           // fill r/g/b data
           int rgb;
-          memcpy (&rgb, reinterpret_cast<const char*> (&input_->points[cp]) + rgba_index, sizeof (int));
-          centroid[centroid_size - 3] = static_cast<float> ((rgb >> 16) & 0x0000ff);
-          centroid[centroid_size - 2] = static_cast<float> ((rgb >> 8) & 0x0000ff);
-          centroid[centroid_size - 1] = static_cast<float> ((rgb) & 0x0000ff);
+          memcpy(&rgb, reinterpret_cast<const char*>(&input_->points[cp]) + rgba_index, sizeof(int));
+          centroid[centroid_size - 3] = static_cast<float>((rgb >> 16) & 0x0000ff);
+          centroid[centroid_size - 2] = static_cast<float>((rgb >> 8) & 0x0000ff);
+          centroid[centroid_size - 1] = static_cast<float>((rgb)&0x0000ff);
         }
-        pcl::for_each_type<FieldList> (pcl::NdCopyPointEigenFunctor<PointT> (input_->points[cp], centroid));
+        pcl::for_each_type<FieldList>(pcl::NdCopyPointEigenFunctor<PointT>(input_->points[cp], centroid));
         leaf.centroid += centroid;
       }
       ++leaf.nr_points;
     }
   }
   // No distance filtering, process all data
-  else
-  {
+  else {
     // First pass: go over all points and insert them into the right leaf
-    for (size_t cp = 0; cp < input_->points.size (); ++cp)
-    {
-      if (!input_->is_dense)
+    for(size_t cp = 0; cp < input_->points.size(); ++cp) {
+      if(!input_->is_dense)
         // Check if the point is invalid
-        if (!std::isfinite (input_->points[cp].x) ||
-            !std::isfinite (input_->points[cp].y) ||
-            !std::isfinite (input_->points[cp].z))
-          continue;
+        if(!std::isfinite(input_->points[cp].x) || !std::isfinite(input_->points[cp].y) || !std::isfinite(input_->points[cp].z)) continue;
 
-      int ijk0 = static_cast<int> (floor (input_->points[cp].x * inverse_leaf_size_[0]) - static_cast<float> (min_b_[0]));
-      int ijk1 = static_cast<int> (floor (input_->points[cp].y * inverse_leaf_size_[1]) - static_cast<float> (min_b_[1]));
-      int ijk2 = static_cast<int> (floor (input_->points[cp].z * inverse_leaf_size_[2]) - static_cast<float> (min_b_[2]));
+      int ijk0 = static_cast<int>(floor(input_->points[cp].x * inverse_leaf_size_[0]) - static_cast<float>(min_b_[0]));
+      int ijk1 = static_cast<int>(floor(input_->points[cp].y * inverse_leaf_size_[1]) - static_cast<float>(min_b_[1]));
+      int ijk2 = static_cast<int>(floor(input_->points[cp].z * inverse_leaf_size_[2]) - static_cast<float>(min_b_[2]));
 
       // Compute the centroid leaf index
       int idx = ijk0 * divb_mul_[0] + ijk1 * divb_mul_[1] + ijk2 * divb_mul_[2];
 
-      //int idx = (((input_->points[cp].getArray4fmap () * inverse_leaf_size_).template cast<int> ()).matrix () - min_b_).dot (divb_mul_);
+      // int idx = (((input_->points[cp].getArray4fmap () * inverse_leaf_size_).template cast<int> ()).matrix () - min_b_).dot (divb_mul_);
       Leaf& leaf = leaves_[idx];
-      if (leaf.nr_points == 0)
-      {
-        leaf.centroid.resize (centroid_size);
-        leaf.centroid.setZero ();
+      if(leaf.nr_points == 0) {
+        leaf.centroid.resize(centroid_size);
+        leaf.centroid.setZero();
       }
 
-      Eigen::Vector3d pt3d (input_->points[cp].x, input_->points[cp].y, input_->points[cp].z);
+      Eigen::Vector3d pt3d(input_->points[cp].x, input_->points[cp].y, input_->points[cp].z);
       // Accumulate point sum for centroid calculation
       leaf.mean_ += pt3d;
       // Accumulate x*xT for single pass covariance calculation
-      leaf.cov_ += pt3d * pt3d.transpose ();
+      leaf.cov_ += pt3d * pt3d.transpose();
 
       // Do we need to process all the fields?
-      if (!downsample_all_data_)
-      {
-        Eigen::Vector4f pt (input_->points[cp].x, input_->points[cp].y, input_->points[cp].z, 0);
-        leaf.centroid.template head<4> () += pt;
-      }
-      else
-      {
+      if(!downsample_all_data_) {
+        Eigen::Vector4f pt(input_->points[cp].x, input_->points[cp].y, input_->points[cp].z, 0);
+        leaf.centroid.template head<4>() += pt;
+      } else {
         // Copy all the fields
-        Eigen::VectorXf centroid = Eigen::VectorXf::Zero (centroid_size);
+        Eigen::VectorXf centroid = Eigen::VectorXf::Zero(centroid_size);
         // ---[ RGB special case
-        if (rgba_index >= 0)
-        {
+        if(rgba_index >= 0) {
           // Fill r/g/b data, assuming that the order is BGRA
           int rgb;
-          memcpy (&rgb, reinterpret_cast<const char*> (&input_->points[cp]) + rgba_index, sizeof (int));
-          centroid[centroid_size - 3] = static_cast<float> ((rgb >> 16) & 0x0000ff);
-          centroid[centroid_size - 2] = static_cast<float> ((rgb >> 8) & 0x0000ff);
-          centroid[centroid_size - 1] = static_cast<float> ((rgb) & 0x0000ff);
+          memcpy(&rgb, reinterpret_cast<const char*>(&input_->points[cp]) + rgba_index, sizeof(int));
+          centroid[centroid_size - 3] = static_cast<float>((rgb >> 16) & 0x0000ff);
+          centroid[centroid_size - 2] = static_cast<float>((rgb >> 8) & 0x0000ff);
+          centroid[centroid_size - 1] = static_cast<float>((rgb)&0x0000ff);
         }
-        pcl::for_each_type<FieldList> (pcl::NdCopyPointEigenFunctor<PointT> (input_->points[cp], centroid));
+        pcl::for_each_type<FieldList>(pcl::NdCopyPointEigenFunctor<PointT>(input_->points[cp], centroid));
         leaf.centroid += centroid;
       }
       ++leaf.nr_points;
@@ -264,12 +232,10 @@ pclomp::VoxelGridCovariance<PointT>::applyFilter (PointCloud &output)
   }
 
   // Second pass: go over all leaves and compute centroids and covariance matrices
-  output.points.reserve (leaves_.size ());
-  if (searchable_)
-    voxel_centroids_leaf_indices_.reserve (leaves_.size ());
+  output.points.reserve(leaves_.size());
+  if(searchable_) voxel_centroids_leaf_indices_.reserve(leaves_.size());
   int cp = 0;
-  if (save_leaf_layout_)
-    leaf_layout_.resize (div_b_[0] * div_b_[1] * div_b_[2], -1);
+  if(save_leaf_layout_) leaf_layout_.resize(div_b_[0] * div_b_[1] * div_b_[2], -1);
 
   // Eigen values and vectors calculated to prevent near singular matrices
   Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> eigensolver;
@@ -279,14 +245,12 @@ pclomp::VoxelGridCovariance<PointT>::applyFilter (PointCloud &output)
   // Eigen values less than a threshold of max eigen value are inflated to a set fraction of the max eigen value.
   double min_covar_eigvalue;
 
-  for (auto it = leaves_.begin (); it != leaves_.end (); ++it)
-  {
-
+  for(auto it = leaves_.begin(); it != leaves_.end(); ++it) {
     // Normalize the centroid
     Leaf& leaf = it->second;
 
     // Normalize the centroid
-    leaf.centroid /= static_cast<float> (leaf.nr_points);
+    leaf.centroid /= static_cast<float>(leaf.nr_points);
     // Point sum used for single pass covariance calculation
     pt_sum = leaf.mean_;
     // Normalize mean
@@ -294,165 +258,139 @@ pclomp::VoxelGridCovariance<PointT>::applyFilter (PointCloud &output)
 
     // If the voxel contains sufficient points, its covariance is calculated and is added to the voxel centroids and output clouds.
     // Points with less than the minimum points will have a can not be accurately approximated using a normal distribution.
-    if (leaf.nr_points >= min_points_per_voxel_)
-    {
-      if (save_leaf_layout_)
-        leaf_layout_[it->first] = cp++;
+    if(leaf.nr_points >= min_points_per_voxel_) {
+      if(save_leaf_layout_) leaf_layout_[it->first] = cp++;
 
-      output.push_back (PointT ());
+      output.push_back(PointT());
 
       // Do we need to process all the fields?
-      if (!downsample_all_data_)
-      {
-        output.points.back ().x = leaf.centroid[0];
-        output.points.back ().y = leaf.centroid[1];
-        output.points.back ().z = leaf.centroid[2];
-      }
-      else
-      {
-        pcl::for_each_type<FieldList> (pcl::NdCopyEigenPointFunctor<PointT> (leaf.centroid, output.back ()));
+      if(!downsample_all_data_) {
+        output.points.back().x = leaf.centroid[0];
+        output.points.back().y = leaf.centroid[1];
+        output.points.back().z = leaf.centroid[2];
+      } else {
+        pcl::for_each_type<FieldList>(pcl::NdCopyEigenPointFunctor<PointT>(leaf.centroid, output.back()));
         // ---[ RGB special case
-        if (rgba_index >= 0)
-        {
+        if(rgba_index >= 0) {
           // pack r/g/b into rgb
           float r = leaf.centroid[centroid_size - 3], g = leaf.centroid[centroid_size - 2], b = leaf.centroid[centroid_size - 1];
-          int rgb = (static_cast<int> (r)) << 16 | (static_cast<int> (g)) << 8 | (static_cast<int> (b));
-          memcpy (reinterpret_cast<char*> (&output.points.back ()) + rgba_index, &rgb, sizeof (float));
+          int rgb = (static_cast<int>(r)) << 16 | (static_cast<int>(g)) << 8 | (static_cast<int>(b));
+          memcpy(reinterpret_cast<char*>(&output.points.back()) + rgba_index, &rgb, sizeof(float));
         }
       }
 
       // Stores the voxel indices for fast access searching
-      if (searchable_)
-        voxel_centroids_leaf_indices_.push_back (static_cast<int> (it->first));
+      if(searchable_) voxel_centroids_leaf_indices_.push_back(static_cast<int>(it->first));
 
       // Single pass covariance calculation
-      leaf.cov_ = (leaf.cov_ - 2 * (pt_sum * leaf.mean_.transpose ())) / leaf.nr_points + leaf.mean_ * leaf.mean_.transpose ();
+      leaf.cov_ = (leaf.cov_ - 2 * (pt_sum * leaf.mean_.transpose())) / leaf.nr_points + leaf.mean_ * leaf.mean_.transpose();
       leaf.cov_ *= (leaf.nr_points - 1.0) / leaf.nr_points;
 
-      //Normalize Eigen Val such that max no more than 100x min.
-      eigensolver.compute (leaf.cov_);
-      eigen_val = eigensolver.eigenvalues ().asDiagonal ();
-      leaf.evecs_ = eigensolver.eigenvectors ();
+      // Normalize Eigen Val such that max no more than 100x min.
+      eigensolver.compute(leaf.cov_);
+      eigen_val = eigensolver.eigenvalues().asDiagonal();
+      leaf.evecs_ = eigensolver.eigenvectors();
 
-      if (eigen_val (0, 0) < 0 || eigen_val (1, 1) < 0 || eigen_val (2, 2) <= 0)
-      {
+      if(eigen_val(0, 0) < 0 || eigen_val(1, 1) < 0 || eigen_val(2, 2) <= 0) {
         leaf.nr_points = -1;
         continue;
       }
 
       // Avoids matrices near singularities (eq 6.11)[Magnusson 2009]
 
-      min_covar_eigvalue = min_covar_eigvalue_mult_ * eigen_val (2, 2);
-      if (eigen_val (0, 0) < min_covar_eigvalue)
-      {
-        eigen_val (0, 0) = min_covar_eigvalue;
+      min_covar_eigvalue = min_covar_eigvalue_mult_ * eigen_val(2, 2);
+      if(eigen_val(0, 0) < min_covar_eigvalue) {
+        eigen_val(0, 0) = min_covar_eigvalue;
 
-        if (eigen_val (1, 1) < min_covar_eigvalue)
-        {
-          eigen_val (1, 1) = min_covar_eigvalue;
+        if(eigen_val(1, 1) < min_covar_eigvalue) {
+          eigen_val(1, 1) = min_covar_eigvalue;
         }
 
-        leaf.cov_ = leaf.evecs_ * eigen_val * leaf.evecs_.inverse ();
+        leaf.cov_ = leaf.evecs_ * eigen_val * leaf.evecs_.inverse();
       }
-      leaf.evals_ = eigen_val.diagonal ();
+      leaf.evals_ = eigen_val.diagonal();
 
-      leaf.icov_ = leaf.cov_.inverse ();
-      if (leaf.icov_.maxCoeff () == std::numeric_limits<float>::infinity ( )
-          || leaf.icov_.minCoeff () == -std::numeric_limits<float>::infinity ( ) )
-      {
+      leaf.icov_ = leaf.cov_.inverse();
+      if(leaf.icov_.maxCoeff() == std::numeric_limits<float>::infinity() || leaf.icov_.minCoeff() == -std::numeric_limits<float>::infinity()) {
         leaf.nr_points = -1;
       }
-
     }
   }
 
-  output.width = static_cast<uint32_t> (output.points.size ());
+  output.width = static_cast<uint32_t>(output.points.size());
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointT> int
-pclomp::VoxelGridCovariance<PointT>::getNeighborhoodAtPoint(const Eigen::MatrixXi& relative_coordinates, const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const
-{
-	neighbors.clear();
+template<typename PointT>
+int pclomp::VoxelGridCovariance<PointT>::getNeighborhoodAtPoint(const Eigen::MatrixXi& relative_coordinates, const PointT& reference_point, std::vector<LeafConstPtr>& neighbors) const {
+  neighbors.clear();
 
-	// Find displacement coordinates
-	Eigen::Vector4i ijk(static_cast<int> (floor(reference_point.x / leaf_size_[0])),
-		static_cast<int> (floor(reference_point.y / leaf_size_[1])),
-		static_cast<int> (floor(reference_point.z / leaf_size_[2])), 0);
-	Eigen::Array4i diff2min = min_b_ - ijk;
-	Eigen::Array4i diff2max = max_b_ - ijk;
-	neighbors.reserve(relative_coordinates.cols());
+  // Find displacement coordinates
+  Eigen::Vector4i ijk(static_cast<int>(floor(reference_point.x / leaf_size_[0])), static_cast<int>(floor(reference_point.y / leaf_size_[1])), static_cast<int>(floor(reference_point.z / leaf_size_[2])), 0);
+  Eigen::Array4i diff2min = min_b_ - ijk;
+  Eigen::Array4i diff2max = max_b_ - ijk;
+  neighbors.reserve(relative_coordinates.cols());
 
-	// Check each neighbor to see if it is occupied and contains sufficient points
-	// Slower than radius search because needs to check 26 indices
-	for (int ni = 0; ni < relative_coordinates.cols(); ni++)
-	{
-		Eigen::Vector4i displacement = (Eigen::Vector4i() << relative_coordinates.col(ni), 0).finished();
-		// Checking if the specified cell is in the grid
-		if ((diff2min <= displacement.array()).all() && (diff2max >= displacement.array()).all())
-		{
-			auto leaf_iter = leaves_.find(((ijk + displacement - min_b_).dot(divb_mul_)));
-			if (leaf_iter != leaves_.end() && leaf_iter->second.nr_points >= min_points_per_voxel_)
-			{
-				LeafConstPtr leaf = &(leaf_iter->second);
-				neighbors.push_back(leaf);
-			}
-		}
-	}
+  // Check each neighbor to see if it is occupied and contains sufficient points
+  // Slower than radius search because needs to check 26 indices
+  for(int ni = 0; ni < relative_coordinates.cols(); ni++) {
+    Eigen::Vector4i displacement = (Eigen::Vector4i() << relative_coordinates.col(ni), 0).finished();
+    // Checking if the specified cell is in the grid
+    if((diff2min <= displacement.array()).all() && (diff2max >= displacement.array()).all()) {
+      auto leaf_iter = leaves_.find(((ijk + displacement - min_b_).dot(divb_mul_)));
+      if(leaf_iter != leaves_.end() && leaf_iter->second.nr_points >= min_points_per_voxel_) {
+        LeafConstPtr leaf = &(leaf_iter->second);
+        neighbors.push_back(leaf);
+      }
+    }
+  }
 
-	return (static_cast<int> (neighbors.size()));
+  return (static_cast<int>(neighbors.size()));
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointT> int
-pclomp::VoxelGridCovariance<PointT>::getNeighborhoodAtPoint(const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const
-{
-	neighbors.clear();
+template<typename PointT>
+int pclomp::VoxelGridCovariance<PointT>::getNeighborhoodAtPoint(const PointT& reference_point, std::vector<LeafConstPtr>& neighbors) const {
+  neighbors.clear();
 
-	// Find displacement coordinates
-	Eigen::MatrixXi relative_coordinates = pcl::getAllNeighborCellIndices();
-	return getNeighborhoodAtPoint(relative_coordinates, reference_point, neighbors);
+  // Find displacement coordinates
+  Eigen::MatrixXi relative_coordinates = pcl::getAllNeighborCellIndices();
+  return getNeighborhoodAtPoint(relative_coordinates, reference_point, neighbors);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointT> int
-pclomp::VoxelGridCovariance<PointT>::getNeighborhoodAtPoint7(const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const
-{
-	neighbors.clear();
+template<typename PointT>
+int pclomp::VoxelGridCovariance<PointT>::getNeighborhoodAtPoint7(const PointT& reference_point, std::vector<LeafConstPtr>& neighbors) const {
+  neighbors.clear();
 
-	Eigen::MatrixXi relative_coordinates(3, 7);
-	relative_coordinates.setZero();
-	relative_coordinates(0, 1) = 1;
-	relative_coordinates(0, 2) = -1;
-	relative_coordinates(1, 3) = 1;
-	relative_coordinates(1, 4) = -1;
-	relative_coordinates(2, 5) = 1;
-	relative_coordinates(2, 6) = -1;
+  Eigen::MatrixXi relative_coordinates(3, 7);
+  relative_coordinates.setZero();
+  relative_coordinates(0, 1) = 1;
+  relative_coordinates(0, 2) = -1;
+  relative_coordinates(1, 3) = 1;
+  relative_coordinates(1, 4) = -1;
+  relative_coordinates(2, 5) = 1;
+  relative_coordinates(2, 6) = -1;
 
-	return getNeighborhoodAtPoint(relative_coordinates, reference_point, neighbors);
+  return getNeighborhoodAtPoint(relative_coordinates, reference_point, neighbors);
 }
 
-
 //////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointT> int
-pclomp::VoxelGridCovariance<PointT>::getNeighborhoodAtPoint1(const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const
-{
-	neighbors.clear();
-	return getNeighborhoodAtPoint(Eigen::MatrixXi::Zero(3,1), reference_point, neighbors);
+template<typename PointT>
+int pclomp::VoxelGridCovariance<PointT>::getNeighborhoodAtPoint1(const PointT& reference_point, std::vector<LeafConstPtr>& neighbors) const {
+  neighbors.clear();
+  return getNeighborhoodAtPoint(Eigen::MatrixXi::Zero(3, 1), reference_point, neighbors);
 }
 
-
-
 //////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointT> void
-pclomp::VoxelGridCovariance<PointT>::getDisplayCloud (pcl::PointCloud<pcl::PointXYZ>& cell_cloud)
-{
-  cell_cloud.clear ();
+template<typename PointT>
+void pclomp::VoxelGridCovariance<PointT>::getDisplayCloud(pcl::PointCloud<pcl::PointXYZ>& cell_cloud) {
+  cell_cloud.clear();
 
   int pnt_per_cell = 1000;
   boost::mt19937 rng;
-  boost::normal_distribution<> nd (0.0, leaf_size_.head (3).norm ());
-  boost::variate_generator<boost::mt19937&, boost::normal_distribution<> > var_nor (rng, nd);
+  boost::normal_distribution<> nd(0.0, leaf_size_.head(3).norm());
+  boost::variate_generator<boost::mt19937&, boost::normal_distribution<> > var_nor(rng, nd);
 
   Eigen::LLT<Eigen::Matrix3d> llt_of_cov;
   Eigen::Matrix3d cholesky_decomp;
@@ -461,22 +399,19 @@ pclomp::VoxelGridCovariance<PointT>::getDisplayCloud (pcl::PointCloud<pcl::Point
   Eigen::Vector3d dist_point;
 
   // Generate points for each occupied voxel with sufficient points.
-  for (auto it = leaves_.begin (); it != leaves_.end (); ++it)
-  {
+  for(auto it = leaves_.begin(); it != leaves_.end(); ++it) {
     Leaf& leaf = it->second;
 
-    if (leaf.nr_points >= min_points_per_voxel_)
-    {
+    if(leaf.nr_points >= min_points_per_voxel_) {
       cell_mean = leaf.mean_;
-      llt_of_cov.compute (leaf.cov_);
-      cholesky_decomp = llt_of_cov.matrixL ();
+      llt_of_cov.compute(leaf.cov_);
+      cholesky_decomp = llt_of_cov.matrixL();
 
       // Random points generated by sampling the normal distribution given by voxel mean and covariance matrix
-      for (int i = 0; i < pnt_per_cell; i++)
-      {
-        rand_point = Eigen::Vector3d (var_nor (), var_nor (), var_nor ());
+      for(int i = 0; i < pnt_per_cell; i++) {
+        rand_point = Eigen::Vector3d(var_nor(), var_nor(), var_nor());
         dist_point = cell_mean + cholesky_decomp * rand_point;
-        cell_cloud.push_back (pcl::PointXYZ (static_cast<float> (dist_point (0)), static_cast<float> (dist_point (1)), static_cast<float> (dist_point (2))));
+        cell_cloud.push_back(pcl::PointXYZ(static_cast<float>(dist_point(0)), static_cast<float>(dist_point(1)), static_cast<float>(dist_point(2))));
       }
     }
   }
@@ -484,4 +419,4 @@ pclomp::VoxelGridCovariance<PointT>::getDisplayCloud (pcl::PointCloud<pcl::Point
 
 #define PCL_INSTANTIATE_VoxelGridCovariance(T) template class PCL_EXPORTS pcl::VoxelGridCovariance<T>;
 
-#endif    // PCL_VOXEL_GRID_COVARIANCE_IMPL_H_
+#endif  // PCL_VOXEL_GRID_COVARIANCE_IMPL_H_

--- a/src/pclomp/gicp_omp.cpp
+++ b/src/pclomp/gicp_omp.cpp
@@ -3,4 +3,3 @@
 
 template class pclomp::GeneralizedIterativeClosestPoint<pcl::PointXYZ, pcl::PointXYZ>;
 template class pclomp::GeneralizedIterativeClosestPoint<pcl::PointXYZI, pcl::PointXYZI>;
-


### PR DESCRIPTION
It is expected that various changes will be made to ndt_omp in the future, and it is important that the differences are easy to understand.
Using formatters leads to suppression of non-essential differences.

Although there will be a large difference in this pull request, I consider this to be an important change.

If you have any opposing opinions, please feel free to comment.

## Evaluation
It has been confirmed that the `logging_simulator` runs with the same accuracy as before on AWSIM data with GT.
