### PR TITLE
Refactored MultiVoxelGridCovariance and MultiGridNormalDistributionsTransform

### DIFF
--- a/include/multigrid_pclomp/multigrid_ndt_omp.h
+++ b/include/multigrid_pclomp/multigrid_ndt_omp.h
@@ -179,7 +179,7 @@ public:
   /** \brief Provide a pointer to the input target (e.g., the point cloud that we want to align the input source to).
    * \param[in] cloud the input point cloud target
    */
-  inline void addTarget(const PointCloudTargetConstPtr &cloud, const std::string target_id) {
+  inline void addTarget(const PointCloudTargetConstPtr &cloud, const std::string &target_id) {
     pcl::Registration<PointSource, PointTarget>::setInputTarget(cloud);
     target_cells_.setLeafSize(resolution_, resolution_, resolution_);
     target_cells_.setInputCloudAndFilter(cloud, target_id);

--- a/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp
+++ b/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp
@@ -1090,7 +1090,7 @@ double pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::
 template<typename PointSource, typename PointTarget>
 double pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::calculateNearestVoxelTransformationLikelihood(const PointCloudSource &trans_cloud) const {
   double nearest_voxel_score = 0;
-  size_t found_neigborhood_voxel_num = 0;
+  size_t found_neighborhood_voxel_num = 0;
 
   for(std::size_t idx = 0; idx < trans_cloud.points.size(); idx++) {
     double nearest_voxel_score_pt = 0;
@@ -1124,14 +1124,14 @@ double pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::
     }
 
     if(!neighborhood.empty()) {
-      ++found_neigborhood_voxel_num;
+      ++found_neighborhood_voxel_num;
       nearest_voxel_score += nearest_voxel_score_pt;
     }
   }
 
   double output_score = 0;
-  if(found_neigborhood_voxel_num != 0) {
-    output_score = nearest_voxel_score / static_cast<double>(found_neigborhood_voxel_num);
+  if(found_neighborhood_voxel_num != 0) {
+    output_score = nearest_voxel_score / static_cast<double>(found_neighborhood_voxel_num);
   }
   return output_score;
 }


### PR DESCRIPTION
This PR is related to

* https://github.com/tier4/ndt_omp/pull/29

To make it easier to see the differences in the pull request above, I will first conduct refactoring in this pull request.

## Changes
* Apply formatter
* Add five functions to `Leaf` struct
* Rename `nr_points` -> `nr_points_`
* Rename `centroid` -> `centroid_`
* Move implementation of functions from `multi_voxel_grid_covariance_omp.h` to `multi_voxel_grid_covariance_omp_impl.hpp`
* Fix `const std::string target_id` -> `const std::string &target_id`
* Fix typo `found_neigborhood_voxel_num` -> `found_neighborhood_voxel_num`

## Evaluation
It has been confirmed that the `logging_simulator` runs with the same accuracy as before on AWSIM data with GT.