### PR TITLE
refactor(ndt_omp): apply static analysis

### DIFF
--- a/apps/align.cpp
+++ b/apps/align.cpp
@@ -79,18 +79,21 @@ int main(int argc, char ** argv)
   std::cout << "--- pcl::GICP ---" << std::endl;
   pcl::GeneralizedIterativeClosestPoint<pcl::PointXYZ, pcl::PointXYZ>::Ptr gicp(
     new pcl::GeneralizedIterativeClosestPoint<pcl::PointXYZ, pcl::PointXYZ>());
-  align(gicp, target_cloud, source_cloud);
+  // cppcheck-suppress redundantAssignment
+  aligned = align(gicp, target_cloud, source_cloud);
 
   std::cout << "--- pclomp::GICP ---" << std::endl;
   pclomp::GeneralizedIterativeClosestPoint<pcl::PointXYZ, pcl::PointXYZ>::Ptr gicp_omp(
     new pclomp::GeneralizedIterativeClosestPoint<pcl::PointXYZ, pcl::PointXYZ>());
+  // cppcheck-suppress redundantAssignment
   aligned = align(gicp_omp, target_cloud, source_cloud);
 
   std::cout << "--- pcl::NDT ---" << std::endl;
   pcl::NormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>::Ptr ndt(
     new pcl::NormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>());
   ndt->setResolution(1.0);
-  align(ndt, target_cloud, source_cloud);
+  // cppcheck-suppress redundantAssignment
+  aligned = align(ndt, target_cloud, source_cloud);
 
   std::vector<int> num_threads = {1, omp_get_max_threads()};
   std::vector<std::pair<std::string, pclomp::NeighborSearchMethod>> search_methods = {
@@ -110,11 +113,13 @@ int main(int argc, char ** argv)
                 << std::endl;
       ndt_omp->setNumThreads(n);
       ndt_omp->setNeighborhoodSearchMethod(search_method.second);
-      align(ndt_omp, target_cloud, source_cloud);
+      // cppcheck-suppress redundantAssignment
+      aligned = align(ndt_omp, target_cloud, source_cloud);
     }
 
     std::cout << "--- multigrid_pclomp::NDT (" << n << " threads) ---" << std::endl;
     mg_ndt_omp->setNumThreads(n);
+    // cppcheck-suppress redundantAssignment
     aligned = align(mg_ndt_omp, target_cloud, source_cloud);
   }
 

--- a/apps/check_covariance.cpp
+++ b/apps/check_covariance.cpp
@@ -181,14 +181,14 @@ int main(int argc, char ** argv)
     ofs_mndt << "index,score,initial_x,initial_y,result_x,result_y" << std::endl;
     ofs_mndt << std::fixed;
     for (int j = 0; j < n_mndt; j++) {
-      const pclomp::NdtResult & ndt_result = result_of_mndt.ndt_results[j];
-      const auto nvtl = ndt_result.nearest_voxel_transformation_likelihood;
+      const pclomp::NdtResult & multi_ndt_result = result_of_mndt.ndt_results[j];
+      const auto nvtl = multi_ndt_result.nearest_voxel_transformation_likelihood;
       const auto initial_x = result_of_mndt.ndt_initial_poses[j](0, 3);
       const auto initial_y = result_of_mndt.ndt_initial_poses[j](1, 3);
-      const auto result_x = ndt_result.pose(0, 3);
-      const auto result_y = ndt_result.pose(1, 3);
-      ofs_mndt << j << "," << nvtl << "," << initial_x << "," << initial_y << "," << result_x << ","
-               << result_y << std::endl;
+      const auto multi_ndt_result_x = multi_ndt_result.pose(0, 3);
+      const auto multi_ndt_result_y = multi_ndt_result.pose(1, 3);
+      ofs_mndt << j << "," << nvtl << "," << initial_x << "," << initial_y << ","
+               << multi_ndt_result_x << "," << multi_ndt_result_y << std::endl;
     }
 
     // output multi ndt score result
@@ -197,14 +197,14 @@ int main(int argc, char ** argv)
     ofs_mndt_score << "index,score,initial_x,initial_y,result_x,result_y" << std::endl;
     ofs_mndt_score << std::fixed;
     for (int j = 0; j < n_mndt_score; j++) {
-      const pclomp::NdtResult & ndt_result = result_of_mndt_score.ndt_results[j];
-      const auto nvtl = ndt_result.nearest_voxel_transformation_likelihood;
+      const pclomp::NdtResult & multi_ndt_score_result = result_of_mndt_score.ndt_results[j];
+      const auto nvtl = multi_ndt_score_result.nearest_voxel_transformation_likelihood;
       const auto initial_x = result_of_mndt_score.ndt_initial_poses[j](0, 3);
       const auto initial_y = result_of_mndt_score.ndt_initial_poses[j](1, 3);
-      const auto result_x = ndt_result.pose(0, 3);
-      const auto result_y = ndt_result.pose(1, 3);
-      ofs_mndt_score << j << "," << nvtl << "," << initial_x << "," << initial_y << "," << result_x
-                     << "," << result_y << std::endl;
+      const auto multi_ndt_score_result_x = multi_ndt_score_result.pose(0, 3);
+      const auto multi_ndt_score_result_y = multi_ndt_score_result.pose(1, 3);
+      ofs_mndt_score << j << "," << nvtl << "," << initial_x << "," << initial_y << ","
+                     << multi_ndt_score_result_x << "," << multi_ndt_score_result_y << std::endl;
     }
   }
 }

--- a/apps/check_covariance.cpp
+++ b/apps/check_covariance.cpp
@@ -47,7 +47,7 @@ int main(int argc, char ** argv)
     std::cerr << "initial_pose_list.size() != source_pcd_list.size()" << std::endl;
     return 1;
   }
-  const int64_t n_data = initial_pose_list.size();
+  const auto n_data = static_cast<int64_t>(initial_pose_list.size());
 
   // prepare ndt
   std::shared_ptr<pclomp::MultiGridNormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>>
@@ -93,7 +93,7 @@ int main(int argc, char ** argv)
 
   // execute align
   for (int64_t i = 0; i < n_data; i++) {
-    const Eigen::Matrix4f initial_pose = initial_pose_list[i];
+    const Eigen::Matrix4f & initial_pose = initial_pose_list[i];
     const std::string & source_pcd = source_pcd_list[i];
     pcl::PointCloud<pcl::PointXYZ>::Ptr source_cloud(new pcl::PointCloud<pcl::PointXYZ>());
     if (pcl::io::loadPCDFile(source_pcd, *source_cloud)) {
@@ -115,10 +115,11 @@ int main(int argc, char ** argv)
     // (1) Laplace approximation
     t1 = std::chrono::system_clock::now();
     const Eigen::Matrix2d cov_by_la =
-      pclomp::estimate_xy_covariance_by_Laplace_approximation(ndt_result.hessian);
+      pclomp::estimate_xy_covariance_by_laplace_approximation(ndt_result.hessian);
     t2 = std::chrono::system_clock::now();
     const auto elapsed_la =
-      std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count() / 1000.0;
+      static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count()) /
+      1000.0;
 
     // (2) Multi NDT
     t1 = std::chrono::system_clock::now();
@@ -128,7 +129,8 @@ int main(int argc, char ** argv)
       result_of_mndt.covariance, ndt_result.pose, 0.0225, 0.0225);
     t2 = std::chrono::system_clock::now();
     const auto elapsed_mndt =
-      std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count() / 1000.0;
+      static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count()) /
+      1000.0;
 
     // (3) Multi NDT with score
     const double temperature = 0.1;
@@ -140,7 +142,8 @@ int main(int argc, char ** argv)
       result_of_mndt_score.covariance, ndt_result.pose, 0.0225, 0.0225);
     t2 = std::chrono::system_clock::now();
     const auto elapsed_mndt_score =
-      std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count() / 1000.0;
+      static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count()) /
+      1000.0;
 
     // output result
     const auto result_x = ndt_result.pose(0, 3);
@@ -174,7 +177,7 @@ int main(int argc, char ** argv)
 
     // output multi ndt result
     std::ofstream ofs_mndt(multi_ndt_dir + "/" + filename_ss.str());
-    const int n_mndt = result_of_mndt.ndt_results.size();
+    const auto n_mndt = static_cast<int64_t>(result_of_mndt.ndt_results.size());
     ofs_mndt << "index,score,initial_x,initial_y,result_x,result_y" << std::endl;
     ofs_mndt << std::fixed;
     for (int j = 0; j < n_mndt; j++) {
@@ -190,7 +193,7 @@ int main(int argc, char ** argv)
 
     // output multi ndt score result
     std::ofstream ofs_mndt_score(multi_ndt_score_dir + "/" + filename_ss.str());
-    const int n_mndt_score = result_of_mndt_score.ndt_results.size();
+    const auto n_mndt_score = static_cast<int64_t>(result_of_mndt_score.ndt_results.size());
     ofs_mndt_score << "index,score,initial_x,initial_y,result_x,result_y" << std::endl;
     ofs_mndt_score << std::fixed;
     for (int j = 0; j < n_mndt_score; j++) {

--- a/apps/pcd_map_grid_manager.hpp
+++ b/apps/pcd_map_grid_manager.hpp
@@ -54,12 +54,12 @@ public:
     const int y_min = static_cast<int>(std::ceil((y - get_around_) / resolution_));
     const int y_max = static_cast<int>(std::ceil((y + get_around_) / resolution_));
     std::vector<std::pair<int, int>> curr_keys;
-    for (int x = x_min; x <= x_max; x++) {
-      for (int y = y_min; y <= y_max; y++) {
-        if (map_grid_.count(std::make_pair(x, y)) == 0) {
+    for (int x_ind = x_min; x_ind <= x_max; x_ind++) {
+      for (int y_ind = y_min; y_ind <= y_max; y_ind++) {
+        if (map_grid_.count(std::make_pair(x_ind, y_ind)) == 0) {
           continue;
         }
-        curr_keys.emplace_back(std::make_pair(x, y));
+        curr_keys.emplace_back(std::make_pair(x_ind, y_ind));
       }
     }
 

--- a/apps/pcd_map_grid_manager.hpp
+++ b/apps/pcd_map_grid_manager.hpp
@@ -16,6 +16,12 @@
 #define NDT_OMP__APPS__PCD_MAP_GRID_MANAGER_HPP_
 
 #include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
 
 using AddPair = std::pair<std::string, pcl::PointCloud<pcl::PointXYZ>::Ptr>;
 using AddResult = std::vector<AddPair>;
@@ -24,7 +30,7 @@ using RemoveResult = std::vector<std::string>;
 class MapGridManager
 {
 public:
-  MapGridManager(const pcl::PointCloud<pcl::PointXYZ>::Ptr target_cloud)
+  explicit MapGridManager(const pcl::PointCloud<pcl::PointXYZ>::Ptr target_cloud)
   : target_cloud_(target_cloud)
   {
     for (const auto & point : target_cloud_->points) {
@@ -53,7 +59,7 @@ public:
         if (map_grid_.count(std::make_pair(x, y)) == 0) {
           continue;
         }
-        curr_keys.push_back(std::make_pair(x, y));
+        curr_keys.emplace_back(std::make_pair(x, y));
       }
     }
 
@@ -84,7 +90,7 @@ private:
   std::map<std::pair<int, int>, pcl::PointCloud<pcl::PointXYZ>::Ptr> map_grid_;
   std::vector<std::pair<int, int>> held_keys_;
 
-  std::string to_string_key(const std::pair<int, int> & key)
+  static std::string to_string_key(const std::pair<int, int> & key)
   {
     return std::to_string(key.first) + "_" + std::to_string(key.second);
   }

--- a/apps/regression_test.cpp
+++ b/apps/regression_test.cpp
@@ -62,7 +62,7 @@ int main(int argc, char ** argv)
     std::cerr << "initial_pose_list.size() != source_pcd_list.size()" << std::endl;
     return 1;
   }
-  const int64_t n_data = initial_pose_list.size();
+  const auto n_data = static_cast<int64_t>(initial_pose_list.size());
 
   // prepare ndt
   pclomp::MultiGridNormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>::Ptr mg_ndt_omp(
@@ -89,7 +89,7 @@ int main(int argc, char ** argv)
   // execute align
   for (int64_t i = 0; i < n_data; i++) {
     // get input
-    const Eigen::Matrix4f initial_pose = initial_pose_list[i];
+    const Eigen::Matrix4f & initial_pose = initial_pose_list[i];
     const std::string & source_pcd = source_pcd_list[i];
     const pcl::PointCloud<pcl::PointXYZ>::Ptr source_cloud = load_pcd(source_pcd);
     mg_ndt_omp->setInputSource(source_cloud);

--- a/apps/timer.hpp
+++ b/apps/timer.hpp
@@ -24,12 +24,12 @@ class Timer
 public:
   void start() { start_time_ = std::chrono::steady_clock::now(); }
 
-  double elapsed_milliseconds() const
+  [[nodiscard]] double elapsed_milliseconds() const
   {
     const auto end_time = std::chrono::steady_clock::now();
     const auto elapsed_time = end_time - start_time_;
-    const double microseconds =
-      std::chrono::duration_cast<std::chrono::microseconds>(elapsed_time).count();
+    const double microseconds = static_cast<double>(
+      std::chrono::duration_cast<std::chrono::microseconds>(elapsed_time).count());
     return microseconds / 1000.0;
   }
 

--- a/include/estimate_covariance/estimate_covariance.hpp
+++ b/include/estimate_covariance/estimate_covariance.hpp
@@ -5,6 +5,10 @@
 
 #include <Eigen/Core>
 
+#include <memory>
+#include <utility>
+#include <vector>
+
 namespace pclomp
 {
 
@@ -17,17 +21,17 @@ struct ResultOfMultiNdtCovarianceEstimation
 };
 
 /** \brief Estimate functions */
-Eigen::Matrix2d estimate_xy_covariance_by_Laplace_approximation(
+Eigen::Matrix2d estimate_xy_covariance_by_laplace_approximation(
   const Eigen::Matrix<double, 6, 6> & hessian);
 ResultOfMultiNdtCovarianceEstimation estimate_xy_covariance_by_multi_ndt(
   const NdtResult & ndt_result,
-  std::shared_ptr<pclomp::MultiGridNormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>>
-    ndt_ptr,
+  const std::shared_ptr<
+    pclomp::MultiGridNormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>> & ndt_ptr,
   const std::vector<Eigen::Matrix4f> & poses_to_search);
 ResultOfMultiNdtCovarianceEstimation estimate_xy_covariance_by_multi_ndt_score(
   const NdtResult & ndt_result,
-  std::shared_ptr<pclomp::MultiGridNormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>>
-    ndt_ptr,
+  const std::shared_ptr<
+    pclomp::MultiGridNormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>> & ndt_ptr,
   const std::vector<Eigen::Matrix4f> & poses_to_search, const double temperature);
 
 /** \brief Find rotation matrix aligning covariance to principal axes

--- a/include/estimate_covariance/estimate_covariance.hpp
+++ b/include/estimate_covariance/estimate_covariance.hpp
@@ -23,6 +23,11 @@ struct ResultOfMultiNdtCovarianceEstimation
 /** \brief Estimate functions */
 Eigen::Matrix2d estimate_xy_covariance_by_laplace_approximation(
   const Eigen::Matrix<double, 6, 6> & hessian);
+// temporal compatibility until
+//   https://github.com/autowarefoundation/autoware.universe/pull/8124
+// get merged
+Eigen::Matrix2d estimate_xy_covariance_by_Laplace_approximation(
+  const Eigen::Matrix<double, 6, 6> & hessian);
 ResultOfMultiNdtCovarianceEstimation estimate_xy_covariance_by_multi_ndt(
   const NdtResult & ndt_result,
   const std::shared_ptr<

--- a/include/multigrid_pclomp/multi_voxel_grid_covariance_omp.h
+++ b/include/multigrid_pclomp/multi_voxel_grid_covariance_omp.h
@@ -277,10 +277,10 @@ public:
   }
 
   MultiVoxelGridCovariance(const MultiVoxelGridCovariance & other);
-  MultiVoxelGridCovariance(MultiVoxelGridCovariance && other);
+  MultiVoxelGridCovariance(MultiVoxelGridCovariance && other) noexcept;
 
   MultiVoxelGridCovariance & operator=(const MultiVoxelGridCovariance & other);
-  MultiVoxelGridCovariance & operator=(MultiVoxelGridCovariance && other);
+  MultiVoxelGridCovariance & operator=(MultiVoxelGridCovariance && other) noexcept;
 
   /** \brief Add a cloud to the voxel grid list and build a ND voxel grid from it.
    */
@@ -328,10 +328,6 @@ public:
   void setThreadNum(int thread_num)
   {
     sync();
-
-    if (thread_num <= 0) {
-      thread_num_ = 1;
-    }
 
     thread_num_ = thread_num;
     thread_futs_.resize(thread_num_);

--- a/include/multigrid_pclomp/multi_voxel_grid_covariance_omp.h
+++ b/include/multigrid_pclomp/multi_voxel_grid_covariance_omp.h
@@ -329,6 +329,10 @@ public:
   {
     sync();
 
+    if (thread_num <= 0) {
+      thread_num = 1;
+    }
+
     thread_num_ = thread_num;
     thread_futs_.resize(thread_num_);
     processing_inputs_.resize(thread_num_);

--- a/include/multigrid_pclomp/multi_voxel_grid_covariance_omp_impl.hpp
+++ b/include/multigrid_pclomp/multi_voxel_grid_covariance_omp_impl.hpp
@@ -57,6 +57,12 @@
 #include <pcl/common/common.h>
 #include <pcl/filters/boost.h>
 
+#include <limits>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
 namespace pclomp
 {
 
@@ -83,7 +89,8 @@ MultiVoxelGridCovariance<PointT>::MultiVoxelGridCovariance(const MultiVoxelGridC
 }
 
 template <typename PointT>
-MultiVoxelGridCovariance<PointT>::MultiVoxelGridCovariance(MultiVoxelGridCovariance && other)
+MultiVoxelGridCovariance<PointT>::MultiVoxelGridCovariance(
+  MultiVoxelGridCovariance && other) noexcept
 : pcl::VoxelGrid<PointT>(std::move(other)),
   voxel_centroids_ptr_(std::move(other.voxel_centroids_ptr_)),
   sid_to_iid_(std::move(other.sid_to_iid_)),
@@ -126,9 +133,8 @@ MultiVoxelGridCovariance<PointT> & pclomp::MultiVoxelGridCovariance<PointT>::ope
 
 template <typename PointT>
 MultiVoxelGridCovariance<PointT> & pclomp::MultiVoxelGridCovariance<PointT>::operator=(
-  MultiVoxelGridCovariance && other)
+  MultiVoxelGridCovariance && other) noexcept
 {
-  pcl::VoxelGrid<PointT>::operator=(std::move(other));
   voxel_centroids_ptr_ = std::move(other.voxel_centroids_ptr_);
   sid_to_iid_ = std::move(other.sid_to_iid_);
   grid_list_ = std::move(other.grid_list_);
@@ -140,6 +146,8 @@ MultiVoxelGridCovariance<PointT> & pclomp::MultiVoxelGridCovariance<PointT>::ope
 
   setThreadNum(other.thread_num_);
   last_check_tid_ = -1;
+
+  pcl::VoxelGrid<PointT>::operator=(std::move(other));
 
   return *this;
 }
@@ -301,7 +309,8 @@ void MultiVoxelGridCovariance<PointT>::applyFilter(
     return;
   }
 
-  Eigen::Vector4f min_p, max_p;
+  Eigen::Vector4f min_p;
+  Eigen::Vector4f max_p;
   pcl::getMinMax3D<PointT>(*input, min_p, max_p);
 
   // Check that the leaf size is not too small, given the size of the data

--- a/include/multigrid_pclomp/multigrid_ndt_omp.h
+++ b/include/multigrid_pclomp/multigrid_ndt_omp.h
@@ -116,12 +116,13 @@ public:
 
   // Copy & move constructor
   MultiGridNormalDistributionsTransform(const MultiGridNormalDistributionsTransform & other);
-  MultiGridNormalDistributionsTransform(MultiGridNormalDistributionsTransform && other);
+  MultiGridNormalDistributionsTransform(MultiGridNormalDistributionsTransform && other) noexcept;
 
   // Copy & move assignments
   MultiGridNormalDistributionsTransform & operator=(
     const MultiGridNormalDistributionsTransform & other);
-  MultiGridNormalDistributionsTransform & operator=(MultiGridNormalDistributionsTransform && other);
+  MultiGridNormalDistributionsTransform & operator=(
+    MultiGridNormalDistributionsTransform && other) noexcept;
 
   /** \brief Empty destructor */
   virtual ~MultiGridNormalDistributionsTransform() {}
@@ -228,7 +229,7 @@ public:
   inline Eigen::Matrix<double, 6, 6> getHessian() const { return hessian_; }
 
   /** \brief Return the transformation array */
-  inline const std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f>>
+  inline const std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f>> &
   getFinalTransformationArray() const
   {
     return transformation_array_;
@@ -548,7 +549,7 @@ protected:
   std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f>> transformation_array_;
   std::vector<float> transform_probability_array_;
   std::vector<float> nearest_voxel_transformation_likelihood_array_;
-  double nearest_voxel_transformation_likelihood_;
+  double nearest_voxel_transformation_likelihood_{};
 
   boost::optional<Eigen::Matrix4f> regularization_pose_;
   Eigen::Vector3f regularization_pose_translation_;

--- a/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp
+++ b/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp
@@ -194,12 +194,9 @@ MultiGridNormalDistributionsTransform<
   params_.regularization_scale_factor = 0.0f;
   params_.use_line_search = false;
 
-  double gauss_c1 = NAN;
-  double gauss_c2 = NAN;
-
   // Initializes the gaussian fitting parameters (eq. 6.8) [Magnusson 2009]
-  gauss_c1 = 10.0 * (1 - outlier_ratio_);
-  gauss_c2 = outlier_ratio_ / pow(params_.resolution, 3);
+  double gauss_c1 = 10.0 * (1 - outlier_ratio_);
+  double gauss_c2 = outlier_ratio_ / pow(params_.resolution, 3);
   gauss_d3_ = -log(gauss_c2);
   gauss_d1_ = -log(gauss_c1 + gauss_c2) - gauss_d3_;
   gauss_d2_ = -2 * log((-log(gauss_c1 * exp(-0.5) + gauss_c2) - gauss_d3_) / gauss_d1_);
@@ -213,12 +210,9 @@ void MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeTra
   nr_iterations_ = 0;
   converged_ = false;
 
-  double gauss_c1 = NAN;
-  double gauss_c2 = NAN;
-
   // Initializes the gaussian fitting parameters (eq. 6.8) [Magnusson 2009]
-  gauss_c1 = 10 * (1 - outlier_ratio_);
-  gauss_c2 = outlier_ratio_ / pow(params_.resolution, 3);
+  double gauss_c1 = 10 * (1 - outlier_ratio_);
+  double gauss_c2 = outlier_ratio_ / pow(params_.resolution, 3);
   gauss_d3_ = -log(gauss_c2);
   gauss_d1_ = -log(gauss_c1 + gauss_c2) - gauss_d3_;
   gauss_d2_ = -2.0 * log((-log(gauss_c1 * exp(-0.5) + gauss_c2) - gauss_d3_) / gauss_d1_);
@@ -252,7 +246,6 @@ void MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeTra
   Eigen::Matrix<double, 6, 6> hessian;
 
   double score = 0;
-  double delta_p_norm = NAN;
 
   if (regularization_pose_) {
     Eigen::Transform<float, 3, Eigen::Affine, Eigen::ColMajor> regularization_pose_transformation;
@@ -275,7 +268,7 @@ void MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeTra
     delta_p = sv.solve(-score_gradient);
 
     // Calculate step length with guaranteed sufficient decrease [More, Thuente 1994]
-    delta_p_norm = delta_p.norm();
+    double delta_p_norm = delta_p.norm();
 
     if (delta_p_norm == 0 || delta_p_norm != delta_p_norm) {
       if (input_->empty()) {
@@ -506,12 +499,12 @@ void MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeAng
   Eigen::Matrix<double, 6, 1> & p, bool compute_hessian)
 {
   // Simplified math for near 0 angles
-  double cx = NAN;
-  double cy = NAN;
-  double cz = NAN;
-  double sx = NAN;
-  double sy = NAN;
-  double sz = NAN;
+  double cx = 1.0;
+  double cy = 1.0;
+  double cz = 1.0;
+  double sx = 0.0;
+  double sy = 0.0;
+  double sz = 0.0;
   if (fabs(p(3)) < 10e-5) {
     // p(3) = 0;
     cx = 1.0;
@@ -874,7 +867,7 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::trialVal
     // Equation 2.4.5 [Sun, Yuan 2006]
     double a_s = a_l - (a_l - a_t) / (g_l - g_t) * g_l;
 
-    double a_t_next = NAN;
+    double a_t_next = 0.0;
 
     if (std::fabs(a_c - a_t) < std::fabs(a_s - a_t))
       a_t_next = a_c;

--- a/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp
+++ b/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp
@@ -57,6 +57,10 @@
 
 #include "multigrid_pclomp/multigrid_ndt_omp.h"
 
+#include <algorithm>
+#include <utility>
+#include <vector>
+
 namespace pclomp
 {
 
@@ -87,7 +91,7 @@ MultiGridNormalDistributionsTransform<PointSource, PointTarget>::
 
 template <typename PointSource, typename PointTarget>
 MultiGridNormalDistributionsTransform<PointSource, PointTarget>::
-  MultiGridNormalDistributionsTransform(MultiGridNormalDistributionsTransform && other)
+  MultiGridNormalDistributionsTransform(MultiGridNormalDistributionsTransform && other) noexcept
 : BaseRegType(std::move(other)),
   target_cells_(std::move(other.target_cells_)),
   params_(std::move(other.params_))
@@ -114,8 +118,6 @@ MultiGridNormalDistributionsTransform<PointSource, PointTarget> &
 MultiGridNormalDistributionsTransform<PointSource, PointTarget>::operator=(
   const MultiGridNormalDistributionsTransform & other)
 {
-  BaseRegType::operator=(other);
-
   target_cells_ = other.target_cells_;
   params_ = other.params_;
 
@@ -135,16 +137,16 @@ MultiGridNormalDistributionsTransform<PointSource, PointTarget>::operator=(
   regularization_pose_ = other.regularization_pose_;
   regularization_pose_translation_ = other.regularization_pose_translation_;
 
+  BaseRegType::operator=(other);
+
   return *this;
 }
 
 template <typename PointSource, typename PointTarget>
 MultiGridNormalDistributionsTransform<PointSource, PointTarget> &
 MultiGridNormalDistributionsTransform<PointSource, PointTarget>::operator=(
-  MultiGridNormalDistributionsTransform && other)
+  MultiGridNormalDistributionsTransform && other) noexcept
 {
-  BaseRegType::operator=(std::move(other));
-
   target_cells_ = std::move(other.target_cells_);
   params_ = std::move(other.params_);
 
@@ -163,6 +165,8 @@ MultiGridNormalDistributionsTransform<PointSource, PointTarget>::operator=(
 
   regularization_pose_ = other.regularization_pose_;
   regularization_pose_translation_ = other.regularization_pose_translation_;
+
+  BaseRegType::operator=(std::move(other));
 
   return *this;
 }
@@ -190,7 +194,8 @@ MultiGridNormalDistributionsTransform<
   params_.regularization_scale_factor = 0.0f;
   params_.use_line_search = false;
 
-  double gauss_c1, gauss_c2;
+  double gauss_c1;
+  double gauss_c2;
 
   // Initializes the gaussian fitting parameters (eq. 6.8) [Magnusson 2009]
   gauss_c1 = 10.0 * (1 - outlier_ratio_);
@@ -208,7 +213,8 @@ void MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeTra
   nr_iterations_ = 0;
   converged_ = false;
 
-  double gauss_c1, gauss_c2;
+  double gauss_c1;
+  double gauss_c2;
 
   // Initializes the gaussian fitting parameters (eq. 6.8) [Magnusson 2009]
   gauss_c1 = 10 * (1 - outlier_ratio_);
@@ -234,7 +240,9 @@ void MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeTra
   nearest_voxel_transformation_likelihood_array_.clear();
 
   // Convert initial guess matrix to 6 element transformation vector
-  Eigen::Matrix<double, 6, 1> p, delta_p, score_gradient;
+  Eigen::Matrix<double, 6, 1> p;
+  Eigen::Matrix<double, 6, 1> delta_p;
+  Eigen::Matrix<double, 6, 1> score_gradient;
   Eigen::Vector3f init_translation = eig_transformation.translation();
   Eigen::Vector3f init_rotation = eig_transformation.rotation().eulerAngles(0, 1, 2);
 
@@ -498,7 +506,12 @@ void MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeAng
   Eigen::Matrix<double, 6, 1> & p, bool compute_hessian)
 {
   // Simplified math for near 0 angles
-  double cx, cy, cz, sx, sy, sz;
+  double cx;
+  double cy;
+  double cz;
+  double sx;
+  double sy;
+  double sz;
   if (fabs(p(3)) < 10e-5) {
     // p(3) = 0;
     cx = 1.0;
@@ -786,14 +799,14 @@ bool MultiGridNormalDistributionsTransform<PointSource, PointTarget>::updateInte
     return (false);
   }
   // Case U2 in Update Algorithm and Case b in Modified Update Algorithm [More, Thuente 1994]
-  else if (g_t * (a_l - a_t) > 0) {
+  if (g_t * (a_l - a_t) > 0) {
     a_l = a_t;
     f_l = f_t;
     g_l = g_t;
     return (false);
   }
   // Case U3 in Update Algorithm and Case c in Modified Update Algorithm [More, Thuente 1994]
-  else if (g_t * (a_l - a_t) < 0) {
+  if (g_t * (a_l - a_t) < 0) {
     a_u = a_l;
     f_u = f_l;
     g_u = g_l;
@@ -804,8 +817,7 @@ bool MultiGridNormalDistributionsTransform<PointSource, PointTarget>::updateInte
     return (false);
   }
   // Interval Converged
-  else
-    return (true);
+  return (true);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -827,13 +839,13 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::trialVal
     // Equation 2.4.2 [Sun, Yuan 2006]
     double a_q = a_l - 0.5 * (a_l - a_t) * g_l / (g_l - (f_l - f_t) / (a_l - a_t));
 
-    if (std::fabs(a_c - a_l) < std::fabs(a_q - a_l))
+    if (std::fabs(a_c - a_l) < std::fabs(a_q - a_l)) {
       return (a_c);
-    else
-      return (0.5 * (a_q + a_c));
+    }
+    return (0.5 * (a_q + a_c));
   }
   // Case 2 in Trial Value Selection [More, Thuente 1994]
-  else if (g_t * g_l < 0) {
+  if (g_t * g_l < 0) {
     // Calculate the minimizer of the cubic that interpolates f_l, f_t, g_l and g_t
     // Equation 2.4.52 [Sun, Yuan 2006]
     double z = 3 * (f_t - f_l) / (a_t - a_l) - g_t - g_l;
@@ -845,13 +857,13 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::trialVal
     // Equation 2.4.5 [Sun, Yuan 2006]
     double a_s = a_l - (a_l - a_t) / (g_l - g_t) * g_l;
 
-    if (std::fabs(a_c - a_t) >= std::fabs(a_s - a_t))
+    if (std::fabs(a_c - a_t) >= std::fabs(a_s - a_t)) {
       return (a_c);
-    else
-      return (a_s);
+    }
+    return (a_s);
   }
   // Case 3 in Trial Value Selection [More, Thuente 1994]
-  else if (std::fabs(g_t) <= std::fabs(g_l)) {
+  if (std::fabs(g_t) <= std::fabs(g_l)) {
     // Calculate the minimizer of the cubic that interpolates f_l, f_t, g_l and g_t
     // Equation 2.4.52 [Sun, Yuan 2006]
     double z = 3 * (f_t - f_l) / (a_t - a_l) - g_t - g_l;
@@ -869,20 +881,18 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::trialVal
     else
       a_t_next = a_s;
 
-    if (a_t > a_l)
+    if (a_t > a_l) {
       return (std::min(a_t + 0.66 * (a_u - a_t), a_t_next));
-    else
-      return (std::max(a_t + 0.66 * (a_u - a_t), a_t_next));
+    }
+    return (std::max(a_t + 0.66 * (a_u - a_t), a_t_next));
   }
   // Case 4 in Trial Value Selection [More, Thuente 1994]
-  else {
-    // Calculate the minimizer of the cubic that interpolates f_u, f_t, g_u and g_t
-    // Equation 2.4.52 [Sun, Yuan 2006]
-    double z = 3 * (f_t - f_u) / (a_t - a_u) - g_t - g_u;
-    double w = std::sqrt(z * z - g_t * g_u);
-    // Equation 2.4.56 [Sun, Yuan 2006]
-    return (a_u + (a_t - a_u) * (w - g_u - z) / (g_t - g_u + 2 * w));
-  }
+  // Calculate the minimizer of the cubic that interpolates f_u, f_t, g_u and g_t
+  // Equation 2.4.52 [Sun, Yuan 2006]
+  double z = 3 * (f_t - f_u) / (a_t - a_u) - g_t - g_u;
+  double w = std::sqrt(z * z - g_t * g_u);
+  // Equation 2.4.56 [Sun, Yuan 2006]
+  return (a_u + (a_t - a_u) * (w - g_u - z) / (g_t - g_u + 2 * w));
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -901,13 +911,11 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeS
 
   if (d_phi_0 >= 0) {
     // Not a decent direction
-    if (d_phi_0 == 0)
-      return 0;
-    else {
-      // Reverse step direction and calculate optimal step.
-      d_phi_0 *= -1;
-      step_dir *= -1;
-    }
+    if (d_phi_0 == 0) return 0;
+
+    // Reverse step direction and calculate optimal step.
+    d_phi_0 *= -1;
+    step_dir *= -1;
   }
 
   // The Search Algorithm for T(mu) [More, Thuente 1994]
@@ -921,7 +929,8 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeS
   double nu = 0.9;
 
   // Initial endpoints of Interval I,
-  double a_l = 0, a_u = 0;
+  double a_l = 0;
+  double a_u = 0;
 
   // Auxiliary function psi is used until I is determined ot be a closed interval, Equation 2.1
   // [More, Thuente 1994]
@@ -933,7 +942,8 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeS
 
   // Check used to allow More-Thuente step length calculation to be skipped by making step_min ==
   // step_max
-  bool interval_converged = (step_max - step_min) < 0, open_interval = true;
+  bool interval_converged = (step_max - step_min) < 0;
+  bool open_interval = true;
 
   double a_t = step_init;
   a_t = std::min(a_t, step_max);

--- a/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp
+++ b/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp
@@ -730,7 +730,7 @@ void MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeHes
     // Equations 6.18 and 6.20 [Magnusson 2009]
     computePointDerivatives(x, point_gradient, point_hessian);
 
-    for (auto & cell : neighborhood) {
+    for (const auto & cell : neighborhood) {
       // Update hessian, lines 21 in Algorithm 2, according to Equations 6.10, 6.12 and 6.13,
       // respectively [Magnusson 2009]
       updateHessian(
@@ -740,7 +740,7 @@ void MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeHes
   }
 
   // Sum over t_hessians
-  for (auto & th : t_hessians) {
+  for (const auto & th : t_hessians) {
     hessian += th;
   }
 }
@@ -1098,7 +1098,7 @@ MultiGridNormalDistributionsTransform<PointSource, PointTarget>::calculateTransf
   }
 
   // Sum the point-wise scores
-  for (auto & ts : t_scores) {
+  for (const auto & ts : t_scores) {
     score += ts;
   }
 

--- a/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp
+++ b/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp
@@ -194,8 +194,8 @@ MultiGridNormalDistributionsTransform<
   params_.regularization_scale_factor = 0.0f;
   params_.use_line_search = false;
 
-  double gauss_c1;
-  double gauss_c2;
+  double gauss_c1 = NAN;
+  double gauss_c2 = NAN;
 
   // Initializes the gaussian fitting parameters (eq. 6.8) [Magnusson 2009]
   gauss_c1 = 10.0 * (1 - outlier_ratio_);
@@ -213,8 +213,8 @@ void MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeTra
   nr_iterations_ = 0;
   converged_ = false;
 
-  double gauss_c1;
-  double gauss_c2;
+  double gauss_c1 = NAN;
+  double gauss_c2 = NAN;
 
   // Initializes the gaussian fitting parameters (eq. 6.8) [Magnusson 2009]
   gauss_c1 = 10 * (1 - outlier_ratio_);
@@ -252,7 +252,7 @@ void MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeTra
   Eigen::Matrix<double, 6, 6> hessian;
 
   double score = 0;
-  double delta_p_norm;
+  double delta_p_norm = NAN;
 
   if (regularization_pose_) {
     Eigen::Transform<float, 3, Eigen::Affine, Eigen::ColMajor> regularization_pose_transformation;
@@ -506,12 +506,12 @@ void MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeAng
   Eigen::Matrix<double, 6, 1> & p, bool compute_hessian)
 {
   // Simplified math for near 0 angles
-  double cx;
-  double cy;
-  double cz;
-  double sx;
-  double sy;
-  double sz;
+  double cx = NAN;
+  double cy = NAN;
+  double cz = NAN;
+  double sx = NAN;
+  double sy = NAN;
+  double sz = NAN;
   if (fabs(p(3)) < 10e-5) {
     // p(3) = 0;
     cx = 1.0;
@@ -874,7 +874,7 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::trialVal
     // Equation 2.4.5 [Sun, Yuan 2006]
     double a_s = a_l - (a_l - a_t) / (g_l - g_t) * g_l;
 
-    double a_t_next;
+    double a_t_next = NAN;
 
     if (std::fabs(a_c - a_t) < std::fabs(a_s - a_t))
       a_t_next = a_c;

--- a/include/pclomp/gicp_omp.h
+++ b/include/pclomp/gicp_omp.h
@@ -340,7 +340,7 @@ protected:
   /// \brief optimization functor structure
   struct OptimizationFunctorWithIndices : public BFGSDummyFunctor<double, 6>
   {
-    OptimizationFunctorWithIndices(const GeneralizedIterativeClosestPoint * gicp)
+    explicit OptimizationFunctorWithIndices(const GeneralizedIterativeClosestPoint * gicp)
     : BFGSDummyFunctor<double, 6>(), gicp_(gicp)
     {
     }

--- a/include/pclomp/gicp_omp_impl.hpp
+++ b/include/pclomp/gicp_omp_impl.hpp
@@ -44,6 +44,9 @@
 #include <pcl/registration/exceptions.h>
 
 #include <atomic>
+#include <limits>
+#include <utility>
+#include <vector>
 
 ////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointSource, typename PointTarget>
@@ -52,7 +55,7 @@ void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::compute
   typename pcl::PointCloud<PointT>::ConstPtr cloud,
   const typename pcl::search::KdTree<PointT>::ConstPtr kdtree, MatricesVector & cloud_covariances)
 {
-  if (k_correspondences_ > int(cloud->size())) {
+  if (k_correspondences_ > static_cast<int>(cloud->size())) {
     PCL_ERROR(
       "[pcl::GeneralizedIterativeClosestPoint::computeCovariances] Number of points in cloud (%lu) "
       "is less than k_correspondences_ (%lu)!\n",
@@ -240,12 +243,13 @@ void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::
     PCL_DEBUG("BFGS solver finished with exit code %i \n", result);
     transformation_matrix.setIdentity();
     applyState(transformation_matrix, x);
-  } else
+  } else {
     PCL_THROW_EXCEPTION(
       pcl::SolverDidntConvergeException,
       "[pcl::" << getClassName()
                << "::TransformationEstimationBFGS::estimateRigidTransformation] BFGS solver didn't "
                   "converge!");
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////
@@ -370,7 +374,7 @@ inline void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::
         .template cast<double>() *
       res);
     // Increment total error
-    f += double(res.transpose() * temp);
+    f += static_cast<double>(res.transpose() * temp);
     // Increment translation gradient
     // g.head<3> ()+= 2*M*res/num_matches (we postpone 2/num_matches after the loop closes)
     g.head<3>() += temp;
@@ -379,8 +383,8 @@ inline void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::
     // Increment rotation gradient
     R += p_src3 * temp.transpose();
   }
-  f /= double(m);
-  g.head<3>() *= double(2.0 / m);
+  f /= static_cast<double>(m);
+  g.head<3>() *= static_cast<double>(2.0 / m);
   R *= 2.0 / m;
   gicp_->computeRDerivative(x, R, g);
 }
@@ -392,7 +396,6 @@ pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeTrans
   PointCloudSource & output, const Eigen::Matrix4f & guess)
 {
   pcl::IterativeClosestPoint<PointSource, PointTarget>::initComputeReciprocal();
-  using namespace std;
   // Difference between consecutive transforms
   double delta = 0;
   // Get the size of the target
@@ -436,7 +439,8 @@ pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeTrans
     for (size_t i = 0; i < 4; i++)
       for (size_t j = 0; j < 4; j++)
         for (size_t k = 0; k < 4; k++)
-          transform_R(i, j) += double(transformation_(i, k)) * double(guess(k, j));
+          transform_R(i, j) +=
+            static_cast<double>(transformation_(i, k)) * static_cast<double>(guess(k, j));
 
     const Eigen::Matrix3d R = transform_R.topLeftCorner<3, 3>();
 
@@ -533,8 +537,9 @@ pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeTrans
         "Transformation difference: %f\n",
         getClassName().c_str(), nr_iterations_, max_iterations_,
         (transformation_ - previous_transformation_).array().abs().sum());
-    } else
+    } else {
       PCL_DEBUG("[pcl::%s::computeTransformation] Convergence failed\n", getClassName().c_str());
+    }
   }
   final_transformation_ = previous_transformation_ * guess;
 

--- a/include/pclomp/gicp_omp_impl.hpp
+++ b/include/pclomp/gicp_omp_impl.hpp
@@ -227,7 +227,6 @@ void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::
 
   int inner_iterations_ = 0;
   int result = bfgs.minimizeInit(x);
-  result = BFGSSpace::Running;
   do {
     inner_iterations_++;
     result = bfgs.minimizeOneStep(x);
@@ -467,9 +466,9 @@ pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeTrans
         Eigen::Matrix4f & M_ = mahalanobis_[i];
         M_.setZero();
 
-        Eigen::Matrix3d M = M_.block<3, 3>(0, 0).cast<double>();
+        // Eigen::Matrix3d M = M_.block<3, 3>(0, 0).cast<double>();
         // M = R*C1
-        M = R * C1;
+        Eigen::Matrix3d M = R * C1;
         // temp = M*R' + C2 = R*C1*R' + C2
         Eigen::Matrix3d temp = M * R.transpose();
         temp += C2;

--- a/include/pclomp/ndt_omp.h
+++ b/include/pclomp/ndt_omp.h
@@ -182,7 +182,7 @@ public:
   inline Eigen::Matrix<double, 6, 6> getHessian() const { return hessian_; }
 
   /** \brief Return the transformation array */
-  inline const std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f>>
+  inline const std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f>> &
   getFinalTransformationArray() const
   {
     return transformation_array_;
@@ -322,7 +322,7 @@ protected:
    */
   double updateDerivatives(
     Eigen::Matrix<double, 6, 1> & score_gradient, Eigen::Matrix<double, 6, 6> & hessian,
-    const Eigen::Matrix<float, 4, 6> & point_gradient_,
+    const Eigen::Matrix<float, 4, 6> & point_gradient4,
     const Eigen::Matrix<float, 24, 6> & point_hessian_, const Eigen::Vector3d & x_trans,
     const Eigen::Matrix3d & c_inv, bool compute_hessian = true) const;
 

--- a/include/pclomp/ndt_omp_impl.hpp
+++ b/include/pclomp/ndt_omp_impl.hpp
@@ -69,8 +69,8 @@ pclomp::NormalDistributionsTransform<PointSource, PointTarget>::NormalDistributi
   params_.regularization_scale_factor = 0.0f;
   params_.use_line_search = false;
 
-  double gauss_c1;
-  double gauss_c2;
+  double gauss_c1 = NAN;
+  double gauss_c2 = NAN;
 
   // Initializes the gaussian fitting parameters (eq. 6.8) [Magnusson 2009]
   gauss_c1 = 10.0 * (1 - outlier_ratio_);
@@ -88,8 +88,8 @@ void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeTran
   nr_iterations_ = 0;
   converged_ = false;
 
-  double gauss_c1;
-  double gauss_c2;
+  double gauss_c1 = NAN;
+  double gauss_c2 = NAN;
 
   // Initializes the gaussian fitting parameters (eq. 6.8) [Magnusson 2009]
   gauss_c1 = 10 * (1 - outlier_ratio_);
@@ -122,7 +122,7 @@ void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeTran
   Eigen::Matrix<double, 6, 6> hessian;
 
   double score = 0;
-  double delta_p_norm;
+  double delta_p_norm = NAN;
 
   if (regularization_pose_) {
     Eigen::Transform<float, 3, Eigen::Affine, Eigen::ColMajor> regularization_pose_transformation;
@@ -400,12 +400,12 @@ void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeAngl
   Eigen::Matrix<double, 6, 1> & p, bool compute_hessian)
 {
   // Simplified math for near 0 angles
-  double cx;
-  double cy;
-  double cz;
-  double sx;
-  double sy;
-  double sz;
+  double cx = NAN;
+  double cy = NAN;
+  double cz = NAN;
+  double sx = NAN;
+  double sy = NAN;
+  double sz = NAN;
   if (fabs(p(3)) < 10e-5) {
     // p(3) = 0;
     cx = 1.0;
@@ -898,7 +898,7 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::trialValu
     // Equation 2.4.5 [Sun, Yuan 2006]
     double a_s = a_l - (a_l - a_t) / (g_l - g_t) * g_l;
 
-    double a_t_next;
+    double a_t_next = NAN;
 
     if (std::fabs(a_c - a_t) < std::fabs(a_s - a_t))
       a_t_next = a_c;

--- a/include/pclomp/ndt_omp_impl.hpp
+++ b/include/pclomp/ndt_omp_impl.hpp
@@ -1,4 +1,6 @@
 #include "ndt_omp.h"
+
+#include <cmath>
 /*
  * Software License Agreement (BSD License)
  *
@@ -42,6 +44,9 @@
 #ifndef PCL_REGISTRATION_NDT_OMP_IMPL_H_
 #define PCL_REGISTRATION_NDT_OMP_IMPL_H_
 
+#include <algorithm>
+#include <vector>
+
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointSource, typename PointTarget>
 pclomp::NormalDistributionsTransform<PointSource, PointTarget>::NormalDistributionsTransform()
@@ -51,30 +56,7 @@ pclomp::NormalDistributionsTransform<PointSource, PointTarget>::NormalDistributi
   gauss_d2_(),
   gauss_d3_(),
   trans_probability_(),
-  regularization_pose_(boost::none),
-  j_ang_a_(),
-  j_ang_b_(),
-  j_ang_c_(),
-  j_ang_d_(),
-  j_ang_e_(),
-  j_ang_f_(),
-  j_ang_g_(),
-  j_ang_h_(),
-  h_ang_a2_(),
-  h_ang_a3_(),
-  h_ang_b2_(),
-  h_ang_b3_(),
-  h_ang_c2_(),
-  h_ang_c3_(),
-  h_ang_d1_(),
-  h_ang_d2_(),
-  h_ang_d3_(),
-  h_ang_e1_(),
-  h_ang_e2_(),
-  h_ang_e3_(),
-  h_ang_f1_(),
-  h_ang_f2_(),
-  h_ang_f3_()
+  regularization_pose_(boost::none)
 {
   reg_name_ = "NormalDistributionsTransform";
 
@@ -87,7 +69,8 @@ pclomp::NormalDistributionsTransform<PointSource, PointTarget>::NormalDistributi
   params_.regularization_scale_factor = 0.0f;
   params_.use_line_search = false;
 
-  double gauss_c1, gauss_c2;
+  double gauss_c1;
+  double gauss_c2;
 
   // Initializes the gaussian fitting parameters (eq. 6.8) [Magnusson 2009]
   gauss_c1 = 10.0 * (1 - outlier_ratio_);
@@ -105,7 +88,8 @@ void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeTran
   nr_iterations_ = 0;
   converged_ = false;
 
-  double gauss_c1, gauss_c2;
+  double gauss_c1;
+  double gauss_c2;
 
   // Initializes the gaussian fitting parameters (eq. 6.8) [Magnusson 2009]
   gauss_c1 = 10 * (1 - outlier_ratio_);
@@ -127,7 +111,9 @@ void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeTran
   transformation_array_.push_back(final_transformation_);
 
   // Convert initial guess matrix to 6 element transformation vector
-  Eigen::Matrix<double, 6, 1> p, delta_p, score_gradient;
+  Eigen::Matrix<double, 6, 1> p;
+  Eigen::Matrix<double, 6, 1> delta_p;
+  Eigen::Matrix<double, 6, 1> score_gradient;
   Eigen::Vector3f init_translation = eig_transformation.translation();
   Eigen::Vector3f init_rotation = eig_transformation.rotation().eulerAngles(0, 1, 2);
   p << init_translation(0), init_translation(1), init_translation(2), init_rotation(0),
@@ -268,20 +254,22 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeDe
     int thread_n = omp_get_thread_num();
 
     // Original Point and Transformed Point
-    PointSource x_pt, x_trans_pt;
+    PointSource x_pt;
+    PointSource x_trans_pt;
     // Original Point and Transformed Point (for math)
-    Eigen::Vector3d x, x_trans;
+    Eigen::Vector3d x;
+    Eigen::Vector3d x_trans;
     // Occupied Voxel
     TargetGridLeafConstPtr cell;
     // Inverse Covariance of Occupied Voxel
     Eigen::Matrix3d c_inv;
 
     // Initialize Point Gradient and Hessian
-    Eigen::Matrix<float, 4, 6> point_gradient_;
-    Eigen::Matrix<float, 24, 6> point_hessian_;
-    point_gradient_.setZero();
-    point_gradient_.block<3, 3>(0, 0).setIdentity();
-    point_hessian_.setZero();
+    Eigen::Matrix<float, 4, 6> point_gradient;
+    Eigen::Matrix<float, 24, 6> point_hessian;
+    point_gradient.setZero();
+    point_gradient.block<3, 3>(0, 0).setIdentity();
+    point_hessian.setZero();
 
     x_trans_pt = trans_cloud.points[idx];
 
@@ -313,7 +301,7 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeDe
 
     for (typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it =
            neighborhood.begin();
-         neighborhood_it != neighborhood.end(); neighborhood_it++) {
+         neighborhood_it != neighborhood.end(); ++neighborhood_it) {
       cell = *neighborhood_it;
       x_pt = input_->points[idx];
       x = Eigen::Vector3d(x_pt.x, x_pt.y, x_pt.z);
@@ -327,11 +315,11 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeDe
 
       // Compute derivative of transform function w.r.t. transform vector, J_E and H_E in
       // Equations 6.18 and 6.20 [Magnusson 2009]
-      computePointDerivatives(x, point_gradient_, point_hessian_);
+      computePointDerivatives(x, point_gradient, point_hessian);
       // Update score, gradient and hessian, lines 19-21 in Algorithm 2, according to
       // Equations 6.10, 6.12 and 6.13, respectively [Magnusson 2009]
       double score_pt = updateDerivatives(
-        score_gradient_pt, hessian_pt, point_gradient_, point_hessian_, x_trans, c_inv,
+        score_gradient_pt, hessian_pt, point_gradient, point_hessian, x_trans, c_inv,
         compute_hessian);
       neighborhood_count++;
       sum_score_pt += score_pt;
@@ -412,7 +400,12 @@ void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeAngl
   Eigen::Matrix<double, 6, 1> & p, bool compute_hessian)
 {
   // Simplified math for near 0 angles
-  double cx, cy, cz, sx, sy, sz;
+  double cx;
+  double cy;
+  double cz;
+  double sx;
+  double sy;
+  double sz;
   if (fabs(p(3)) < 10e-5) {
     // p(3) = 0;
     cx = 1.0;
@@ -450,18 +443,28 @@ void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeAngl
   j_ang_h_ << (sx * cz + cx * sy * sz), (cx * sy * cz - sx * sz), 0;
 
   j_ang.setZero();
-  j_ang.row(0).noalias() =
-    Eigen::Vector4f((-sx * sz + cx * sy * cz), (-sx * cz - cx * sy * sz), (-cx * cy), 0.0f);
-  j_ang.row(1).noalias() =
-    Eigen::Vector4f((cx * sz + sx * sy * cz), (cx * cz - sx * sy * sz), (-sx * cy), 0.0f);
-  j_ang.row(2).noalias() = Eigen::Vector4f((-sy * cz), sy * sz, cy, 0.0f);
-  j_ang.row(3).noalias() = Eigen::Vector4f(sx * cy * cz, (-sx * cy * sz), sx * sy, 0.0f);
-  j_ang.row(4).noalias() = Eigen::Vector4f((-cx * cy * cz), cx * cy * sz, (-cx * sy), 0.0f);
-  j_ang.row(5).noalias() = Eigen::Vector4f((-cy * sz), (-cy * cz), 0, 0.0f);
-  j_ang.row(6).noalias() =
-    Eigen::Vector4f((cx * cz - sx * sy * sz), (-cx * sz - sx * sy * cz), 0, 0.0f);
-  j_ang.row(7).noalias() =
-    Eigen::Vector4f((sx * cz + cx * sy * sz), (cx * sy * cz - sx * sz), 0, 0.0f);
+  j_ang.row(0).noalias() = Eigen::Vector4f(
+    static_cast<float>(-sx * sz + cx * sy * cz), static_cast<float>(-sx * cz - cx * sy * sz),
+    static_cast<float>(-cx * cy), 0.0f);
+  j_ang.row(1).noalias() = Eigen::Vector4f(
+    static_cast<float>(cx * sz + sx * sy * cz), static_cast<float>(cx * cz - sx * sy * sz),
+    static_cast<float>(-sx * cy), 0.0f);
+  j_ang.row(2).noalias() = Eigen::Vector4f(
+    static_cast<float>(-sy * cz), static_cast<float>(sy * sz), static_cast<float>(cy), 0.0f);
+  j_ang.row(3).noalias() = Eigen::Vector4f(
+    static_cast<float>(sx * cy * cz), static_cast<float>(-sx * cy * sz),
+    static_cast<float>(sx * sy), 0.0f);
+  j_ang.row(4).noalias() = Eigen::Vector4f(
+    static_cast<float>(-cx * cy * cz), static_cast<float>(cx * cy * sz),
+    static_cast<float>(-cx * sy), 0.0f);
+  j_ang.row(5).noalias() =
+    Eigen::Vector4f(static_cast<float>(-cy * sz), static_cast<float>(-cy * cz), 0.0f, 0.0f);
+  j_ang.row(6).noalias() = Eigen::Vector4f(
+    static_cast<float>(cx * cz - sx * sy * sz), static_cast<float>(-cx * sz - sx * sy * cz), 0,
+    0.0f);
+  j_ang.row(7).noalias() = Eigen::Vector4f(
+    static_cast<float>(sx * cz + cx * sy * sz), static_cast<float>(cx * sy * cz - sx * sz), 0,
+    0.0f);
 
   if (compute_hessian) {
     // Precomputed angular hessian components. Letters correspond to Equation 6.21 and numbers
@@ -488,36 +491,52 @@ void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeAngl
     h_ang_f3_ << (-sx * sz + cx * sy * cz), (-cx * sy * sz - sx * cz), 0;
 
     h_ang.setZero();
-    h_ang.row(0).noalias() =
-      Eigen::Vector4f((-cx * sz - sx * sy * cz), (-cx * cz + sx * sy * sz), sx * cy, 0.0f);  // a2
+    h_ang.row(0).noalias() = Eigen::Vector4f(
+      static_cast<float>(-cx * sz - sx * sy * cz), static_cast<float>(-cx * cz + sx * sy * sz),
+      static_cast<float>(sx * cy), 0.0f);  // a2
     h_ang.row(1).noalias() = Eigen::Vector4f(
-      (-sx * sz + cx * sy * cz), (-cx * sy * sz - sx * cz), (-cx * cy), 0.0f);  // a3
+      static_cast<float>(-sx * sz + cx * sy * cz), static_cast<float>(-cx * sy * sz - sx * cz),
+      static_cast<float>(-cx * cy), 0.0f);  // a3
 
-    h_ang.row(2).noalias() =
-      Eigen::Vector4f((cx * cy * cz), (-cx * cy * sz), (cx * sy), 0.0f);  // b2
-    h_ang.row(3).noalias() =
-      Eigen::Vector4f((sx * cy * cz), (-sx * cy * sz), (sx * sy), 0.0f);  // b3
+    h_ang.row(2).noalias() = Eigen::Vector4f(
+      static_cast<float>(cx * cy * cz), static_cast<float>(-cx * cy * sz),
+      static_cast<float>(cx * sy), 0.0f);  // b2
+    h_ang.row(3).noalias() = Eigen::Vector4f(
+      static_cast<float>(sx * cy * cz), static_cast<float>(-sx * cy * sz),
+      static_cast<float>(sx * sy), 0.0f);  // b3
 
-    h_ang.row(4).noalias() =
-      Eigen::Vector4f((-sx * cz - cx * sy * sz), (sx * sz - cx * sy * cz), 0, 0.0f);  // c2
-    h_ang.row(5).noalias() =
-      Eigen::Vector4f((cx * cz - sx * sy * sz), (-sx * sy * cz - cx * sz), 0, 0.0f);  // c3
+    h_ang.row(4).noalias() = Eigen::Vector4f(
+      static_cast<float>(-sx * cz - cx * sy * sz), static_cast<float>(sx * sz - cx * sy * cz), 0.0f,
+      0.0f);  // c2
+    h_ang.row(5).noalias() = Eigen::Vector4f(
+      static_cast<float>(cx * cz - sx * sy * sz), static_cast<float>(-sx * sy * cz - cx * sz), 0.0f,
+      0.0f);  // c3
 
-    h_ang.row(6).noalias() = Eigen::Vector4f((-cy * cz), (cy * sz), (sy), 0.0f);  // d1
-    h_ang.row(7).noalias() =
-      Eigen::Vector4f((-sx * sy * cz), (sx * sy * sz), (sx * cy), 0.0f);  // d2
-    h_ang.row(8).noalias() =
-      Eigen::Vector4f((cx * sy * cz), (-cx * sy * sz), (-cx * cy), 0.0f);  // d3
+    h_ang.row(6).noalias() = Eigen::Vector4f(
+      static_cast<float>(-cy * cz), static_cast<float>(cy * sz), static_cast<float>(sy),
+      0.0f);  // d1
+    h_ang.row(7).noalias() = Eigen::Vector4f(
+      static_cast<float>(-sx * sy * cz), static_cast<float>(sx * sy * sz),
+      static_cast<float>(sx * cy), 0.0f);  // d2
+    h_ang.row(8).noalias() = Eigen::Vector4f(
+      static_cast<float>(cx * sy * cz), static_cast<float>(-cx * sy * sz),
+      static_cast<float>(-cx * cy), 0.0f);  // d3
 
-    h_ang.row(9).noalias() = Eigen::Vector4f((sy * sz), (sy * cz), 0, 0.0f);               // e1
-    h_ang.row(10).noalias() = Eigen::Vector4f((-sx * cy * sz), (-sx * cy * cz), 0, 0.0f);  // e2
-    h_ang.row(11).noalias() = Eigen::Vector4f((cx * cy * sz), (cx * cy * cz), 0, 0.0f);    // e3
+    h_ang.row(9).noalias() =
+      Eigen::Vector4f(static_cast<float>(sy * sz), static_cast<float>(sy * cz), 0.0f, 0.0f);  // e1
+    h_ang.row(10).noalias() = Eigen::Vector4f(
+      static_cast<float>(-sx * cy * sz), static_cast<float>(-sx * cy * cz), 0.0f, 0.0f);  // e2
+    h_ang.row(11).noalias() = Eigen::Vector4f(
+      static_cast<float>(cx * cy * sz), static_cast<float>(cx * cy * cz), 0.0f, 0.0f);  // e3
 
-    h_ang.row(12).noalias() = Eigen::Vector4f((-cy * cz), (cy * sz), 0, 0.0f);  // f1
-    h_ang.row(13).noalias() =
-      Eigen::Vector4f((-cx * sz - sx * sy * cz), (-cx * cz + sx * sy * sz), 0, 0.0f);  // f2
-    h_ang.row(14).noalias() =
-      Eigen::Vector4f((-sx * sz + cx * sy * cz), (-cx * sy * sz - sx * cz), 0, 0.0f);  // f3
+    h_ang.row(12).noalias() =
+      Eigen::Vector4f(static_cast<float>(-cy * cz), static_cast<float>(cy * sz), 0.0f, 0.0f);  // f1
+    h_ang.row(13).noalias() = Eigen::Vector4f(
+      static_cast<float>(-cx * sz - sx * sy * cz), static_cast<float>(-cx * cz + sx * sy * sz),
+      0.0f, 0.0f);  // f2
+    h_ang.row(14).noalias() = Eigen::Vector4f(
+      static_cast<float>(-sx * sz + cx * sy * cz), static_cast<float>(-cx * sy * sz - sx * cz),
+      0.0f, 0.0f);  // f3
   }
 }
 
@@ -527,7 +546,8 @@ void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computePoin
   Eigen::Vector3d & x, Eigen::Matrix<float, 4, 6> & point_gradient_,
   Eigen::Matrix<float, 24, 6> & point_hessian_, bool compute_hessian) const
 {
-  Eigen::Vector4f x4(x[0], x[1], x[2], 0.0f);
+  Eigen::Vector4f x4(
+    static_cast<float>(x[0]), static_cast<float>(x[1]), static_cast<float>(x[2]), 0.0f);
 
   // Calculate first derivative of Transformation Equation 6.17 w.r.t. transform vector p.
   // Derivative w.r.t. ith element of transform vector corresponds to column i, Equation 6.18
@@ -589,7 +609,12 @@ void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computePoin
 
   if (compute_hessian) {
     // Vectors from Equation 6.21 [Magnusson 2009]
-    Eigen::Vector3d a, b, c, d, e, f;
+    Eigen::Vector3d a;
+    Eigen::Vector3d b;
+    Eigen::Vector3d c;
+    Eigen::Vector3d d;
+    Eigen::Vector3d e;
+    Eigen::Vector3d f;
 
     a << 0, x.dot(h_ang_a2_), x.dot(h_ang_a3_);
     b << 0, x.dot(h_ang_b2_), x.dot(h_ang_b3_);
@@ -621,7 +646,9 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::updateDer
   const Eigen::Matrix<float, 24, 6> & point_hessian_, const Eigen::Vector3d & x_trans,
   const Eigen::Matrix3d & c_inv, bool compute_hessian) const
 {
-  Eigen::Matrix<float, 1, 4> x_trans4(x_trans[0], x_trans[1], x_trans[2], 0.0f);
+  Eigen::Matrix<float, 1, 4> x_trans4(
+    static_cast<float>(x_trans[0]), static_cast<float>(x_trans[1]), static_cast<float>(x_trans[2]),
+    0.0f);
   Eigen::Matrix4f c_inv4 = Eigen::Matrix4f::Zero();
   c_inv4.topLeftCorner(3, 3) = c_inv.cast<float>();
 
@@ -679,20 +706,22 @@ void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeHess
   Eigen::Matrix<double, 6, 1> &)
 {
   // Original Point and Transformed Point
-  PointSource x_pt, x_trans_pt;
+  PointSource x_pt;
+  PointSource x_trans_pt;
   // Original Point and Transformed Point (for math)
-  Eigen::Vector3d x, x_trans;
+  Eigen::Vector3d x;
+  Eigen::Vector3d x_trans;
   // Occupied Voxel
   TargetGridLeafConstPtr cell;
   // Inverse Covariance of Occupied Voxel
   Eigen::Matrix3d c_inv;
 
   // Initialize Point Gradient and Hessian
-  Eigen::Matrix<double, 3, 6> point_gradient_;
-  Eigen::Matrix<double, 18, 6> point_hessian_;
-  point_gradient_.setZero();
-  point_gradient_.block<3, 3>(0, 0).setIdentity();
-  point_hessian_.setZero();
+  Eigen::Matrix<double, 3, 6> point_gradient;
+  Eigen::Matrix<double, 18, 6> point_hessian;
+  point_gradient.setZero();
+  point_gradient.block<3, 3>(0, 0).setIdentity();
+  point_hessian.setZero();
 
   hessian.setZero();
 
@@ -724,7 +753,7 @@ void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeHess
 
     for (typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it =
            neighborhood.begin();
-         neighborhood_it != neighborhood.end(); neighborhood_it++) {
+         neighborhood_it != neighborhood.end(); ++neighborhood_it) {
       cell = *neighborhood_it;
 
       {
@@ -740,10 +769,10 @@ void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeHess
 
         // Compute derivative of transform function w.r.t. transform vector, J_E and H_E in
         // Equations 6.18 and 6.20 [Magnusson 2009]
-        computePointDerivatives(x, point_gradient_, point_hessian_);
+        computePointDerivatives(x, point_gradient, point_hessian);
         // Update hessian, lines 21 in Algorithm 2, according to Equations 6.10, 6.12 and 6.13,
         // respectively [Magnusson 2009]
-        updateHessian(hessian, point_gradient_, point_hessian_, x_trans, c_inv);
+        updateHessian(hessian, point_gradient, point_hessian, x_trans, c_inv);
       }
     }
   }
@@ -794,14 +823,14 @@ bool pclomp::NormalDistributionsTransform<PointSource, PointTarget>::updateInter
     return (false);
   }
   // Case U2 in Update Algorithm and Case b in Modified Update Algorithm [More, Thuente 1994]
-  else if (g_t * (a_l - a_t) > 0) {
+  if (g_t * (a_l - a_t) > 0) {
     a_l = a_t;
     f_l = f_t;
     g_l = g_t;
     return (false);
   }
   // Case U3 in Update Algorithm and Case c in Modified Update Algorithm [More, Thuente 1994]
-  else if (g_t * (a_l - a_t) < 0) {
+  if (g_t * (a_l - a_t) < 0) {
     a_u = a_l;
     f_u = f_l;
     g_u = g_l;
@@ -812,8 +841,7 @@ bool pclomp::NormalDistributionsTransform<PointSource, PointTarget>::updateInter
     return (false);
   }
   // Interval Converged
-  else
-    return (true);
+  return (true);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -835,13 +863,13 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::trialValu
     // Equation 2.4.2 [Sun, Yuan 2006]
     double a_q = a_l - 0.5 * (a_l - a_t) * g_l / (g_l - (f_l - f_t) / (a_l - a_t));
 
-    if (std::fabs(a_c - a_l) < std::fabs(a_q - a_l))
+    if (std::fabs(a_c - a_l) < std::fabs(a_q - a_l)) {
       return (a_c);
-    else
-      return (0.5 * (a_q + a_c));
+    }
+    return (0.5 * (a_q + a_c));
   }
   // Case 2 in Trial Value Selection [More, Thuente 1994]
-  else if (g_t * g_l < 0) {
+  if (g_t * g_l < 0) {
     // Calculate the minimizer of the cubic that interpolates f_l, f_t, g_l and g_t
     // Equation 2.4.52 [Sun, Yuan 2006]
     double z = 3 * (f_t - f_l) / (a_t - a_l) - g_t - g_l;
@@ -853,13 +881,13 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::trialValu
     // Equation 2.4.5 [Sun, Yuan 2006]
     double a_s = a_l - (a_l - a_t) / (g_l - g_t) * g_l;
 
-    if (std::fabs(a_c - a_t) >= std::fabs(a_s - a_t))
+    if (std::fabs(a_c - a_t) >= std::fabs(a_s - a_t)) {
       return (a_c);
-    else
-      return (a_s);
+    }
+    return (a_s);
   }
   // Case 3 in Trial Value Selection [More, Thuente 1994]
-  else if (std::fabs(g_t) <= std::fabs(g_l)) {
+  if (std::fabs(g_t) <= std::fabs(g_l)) {
     // Calculate the minimizer of the cubic that interpolates f_l, f_t, g_l and g_t
     // Equation 2.4.52 [Sun, Yuan 2006]
     double z = 3 * (f_t - f_l) / (a_t - a_l) - g_t - g_l;
@@ -877,20 +905,18 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::trialValu
     else
       a_t_next = a_s;
 
-    if (a_t > a_l)
+    if (a_t > a_l) {
       return (std::min(a_t + 0.66 * (a_u - a_t), a_t_next));
-    else
-      return (std::max(a_t + 0.66 * (a_u - a_t), a_t_next));
+    }
+    return (std::max(a_t + 0.66 * (a_u - a_t), a_t_next));
   }
   // Case 4 in Trial Value Selection [More, Thuente 1994]
-  else {
-    // Calculate the minimizer of the cubic that interpolates f_u, f_t, g_u and g_t
-    // Equation 2.4.52 [Sun, Yuan 2006]
-    double z = 3 * (f_t - f_u) / (a_t - a_u) - g_t - g_u;
-    double w = std::sqrt(z * z - g_t * g_u);
-    // Equation 2.4.56 [Sun, Yuan 2006]
-    return (a_u + (a_t - a_u) * (w - g_u - z) / (g_t - g_u + 2 * w));
-  }
+  // Calculate the minimizer of the cubic that interpolates f_u, f_t, g_u and g_t
+  // Equation 2.4.52 [Sun, Yuan 2006]
+  double z = 3 * (f_t - f_u) / (a_t - a_u) - g_t - g_u;
+  double w = std::sqrt(z * z - g_t * g_u);
+  // Equation 2.4.56 [Sun, Yuan 2006]
+  return (a_u + (a_t - a_u) * (w - g_u - z) / (g_t - g_u + 2 * w));
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -909,13 +935,11 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeSt
 
   if (d_phi_0 >= 0) {
     // Not a decent direction
-    if (d_phi_0 == 0)
-      return 0;
-    else {
-      // Reverse step direction and calculate optimal step.
-      d_phi_0 *= -1;
-      step_dir *= -1;
-    }
+    if (d_phi_0 == 0) return 0;
+
+    // Reverse step direction and calculate optimal step.
+    d_phi_0 *= -1;
+    step_dir *= -1;
   }
 
   // The Search Algorithm for T(mu) [More, Thuente 1994]
@@ -929,7 +953,8 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeSt
   double nu = 0.9;
 
   // Initial endpoints of Interval I,
-  double a_l = 0, a_u = 0;
+  double a_l = 0;
+  double a_u = 0;
 
   // Auxiliary function psi is used until I is determined ot be a closed interval, Equation 2.1
   // [More, Thuente 1994]
@@ -941,7 +966,8 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeSt
 
   // Check used to allow More-Thuente step length calculation to be skipped by making step_min ==
   // step_max
-  bool interval_converged = (step_max - step_min) < 0, open_interval = true;
+  bool interval_converged = (step_max - step_min) < 0;
+  bool open_interval = true;
 
   double a_t = step_init;
   a_t = std::min(a_t, step_max);
@@ -1091,7 +1117,7 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::calculate
 
     for (typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it =
            neighborhood.begin();
-         neighborhood_it != neighborhood.end(); neighborhood_it++) {
+         neighborhood_it != neighborhood.end(); ++neighborhood_it) {
       TargetGridLeafConstPtr cell = *neighborhood_it;
 
       Eigen::Vector3d x_trans = Eigen::Vector3d(x_trans_pt.x, x_trans_pt.y, x_trans_pt.z);
@@ -1148,7 +1174,7 @@ pclomp::NormalDistributionsTransform<PointSource, PointTarget>::calculateTransfo
 
     for (typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it =
            neighborhood.begin();
-         neighborhood_it != neighborhood.end(); neighborhood_it++) {
+         neighborhood_it != neighborhood.end(); ++neighborhood_it) {
       TargetGridLeafConstPtr cell = *neighborhood_it;
 
       Eigen::Vector3d x_trans = Eigen::Vector3d(x_trans_pt.x, x_trans_pt.y, x_trans_pt.z);
@@ -1206,7 +1232,7 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::
 
     for (typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it =
            neighborhood.begin();
-         neighborhood_it != neighborhood.end(); neighborhood_it++) {
+         neighborhood_it != neighborhood.end(); ++neighborhood_it) {
       TargetGridLeafConstPtr cell = *neighborhood_it;
 
       Eigen::Vector3d x_trans = Eigen::Vector3d(x_trans_pt.x, x_trans_pt.y, x_trans_pt.z);

--- a/include/pclomp/ndt_struct.hpp
+++ b/include/pclomp/ndt_struct.hpp
@@ -89,13 +89,13 @@ struct NdtResult
 
 struct NdtParams
 {
-  double trans_epsilon;
-  double step_size;
-  double resolution;
-  int max_iterations;
-  NeighborSearchMethod search_method;
-  int num_threads;
-  float regularization_scale_factor;
+  double trans_epsilon{};
+  double step_size{};
+  double resolution{};
+  int max_iterations{};
+  NeighborSearchMethod search_method{};
+  int num_threads{};
+  float regularization_scale_factor{};
 
   // line search is false by default
   // "use_lines_search = true" is not tested well

--- a/include/pclomp/voxel_grid_covariance_omp.h
+++ b/include/pclomp/voxel_grid_covariance_omp.h
@@ -386,7 +386,7 @@ public:
 
     // Find leaves corresponding to neighbors
     k_leaves.reserve(k);
-    for (std::vector<int>::iterator iter = k_indices.begin(); iter != k_indices.end(); iter++) {
+    for (std::vector<int>::iterator iter = k_indices.begin(); iter != k_indices.end(); ++iter) {
       k_leaves.push_back(&leaves_[voxel_centroids_leaf_indices_[*iter]]);
     }
     return k;
@@ -436,7 +436,7 @@ public:
 
     // Find leaves corresponding to neighbors
     k_leaves.reserve(k);
-    for (std::vector<int>::iterator iter = k_indices.begin(); iter != k_indices.end(); iter++) {
+    for (std::vector<int>::iterator iter = k_indices.begin(); iter != k_indices.end(); ++iter) {
       auto leaf = leaves_.find(voxel_centroids_leaf_indices_[*iter]);
       if (leaf == leaves_.end()) {
         std::cerr << "error : could not find the leaf corresponding to the voxel" << std::endl;

--- a/include/pclomp/voxel_grid_covariance_omp_impl.hpp
+++ b/include/pclomp/voxel_grid_covariance_omp_impl.hpp
@@ -191,7 +191,7 @@ void pclomp::VoxelGridCovariance<PointT>::applyFilter(PointCloud & output)
         // ---[ RGB special case
         if (rgba_index >= 0) {
           // fill r/g/b data
-          unsigned int rgb;
+          unsigned int rgb = 0;
           memcpy(
             &rgb, reinterpret_cast<const char *>(&input_->points[cp]) + rgba_index,
             sizeof(unsigned int));
@@ -250,7 +250,7 @@ void pclomp::VoxelGridCovariance<PointT>::applyFilter(PointCloud & output)
         // ---[ RGB special case
         if (rgba_index >= 0) {
           // Fill r/g/b data, assuming that the order is BGRA
-          unsigned int rgb;
+          unsigned int rgb = 0;
           memcpy(
             &rgb, reinterpret_cast<const char *>(&input_->points[cp]) + rgba_index, sizeof(int));
           centroid[centroid_size - 3] = static_cast<float>((rgb >> 16u) & 0x0000ffu);
@@ -278,7 +278,7 @@ void pclomp::VoxelGridCovariance<PointT>::applyFilter(PointCloud & output)
 
   // Eigen values less than a threshold of max eigen value are inflated to a set fraction of the max
   // eigen value.
-  double min_covar_eigvalue;
+  double min_covar_eigvalue = NAN;
 
   for (auto it = leaves_.begin(); it != leaves_.end(); ++it) {
     // Normalize the centroid

--- a/include/pclomp/voxel_grid_covariance_omp_impl.hpp
+++ b/include/pclomp/voxel_grid_covariance_omp_impl.hpp
@@ -46,6 +46,10 @@
 #include <pcl/common/common.h>
 #include <pcl/filters/boost.h>
 
+#include <cmath>
+#include <limits>
+#include <vector>
+
 //////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT>
 void pclomp::VoxelGridCovariance<PointT>::applyFilter(PointCloud & output)
@@ -65,7 +69,8 @@ void pclomp::VoxelGridCovariance<PointT>::applyFilter(PointCloud & output)
   output.is_dense = true;  // we filter out invalid points
   output.points.clear();
 
-  Eigen::Vector4f min_p, max_p;
+  Eigen::Vector4f min_p;
+  Eigen::Vector4f max_p;
   // Get the minimum and maximum dimensions
   if (!filter_field_name_.empty())  // If we don't want to process the entire cloud...
     pcl::getMinMax3D<PointT>(
@@ -117,7 +122,7 @@ void pclomp::VoxelGridCovariance<PointT>::applyFilter(PointCloud & output)
   rgba_index = pcl::getFieldIndex<PointT>("rgb", fields);
   if (rgba_index == -1) rgba_index = pcl::getFieldIndex<PointT>("rgba", fields);
   if (rgba_index >= 0) {
-    rgba_index = fields[rgba_index].offset;
+    rgba_index = static_cast<int>(fields[rgba_index].offset);
     centroid_size += 3;
   }
 
@@ -142,7 +147,7 @@ void pclomp::VoxelGridCovariance<PointT>::applyFilter(PointCloud & output)
           continue;
 
       // Get the distance value
-      const uint8_t * pt_data = reinterpret_cast<const uint8_t *>(&input_->points[cp]);
+      const auto * pt_data = reinterpret_cast<const uint8_t *>(&input_->points[cp]);
       float distance_value = 0;
       memcpy(&distance_value, pt_data + fields[distance_idx].offset, sizeof(float));
 
@@ -186,12 +191,13 @@ void pclomp::VoxelGridCovariance<PointT>::applyFilter(PointCloud & output)
         // ---[ RGB special case
         if (rgba_index >= 0) {
           // fill r/g/b data
-          int rgb;
+          unsigned int rgb;
           memcpy(
-            &rgb, reinterpret_cast<const char *>(&input_->points[cp]) + rgba_index, sizeof(int));
-          centroid[centroid_size - 3] = static_cast<float>((rgb >> 16) & 0x0000ff);
-          centroid[centroid_size - 2] = static_cast<float>((rgb >> 8) & 0x0000ff);
-          centroid[centroid_size - 1] = static_cast<float>((rgb) & 0x0000ff);
+            &rgb, reinterpret_cast<const char *>(&input_->points[cp]) + rgba_index,
+            sizeof(unsigned int));
+          centroid[centroid_size - 3] = static_cast<float>((rgb >> 16u) & 0x0000ffu);
+          centroid[centroid_size - 2] = static_cast<float>((rgb >> 8u) & 0x0000ffu);
+          centroid[centroid_size - 1] = static_cast<float>((rgb) & 0x0000ffu);
         }
         pcl::for_each_type<FieldList>(
           pcl::NdCopyPointEigenFunctor<PointT>(input_->points[cp], centroid));
@@ -199,9 +205,8 @@ void pclomp::VoxelGridCovariance<PointT>::applyFilter(PointCloud & output)
       }
       ++leaf.nr_points;
     }
-  }
-  // No distance filtering, process all data
-  else {
+    // No distance filtering, process all data
+  } else {
     // First pass: go over all points and insert them into the right leaf
     for (size_t cp = 0; cp < input_->points.size(); ++cp) {
       if (!input_->is_dense)
@@ -245,12 +250,12 @@ void pclomp::VoxelGridCovariance<PointT>::applyFilter(PointCloud & output)
         // ---[ RGB special case
         if (rgba_index >= 0) {
           // Fill r/g/b data, assuming that the order is BGRA
-          int rgb;
+          unsigned int rgb;
           memcpy(
             &rgb, reinterpret_cast<const char *>(&input_->points[cp]) + rgba_index, sizeof(int));
-          centroid[centroid_size - 3] = static_cast<float>((rgb >> 16) & 0x0000ff);
-          centroid[centroid_size - 2] = static_cast<float>((rgb >> 8) & 0x0000ff);
-          centroid[centroid_size - 1] = static_cast<float>((rgb) & 0x0000ff);
+          centroid[centroid_size - 3] = static_cast<float>((rgb >> 16u) & 0x0000ffu);
+          centroid[centroid_size - 2] = static_cast<float>((rgb >> 8u) & 0x0000ffu);
+          centroid[centroid_size - 1] = static_cast<float>((rgb) & 0x0000ffu);
         }
         pcl::for_each_type<FieldList>(
           pcl::NdCopyPointEigenFunctor<PointT>(input_->points[cp], centroid));
@@ -305,10 +310,12 @@ void pclomp::VoxelGridCovariance<PointT>::applyFilter(PointCloud & output)
         // ---[ RGB special case
         if (rgba_index >= 0) {
           // pack r/g/b into rgb
-          float r = leaf.centroid[centroid_size - 3], g = leaf.centroid[centroid_size - 2],
-                b = leaf.centroid[centroid_size - 1];
-          int rgb =
-            (static_cast<int>(r)) << 16 | (static_cast<int>(g)) << 8 | (static_cast<int>(b));
+          float r = leaf.centroid[centroid_size - 3];
+          float g = leaf.centroid[centroid_size - 2];
+          float b = leaf.centroid[centroid_size - 1];
+          int rgb = static_cast<int>(
+            (static_cast<unsigned int>(r)) << 16u | (static_cast<unsigned int>(g)) << 8u |
+            (static_cast<unsigned int>(b)));
           memcpy(reinterpret_cast<char *>(&output.points.back()) + rgba_index, &rgb, sizeof(float));
         }
       }

--- a/include/pclomp/voxel_grid_covariance_omp_impl.hpp
+++ b/include/pclomp/voxel_grid_covariance_omp_impl.hpp
@@ -130,8 +130,8 @@ void pclomp::VoxelGridCovariance<PointT>::applyFilter(PointCloud & output)
   // viewpoint first...
   if (!filter_field_name_.empty()) {
     // Get the distance field index
-    std::vector<pcl::PCLPointField> fields;
-    int distance_idx = pcl::getFieldIndex<PointT>(filter_field_name_, fields);
+    std::vector<pcl::PCLPointField> distance_fields;
+    int distance_idx = pcl::getFieldIndex<PointT>(filter_field_name_, distance_fields);
     if (distance_idx == -1)
       PCL_WARN(
         "[pcl::%s::applyFilter] Invalid filter field name. Index is %d.\n", getClassName().c_str(),
@@ -149,7 +149,7 @@ void pclomp::VoxelGridCovariance<PointT>::applyFilter(PointCloud & output)
       // Get the distance value
       const auto * pt_data = reinterpret_cast<const uint8_t *>(&input_->points[cp]);
       float distance_value = 0;
-      memcpy(&distance_value, pt_data + fields[distance_idx].offset, sizeof(float));
+      memcpy(&distance_value, pt_data + distance_fields[distance_idx].offset, sizeof(float));
 
       if (filter_limit_negative_) {
         // Use a threshold for cutting out points which inside the interval

--- a/src/estimate_covariance/estimate_covariance.cpp
+++ b/src/estimate_covariance/estimate_covariance.cpp
@@ -6,18 +6,18 @@
 namespace pclomp
 {
 
-Eigen::Matrix2d estimate_xy_covariance_by_Laplace_approximation(
+Eigen::Matrix2d estimate_xy_covariance_by_laplace_approximation(
   const Eigen::Matrix<double, 6, 6> & hessian)
 {
   const Eigen::Matrix2d hessian_xy = hessian.block<2, 2>(0, 0);
-  const Eigen::Matrix2d covariance_xy = -hessian_xy.inverse();
+  Eigen::Matrix2d covariance_xy = -hessian_xy.inverse();
   return covariance_xy;
 }
 
 ResultOfMultiNdtCovarianceEstimation estimate_xy_covariance_by_multi_ndt(
   const NdtResult & ndt_result,
-  std::shared_ptr<pclomp::MultiGridNormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>>
-    ndt_ptr,
+  const std::shared_ptr<
+    pclomp::MultiGridNormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>> & ndt_ptr,
   const std::vector<Eigen::Matrix4f> & poses_to_search)
 {
   // initialize by the main result
@@ -52,8 +52,8 @@ ResultOfMultiNdtCovarianceEstimation estimate_xy_covariance_by_multi_ndt(
 
 ResultOfMultiNdtCovarianceEstimation estimate_xy_covariance_by_multi_ndt_score(
   const NdtResult & ndt_result,
-  std::shared_ptr<pclomp::MultiGridNormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>>
-    ndt_ptr,
+  const std::shared_ptr<
+    pclomp::MultiGridNormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>> & ndt_ptr,
   const std::vector<Eigen::Matrix4f> & poses_to_search, const double temperature)
 {
   // initialize by the main result
@@ -77,7 +77,7 @@ ResultOfMultiNdtCovarianceEstimation estimate_xy_covariance_by_multi_ndt_score(
     NdtResult sub_ndt_result{};
     sub_ndt_result.pose = curr_pose;
     sub_ndt_result.iteration_num = 0;
-    sub_ndt_result.nearest_voxel_transformation_likelihood = nvtl;
+    sub_ndt_result.nearest_voxel_transformation_likelihood = static_cast<float>(nvtl);
     ndt_results.push_back(sub_ndt_result);
   }
 
@@ -182,7 +182,7 @@ Eigen::Matrix2d adjust_diagonal_covariance(
   Eigen::Matrix2d cov_base_link = rotate_covariance_to_base_link(covariance, pose);
   cov_base_link(0, 0) = std::max(cov_base_link(0, 0), fixed_cov00);
   cov_base_link(1, 1) = std::max(cov_base_link(1, 1), fixed_cov11);
-  const Eigen::Matrix2d cov_map = rotate_covariance_to_map(cov_base_link, pose);
+  Eigen::Matrix2d cov_map = rotate_covariance_to_map(cov_base_link, pose);
   return cov_map;
 }
 

--- a/src/estimate_covariance/estimate_covariance.cpp
+++ b/src/estimate_covariance/estimate_covariance.cpp
@@ -14,6 +14,18 @@ Eigen::Matrix2d estimate_xy_covariance_by_laplace_approximation(
   return covariance_xy;
 }
 
+// temporal compatibility until
+//   https://github.com/autowarefoundation/autoware.universe/pull/8124
+// get merged
+Eigen::Matrix2d estimate_xy_covariance_by_Laplace_approximation(
+  const Eigen::Matrix<double, 6, 6> & hessian)
+{
+  const Eigen::Matrix2d hessian_xy = hessian.block<2, 2>(0, 0);
+  Eigen::Matrix2d covariance_xy = -hessian_xy.inverse();
+  return covariance_xy;
+}
+
+
 ResultOfMultiNdtCovarianceEstimation estimate_xy_covariance_by_multi_ndt(
   const NdtResult & ndt_result,
   const std::shared_ptr<


### PR DESCRIPTION
## Description

This PR applies some suggestions from the linter to code.
Checked with clang-tidy and cppcheck.

needs to be merged with https://github.com/autowarefoundation/autoware.universe/pull/8124

**Fixed**:
- use explicit cast
- add initialization [cppcoreguidelines-init-variables]
- add missing headers
- change function/method
  - use lowercase
  - add keyword to function/method which linter suggested
- use prefix `++` operator
  - for performance
- removed
  - unused var, if branch


**Not Fixed**:
- error from under /usr/*
  - currently, it can't suppressed the errors using the autoware's settings: https://github.com/orgs/autowarefoundation/discussions/4876#discussioncomment-9900497
- safe access to members of unions by boost::variant
  - speed concern
- pointer arithmetic ([cppcoreguidelines-pro-bounds-pointer-arithmetic](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/cppcoreguidelines-pro-bounds-pointer-arithmetic.html))
- [readability-function-cognitive-complexity] from clang-tidy of function `applyFilter`
- using reinterpret_cast
- [cppcoreguidelines-macro-usage](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/cppcoreguidelines-macro-usage.html)
  - https://github.com/tier4/ndt_omp/blob/ef654bdb1a3fe0bae6f3247b4959e230e63ba429/include/pclomp/voxel_grid_covariance_omp_impl.hpp#L420
- [cppcoreguidelines-pro-type-member-init](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/cppcoreguidelines-pro-type-member-init.html)
  - for `thread_num_` in https://github.com/tier4/ndt_omp/blob/ef654bdb1a3fe0bae6f3247b4959e230e63ba429/include/multigrid_pclomp/multi_voxel_grid_covariance_omp_impl.hpp#L105 which initialized in the method
- [openmp-use-default-none]
- [missingMemberCopy]
  - because of comment from https://github.com/tier4/ndt_omp/blob/ef654bdb1a3fe0bae6f3247b4959e230e63ba429/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp#L70
- (deprecated warning for `testGradient`, not scoped for this PR)


## Interface Changes
This PR will change the [estimate_xy_covariance_by_Laplace_approximation](https://github.com/tier4/ndt_omp/blob/ef654bdb1a3fe0bae6f3247b4959e230e63ba429/src/estimate_covariance/estimate_covariance.cpp#L7) to `estimate_xy_covariance_by_laplace_approximation` (lowercase `laplace`) which effect the [ndt_scan_matcher](https://github.com/autowarefoundation/autoware.universe/tree/main/localization/ndt_scan_matcher).


## Checks
Checked with clang-tidy (v14.0.0) and cppcheck (v2.14.1).

Use `.cppcheck_suppressions` for suppressing some notation from cppcheck.

For ignoring some notes using the autoware, autoware.universe repo's suppression files , you need to add followings:
- `CPPLINT.cfg`: `filter=-legal/copyright`
- `.cppcheck_supressions`:  `missingMemberCopy`

<details>
<summary>check_linter.sh</summary>

```
#!/bin/bash
set -eux

TARGET_DIR=$1

current_dir=$(basename $(pwd))
if [[ ! $current_dir =~ ^(autoware|pilot-auto) ]]; then
    echo "This script must be run in a directory with a prefix of autoware or pilot-auto."
    exit 1
fi

set +eux
export CPLUS_INCLUDE_PATH=/usr/include/c++/11:/usr/include/x86_64-linux-gnu/c++/11:$CPLUS_INCLUDE_PATH
set -eux

fdfind -e cpp -e hpp --full-path ${TARGET_DIR} | xargs -P $(nproc) -I{} cpplint {}
fdfind -e cpp -e hpp --full-path ${TARGET_DIR} | xargs -P $(nproc) -I{} clang-tidy -p build/ {}
```
</details>

---

Before fixing the code:
<details>
<summary>Check with check_linter.sh</summary>

```Text
$ ./check_linter.sh ndt_omp
...
Done processing ./src/universe/external/ndt_omp/src/multigrid_pclomp/multi_voxel_grid_covariance_omp.cpp
Done processing ./src/universe/external/ndt_omp/src/pclomp/gicp_omp.cpp
./src/universe/external/ndt_omp/apps/pcd_map_grid_manager.hpp:27:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
Done processing ./src/universe/external/ndt_omp/src/multigrid_pclomp/multigrid_ndt_omp.cpp
Done processing ./src/universe/external/ndt_omp/src/pclomp/ndt_omp.cpp
Done processing ./src/universe/external/ndt_omp/src/pclomp/voxel_grid_covariance_omp.cpp
Done processing ./src/universe/external/ndt_omp/apps/timer.hpp
./src/universe/external/ndt_omp/apps/util.hpp:27:  Add #include <algorithm> for sort  [build/include_what_you_use] [4]
./src/universe/external/ndt_omp/apps/util.hpp:56:  Add #include <string> for string  [build/include_what_you_use] [4]
./src/universe/external/ndt_omp/apps/util.hpp:56:  Add #include <vector> for vector<>  [build/include_what_you_use] [4]
Done processing ./src/universe/external/ndt_omp/apps/util.hpp
Total errors found: 3
./src/universe/external/ndt_omp/include/estimate_covariance/estimate_covariance.hpp:29:  Add #include <memory> for shared_ptr<>  [build/include_what_you_use] [4]
./src/universe/external/ndt_omp/include/estimate_covariance/estimate_covariance.hpp:54:  Add #include <utility> for pair<>  [build/include_what_you_use] [4]
./src/universe/external/ndt_omp/include/estimate_covariance/estimate_covariance.hpp:55:  Add #include <vector> for vector<>  [build/include_what_you_use] [4]
Done processing ./src/universe/external/ndt_omp/include/estimate_covariance/estimate_covariance.hpp
Total errors found: 3
./src/universe/external/ndt_omp/apps/pcd_map_grid_manager.hpp:84:  Add #include <map> for map<>  [build/include_what_you_use] [4]
./src/universe/external/ndt_omp/apps/pcd_map_grid_manager.hpp:85:  Add #include <vector> for vector<>  [build/include_what_you_use] [4]
./src/universe/external/ndt_omp/apps/pcd_map_grid_manager.hpp:87:  Add #include <utility> for pair<>  [build/include_what_you_use] [4]
./src/universe/external/ndt_omp/apps/pcd_map_grid_manager.hpp:87:  Add #include <string> for string  [build/include_what_you_use] [4]
Done processing ./src/universe/external/ndt_omp/apps/pcd_map_grid_manager.hpp
Total errors found: 5
Done processing ./src/universe/external/ndt_omp/include/pclomp/ndt_struct.hpp
./src/universe/external/ndt_omp/include/pclomp/gicp_omp_impl.hpp:55:  Using deprecated casting style.  Use static_cast<int>(...) instead  [readability/casting] [4]
Done processing ./src/universe/external/ndt_omp/apps/align.cpp
Done processing ./src/universe/external/ndt_omp/apps/regression_test.cpp
Done processing ./src/universe/external/ndt_omp/src/estimate_covariance/estimate_covariance.cpp
Done processing ./src/universe/external/ndt_omp/apps/check_covariance.cpp
./src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:204:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:204:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src/universe/external/ndt_omp/include/pclomp/gicp_omp_impl.hpp:243:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src/universe/external/ndt_omp/include/pclomp/gicp_omp_impl.hpp:373:  Using deprecated casting style.  Use static_cast<double>(...) instead  [readability/casting] [4]
./src/universe/external/ndt_omp/include/pclomp/gicp_omp_impl.hpp:382:  Using deprecated casting style.  Use static_cast<double>(...) instead  [readability/casting] [4]
./src/universe/external/ndt_omp/include/pclomp/gicp_omp_impl.hpp:383:  Using deprecated casting style.  Use static_cast<double>(...) instead  [readability/casting] [4]
./src/universe/external/ndt_omp/include/pclomp/gicp_omp_impl.hpp:395:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
./src/universe/external/ndt_omp/include/pclomp/gicp_omp_impl.hpp:439:  Using deprecated casting style.  Use static_cast<double>(...) instead  [readability/casting] [4]
./src/universe/external/ndt_omp/include/multigrid_pclomp/multi_voxel_grid_covariance_omp_impl.hpp:209:  Add #include <utility> for move  [build/include_what_you_use] [4]
./src/universe/external/ndt_omp/include/multigrid_pclomp/multi_voxel_grid_covariance_omp_impl.hpp:282:  Add #include <string> for string  [build/include_what_you_use] [4]
./src/universe/external/ndt_omp/include/multigrid_pclomp/multi_voxel_grid_covariance_omp_impl.hpp:282:  Add #include <vector> for vector<>  [build/include_what_you_use] [4]
./src/universe/external/ndt_omp/include/multigrid_pclomp/multi_voxel_grid_covariance_omp_impl.hpp:340:  Add #include <map> for map<>  [build/include_what_you_use] [4]
./src/universe/external/ndt_omp/include/multigrid_pclomp/multi_voxel_grid_covariance_omp_impl.hpp:456:  Add #include <limits> for numeric_limits<>  [build/include_what_you_use] [4]
Done processing ./src/universe/external/ndt_omp/include/multigrid_pclomp/multi_voxel_grid_covariance_omp_impl.hpp
Total errors found: 5
./src/universe/external/ndt_omp/include/pclomp/gicp_omp_impl.hpp:536:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:351:  Add #include <limits> for numeric_limits<>  [build/include_what_you_use] [4]
./src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:429:  Add #include <vector> for vector<>  [build/include_what_you_use] [4]
Done processing ./src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp
Total errors found: 4
./src/universe/external/ndt_omp/include/pclomp/gicp_omp_impl.hpp:484:  Add #include <vector> for vector<>  [build/include_what_you_use] [4]
./src/universe/external/ndt_omp/include/pclomp/gicp_omp_impl.hpp:492:  Add #include <utility> for pair<>  [build/include_what_you_use] [4]
Done processing ./src/universe/external/ndt_omp/include/pclomp/gicp_omp_impl.hpp
Total errors found: 10
./src/universe/external/ndt_omp/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp:789:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src/universe/external/ndt_omp/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp:789:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src/universe/external/ndt_omp/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp:796:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src/universe/external/ndt_omp/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp:796:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src/universe/external/ndt_omp/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp:807:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src/universe/external/ndt_omp/include/pclomp/ndt_omp_impl.hpp:797:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src/universe/external/ndt_omp/include/pclomp/ndt_omp_impl.hpp:797:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src/universe/external/ndt_omp/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp:836:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src/universe/external/ndt_omp/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp:836:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src/universe/external/ndt_omp/include/pclomp/ndt_omp_impl.hpp:804:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src/universe/external/ndt_omp/include/pclomp/ndt_omp_impl.hpp:804:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src/universe/external/ndt_omp/include/pclomp/ndt_omp_impl.hpp:815:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src/universe/external/ndt_omp/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp:854:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src/universe/external/ndt_omp/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp:854:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src/universe/external/ndt_omp/include/pclomp/ndt_omp_impl.hpp:844:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src/universe/external/ndt_omp/include/pclomp/ndt_omp_impl.hpp:844:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src/universe/external/ndt_omp/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp:878:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src/universe/external/ndt_omp/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp:878:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src/universe/external/ndt_omp/include/pclomp/ndt_omp_impl.hpp:862:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src/universe/external/ndt_omp/include/pclomp/ndt_omp_impl.hpp:862:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src/universe/external/ndt_omp/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp:906:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src/universe/external/ndt_omp/include/pclomp/ndt_omp_impl.hpp:886:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src/universe/external/ndt_omp/include/pclomp/ndt_omp_impl.hpp:886:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src/universe/external/ndt_omp/include/pclomp/ndt_omp_impl.hpp:914:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src/universe/external/ndt_omp/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp:149:  Add #include <utility> for move  [build/include_what_you_use] [4]
./src/universe/external/ndt_omp/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp:994:  Add #include <algorithm> for max  [build/include_what_you_use] [4]
./src/universe/external/ndt_omp/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp:1131:  Add #include <vector> for vector<>  [build/include_what_you_use] [4]
Done processing ./src/universe/external/ndt_omp/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp
Total errors found: 15
./src/universe/external/ndt_omp/include/pclomp/ndt_omp_impl.hpp:1002:  Add #include <algorithm> for max  [build/include_what_you_use] [4]
./src/universe/external/ndt_omp/include/pclomp/ndt_omp_impl.hpp:1207:  Add #include <vector> for vector<>  [build/include_what_you_use] [4]
Done processing ./src/universe/external/ndt_omp/include/pclomp/ndt_omp_impl.hpp
```
</details>

<details>
<summary>Check with cppcheck:</summary>

```
(in .../ndt_omp)
$ cppcheck --enable=all --enable=style --enable=performance --enable=portability --enable=unusedFunction --inconclusive --check-level=exhaustive --suppressions-list=$HOME/autoware/src/universe/autoware.universe/.cppcheck_suppressions ./apps ./src/ -I include/

Checking apps/align.cpp ...
include/pclomp/gicp_omp.h:343:5: style: Struct 'OptimizationFunctorWithIndices' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
    OptimizationFunctorWithIndices(const GeneralizedIterativeClosestPoint * gicp)
    ^
include/pclomp/ndt_omp.h:186:3: performance: Function 'getFinalTransformationArray()' should return member 'transformation_array_' by const reference. [returnByReference]
  getFinalTransformationArray() const
  ^
include/multigrid_pclomp/multigrid_ndt_omp.h:232:3: performance: Function 'getFinalTransformationArray()' should return member 'transformation_array_' by const reference. [returnByReference]
  getFinalTransformationArray() const
  ^
apps/align.cpp:91:11: style: Variable 'aligned' is reassigned a value before the old one has been used. [redundantAssignment]
  aligned = align(ndt, target_cloud, source_cloud);
          ^
apps/align.cpp:85:11: note: aligned is assigned
  aligned = align(gicp_omp, target_cloud, source_cloud);
          ^
apps/align.cpp:91:11: note: aligned is overwritten
  aligned = align(ndt, target_cloud, source_cloud);
          ^
apps/align.cpp:116:13: style: Variable 'aligned' is reassigned a value before the old one has been used. [redundantAssignment]
    aligned = align(mg_ndt_omp, target_cloud, source_cloud);
            ^
apps/align.cpp:111:15: note: aligned is assigned
      aligned = align(ndt_omp, target_cloud, source_cloud);
              ^
apps/align.cpp:116:13: note: aligned is overwritten
    aligned = align(mg_ndt_omp, target_cloud, source_cloud);
            ^
include/multigrid_pclomp/multi_voxel_grid_covariance_omp.h:336:17: style: Variable 'thread_num_' is reassigned a value before the old one has been used. [redundantAssignment]
    thread_num_ = thread_num;
                ^
include/multigrid_pclomp/multi_voxel_grid_covariance_omp.h:333:19: note: thread_num_ is assigned
      thread_num_ = 1;
                  ^
include/multigrid_pclomp/multi_voxel_grid_covariance_omp.h:336:17: note: thread_num_ is overwritten
    thread_num_ = thread_num;
                ^
include/pclomp/voxel_grid_covariance_omp.h:389:88: performance: Prefer prefix ++/-- operators for non-primitive types. [postfixOperator]
    for (std::vector<int>::iterator iter = k_indices.begin(); iter != k_indices.end(); iter++) {
                                                                                       ^
include/pclomp/voxel_grid_covariance_omp.h:439:88: performance: Prefer prefix ++/-- operators for non-primitive types. [postfixOperator]
    for (std::vector<int>::iterator iter = k_indices.begin(); iter != k_indices.end(); iter++) {
                                                                                       ^
1/9 files checked 17% done
Checking apps/check_covariance.cpp ...
2/9 files checked 51% done
Checking apps/regression_test.cpp ...
apps/pcd_map_grid_manager.hpp:27:3: style: Class 'MapGridManager' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
  MapGridManager(const pcl::PointCloud<pcl::PointXYZ>::Ptr target_cloud)
  ^
3/9 files checked 69% done
Checking src/estimate_covariance/estimate_covariance.cpp ...
4/9 files checked 95% done
Checking src/multigrid_pclomp/multi_voxel_grid_covariance_omp.cpp ...
include/multigrid_pclomp/multi_voxel_grid_covariance_omp_impl.hpp:132:36: warning: inconclusive: Access of moved variable 'other'. [accessMoved]
  voxel_centroids_ptr_ = std::move(other.voxel_centroids_ptr_);
                                   ^
include/multigrid_pclomp/multi_voxel_grid_covariance_omp_impl.hpp:131:37: note: Calling std::move(other)
  pcl::VoxelGrid<PointT>::operator=(std::move(other));
                                    ^
include/multigrid_pclomp/multi_voxel_grid_covariance_omp_impl.hpp:132:36: note: Access of moved variable 'other'.
  voxel_centroids_ptr_ = std::move(other.voxel_centroids_ptr_);
                                   ^
include/multigrid_pclomp/multi_voxel_grid_covariance_omp_impl.hpp:133:27: warning: inconclusive: Access of moved variable 'other'. [accessMoved]
  sid_to_iid_ = std::move(other.sid_to_iid_);
                          ^
include/multigrid_pclomp/multi_voxel_grid_covariance_omp_impl.hpp:131:37: note: Calling std::move(other)
  pcl::VoxelGrid<PointT>::operator=(std::move(other));
                                    ^
include/multigrid_pclomp/multi_voxel_grid_covariance_omp_impl.hpp:133:27: note: Access of moved variable 'other'.
  sid_to_iid_ = std::move(other.sid_to_iid_);
                          ^
include/multigrid_pclomp/multi_voxel_grid_covariance_omp_impl.hpp:134:26: warning: inconclusive: Access of moved variable 'other'. [accessMoved]
  grid_list_ = std::move(other.grid_list_);
                         ^
include/multigrid_pclomp/multi_voxel_grid_covariance_omp_impl.hpp:131:37: note: Calling std::move(other)
  pcl::VoxelGrid<PointT>::operator=(std::move(other));
                                    ^
include/multigrid_pclomp/multi_voxel_grid_covariance_omp_impl.hpp:134:26: note: Access of moved variable 'other'.
  grid_list_ = std::move(other.grid_list_);
                         ^
include/multigrid_pclomp/multi_voxel_grid_covariance_omp_impl.hpp:135:23: warning: inconclusive: Access of moved variable 'other'. [accessMoved]
  kdtree_ = std::move(other.kdtree_);
                      ^
include/multigrid_pclomp/multi_voxel_grid_covariance_omp_impl.hpp:131:37: note: Calling std::move(other)
  pcl::VoxelGrid<PointT>::operator=(std::move(other));
                                    ^
include/multigrid_pclomp/multi_voxel_grid_covariance_omp_impl.hpp:135:23: note: Access of moved variable 'other'.
  kdtree_ = std::move(other.kdtree_);
                      ^
include/multigrid_pclomp/multi_voxel_grid_covariance_omp_impl.hpp:136:26: warning: inconclusive: Access of moved variable 'other'. [accessMoved]
  leaf_ptrs_ = std::move(other.leaf_ptrs_);
                         ^
include/multigrid_pclomp/multi_voxel_grid_covariance_omp_impl.hpp:131:37: note: Calling std::move(other)
  pcl::VoxelGrid<PointT>::operator=(std::move(other));
                                    ^
include/multigrid_pclomp/multi_voxel_grid_covariance_omp_impl.hpp:136:26: note: Access of moved variable 'other'.
  leaf_ptrs_ = std::move(other.leaf_ptrs_);
                         ^
include/multigrid_pclomp/multi_voxel_grid_covariance_omp_impl.hpp:138:27: warning: inconclusive: Access of moved variable 'other'. [accessMoved]
  min_points_per_voxel_ = other.min_points_per_voxel_;
                          ^
include/multigrid_pclomp/multi_voxel_grid_covariance_omp_impl.hpp:131:37: note: Calling std::move(other)
  pcl::VoxelGrid<PointT>::operator=(std::move(other));
                                    ^
include/multigrid_pclomp/multi_voxel_grid_covariance_omp_impl.hpp:138:27: note: Access of moved variable 'other'.
  min_points_per_voxel_ = other.min_points_per_voxel_;
                          ^
include/multigrid_pclomp/multi_voxel_grid_covariance_omp_impl.hpp:139:30: warning: inconclusive: Access of moved variable 'other'. [accessMoved]
  min_covar_eigvalue_mult_ = other.min_covar_eigvalue_mult_;
                             ^
include/multigrid_pclomp/multi_voxel_grid_covariance_omp_impl.hpp:131:37: note: Calling std::move(other)
  pcl::VoxelGrid<PointT>::operator=(std::move(other));
                                    ^
include/multigrid_pclomp/multi_voxel_grid_covariance_omp_impl.hpp:139:30: note: Access of moved variable 'other'.
  min_covar_eigvalue_mult_ = other.min_covar_eigvalue_mult_;
                             ^
5/9 files checked 96% done
Checking src/multigrid_pclomp/multigrid_ndt_omp.cpp ...
include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp:65:3: warning: inconclusive: Member variable 'MultiGridNormalDistributionsTransform < pcl :: PointXYZ , pcl :: PointXYZ >::j_ang_' is not assigned in the copy constructor. Should it be copied? [missingMemberCopy]
  MultiGridNormalDistributionsTransform(const MultiGridNormalDistributionsTransform & other)
  ^
...(omitted)
```
</details>

---

After this PR:

<details>
<summary>Check with check_linter.sh</summary>

```Text
$ ./check_linter.sh ndt_omp
...
4240 warnings generated.
Suppressed 4240 warnings (4240 in non-user code).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
15480 warnings and 20 errors generated.
Error while processing /home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/gicp_omp_impl.hpp.
error: too many errors emitted, stopping now [clang-diagnostic-error]
/usr/include/pcl-1.12/pcl/registration/boost.h:41:1: error: C++ requires a type specifier for all declarations [clang-diagnostic-error]
PCL_DEPRECATED_HEADER(1, 15, "Please include the needed boost headers directly.")
^
/usr/include/pcl-1.12/pcl/registration/boost.h:41:82: error: expected ';' after top level declarator [clang-diagnostic-error]
PCL_DEPRECATED_HEADER(1, 15, "Please include the needed boost headers directly.")
                                                                                 ^
/usr/include/stdlib.h:98:8: error: unknown type name 'size_t' [clang-diagnostic-error]
extern size_t __ctype_get_mb_cur_max (void) __THROW __wur;
       ^
... (omitted)
/usr/include/x86_64-linux-gnu/sys/types.h:108:19: note: 'ssize_t' declared here
typedef __ssize_t ssize_t;
                  ^
Suppressed 15480 warnings (15480 in non-user code).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
Found compiler error(s).
11891 warnings generated.
Suppressed 11893 warnings (11891 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
27496 warnings generated.
/home/masakibaba/autoware/src/universe/external/ndt_omp/apps/pcd_map_grid_manager.hpp:37:54: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      const int x = static_cast<int>(std::ceil(point.x / resolution_));
                                                     ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/apps/pcd_map_grid_manager.hpp:38:54: warning: do not access members of unions; use (boost::)variant instead [cppcoreguidelines-pro-type-union-access]
      const int y = static_cast<int>(std::ceil(point.y / resolution_));
                                                     ^
Suppressed 27496 warnings (27494 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
32574 warnings generated.
/home/masakibaba/autoware/src/universe/external/ndt_omp/apps/util.hpp:33:24: warning: do not use pointer arithmetic [cppcoreguidelines-pro-bounds-pointer-arithmetic]
    files.emplace_back(buffer.gl_pathv[i]);
                       ^
Suppressed 32575 warnings (32573 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
41071 warnings generated.
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:55:43: warning: function 'applyFilter' has cognitive complexity of 101 (threshold 25) [readability-function-cognitive-complexity]
void pclomp::VoxelGridCovariance<PointT>::applyFilter(PointCloud & output)
                                          ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:60:3: note: +1, including nesting penalty of 0, nesting level increased to 1
  if (!input_) {
  ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:75:3: note: +1, including nesting penalty of 0, nesting level increased to 1
  if (!filter_field_name_.empty())  // If we don't want to process the entire cloud...
  ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:79:3: note: +1, nesting level increased to 1
  else
  ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:87:3: note: +1, including nesting penalty of 0, nesting level increased to 1
  if ((dx * dy * dz) > std::numeric_limits<int32_t>::max()) {
  ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:117:3: note: +1, including nesting penalty of 0, nesting level increased to 1
  if (downsample_all_data_) centroid_size = boost::mpl::size<FieldList>::value;
  ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:123:3: note: +1, including nesting penalty of 0, nesting level increased to 1
  if (rgba_index == -1) rgba_index = pcl::getFieldIndex<PointT>("rgba", fields);
  ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:124:3: note: +1, including nesting penalty of 0, nesting level increased to 1
  if (rgba_index >= 0) {
  ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:131:3: note: +1, including nesting penalty of 0, nesting level increased to 1
  if (!filter_field_name_.empty()) {
  ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:135:5: note: +2, including nesting penalty of 1, nesting level increased to 2
    if (distance_idx == -1)
    ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:141:5: note: +2, including nesting penalty of 1, nesting level increased to 2
    for (size_t cp = 0; cp < input_->points.size(); ++cp) {
    ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:142:7: note: +3, including nesting penalty of 2, nesting level increased to 3
      if (!input_->is_dense)
      ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:144:9: note: +4, including nesting penalty of 3, nesting level increased to 4
        if (
        ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:145:88: note: +1
          !std::isfinite(input_->points[cp].x) || !std::isfinite(input_->points[cp].y) ||
                                                                                       ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:154:7: note: +3, including nesting penalty of 2, nesting level increased to 3
      if (filter_limit_negative_) {
      ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:156:9: note: +4, including nesting penalty of 3, nesting level increased to 4
        if ((distance_value < filter_limit_max_) && (distance_value > filter_limit_min_)) continue;
        ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:156:50: note: +1
        if ((distance_value < filter_limit_max_) && (distance_value > filter_limit_min_)) continue;
                                                 ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:157:9: note: +1, nesting level increased to 3
      } else {
        ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:159:9: note: +4, including nesting penalty of 3, nesting level increased to 4
        if ((distance_value > filter_limit_max_) || (distance_value < filter_limit_min_)) continue;
        ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:159:50: note: +1
        if ((distance_value > filter_limit_max_) || (distance_value < filter_limit_min_)) continue;
                                                 ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:173:7: note: +3, including nesting penalty of 2, nesting level increased to 3
      if (leaf.nr_points == 0) {
      ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:185:7: note: +3, including nesting penalty of 2, nesting level increased to 3
      if (!downsample_all_data_) {
      ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:188:9: note: +1, nesting level increased to 3
      } else {
        ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:192:9: note: +4, including nesting penalty of 3, nesting level increased to 4
        if (rgba_index >= 0) {
        ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:209:5: note: +1, nesting level increased to 1
  } else {
    ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:211:5: note: +2, including nesting penalty of 1, nesting level increased to 2
    for (size_t cp = 0; cp < input_->points.size(); ++cp) {
    ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:212:7: note: +3, including nesting penalty of 2, nesting level increased to 3
      if (!input_->is_dense)
      ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:214:9: note: +4, including nesting penalty of 3, nesting level increased to 4
        if (
        ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:215:88: note: +1
          !std::isfinite(input_->points[cp].x) || !std::isfinite(input_->points[cp].y) ||
                                                                                       ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:232:7: note: +3, including nesting penalty of 2, nesting level increased to 3
      if (leaf.nr_points == 0) {
      ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:244:7: note: +3, including nesting penalty of 2, nesting level increased to 3
      if (!downsample_all_data_) {
      ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:247:9: note: +1, nesting level increased to 3
      } else {
        ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:251:9: note: +4, including nesting penalty of 3, nesting level increased to 4
        if (rgba_index >= 0) {
        ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:270:3: note: +1, including nesting penalty of 0, nesting level increased to 1
  if (searchable_) voxel_centroids_leaf_indices_.reserve(leaves_.size());
  ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:272:3: note: +1, including nesting penalty of 0, nesting level increased to 1
  if (save_leaf_layout_) leaf_layout_.resize(div_b_[0] * div_b_[1] * div_b_[2], -1);
  ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:283:3: note: +1, including nesting penalty of 0, nesting level increased to 1
  for (auto it = leaves_.begin(); it != leaves_.end(); ++it) {
  ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:297:5: note: +2, including nesting penalty of 1, nesting level increased to 2
    if (leaf.nr_points >= min_points_per_voxel_) {
    ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:298:7: note: +3, including nesting penalty of 2, nesting level increased to 3
      if (save_leaf_layout_) leaf_layout_[it->first] = cp++;
      ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:303:7: note: +3, including nesting penalty of 2, nesting level increased to 3
      if (!downsample_all_data_) {
      ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:307:9: note: +1, nesting level increased to 3
      } else {
        ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:311:9: note: +4, including nesting penalty of 3, nesting level increased to 4
        if (rgba_index >= 0) {
        ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:324:7: note: +3, including nesting penalty of 2, nesting level increased to 3
      if (searchable_) voxel_centroids_leaf_indices_.push_back(static_cast<int>(it->first));
      ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:336:7: note: +3, including nesting penalty of 2, nesting level increased to 3
      if (eigen_val(0, 0) < 0 || eigen_val(1, 1) < 0 || eigen_val(2, 2) <= 0) {
      ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:336:54: note: +1
      if (eigen_val(0, 0) < 0 || eigen_val(1, 1) < 0 || eigen_val(2, 2) <= 0) {
                                                     ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:344:7: note: +3, including nesting penalty of 2, nesting level increased to 3
      if (eigen_val(0, 0) < min_covar_eigvalue) {
      ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:347:9: note: +4, including nesting penalty of 3, nesting level increased to 4
        if (eigen_val(1, 1) < min_covar_eigvalue) {
        ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:356:7: note: +3, including nesting penalty of 2, nesting level increased to 3
      if (
      ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:357:73: note: +1
        leaf.icov_.maxCoeff() == std::numeric_limits<float>::infinity() ||
                                                                        ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:150:30: warning: do not use reinterpret_cast [cppcoreguidelines-pro-type-reinterpret-cast]
      const auto * pt_data = reinterpret_cast<const uint8_t *>(&input_->points[cp]);
                             ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:152:39: warning: do not use pointer arithmetic [cppcoreguidelines-pro-bounds-pointer-arithmetic]
      memcpy(&distance_value, pt_data + fields[distance_idx].offset, sizeof(float));
                                      ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:194:24: warning: variable 'rgb' is not initialized [cppcoreguidelines-init-variables]
          unsigned int rgb;
                       ^
                           = 0
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:196:19: warning: do not use reinterpret_cast [cppcoreguidelines-pro-type-reinterpret-cast]
            &rgb, reinterpret_cast<const char *>(&input_->points[cp]) + rgba_index,
                  ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:196:71: warning: do not use pointer arithmetic [cppcoreguidelines-pro-bounds-pointer-arithmetic]
            &rgb, reinterpret_cast<const char *>(&input_->points[cp]) + rgba_index,
                                                                      ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:253:24: warning: variable 'rgb' is not initialized [cppcoreguidelines-init-variables]
          unsigned int rgb;
                       ^
                           = 0
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:255:19: warning: do not use reinterpret_cast [cppcoreguidelines-pro-type-reinterpret-cast]
            &rgb, reinterpret_cast<const char *>(&input_->points[cp]) + rgba_index, sizeof(int));
                  ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:255:71: warning: do not use pointer arithmetic [cppcoreguidelines-pro-bounds-pointer-arithmetic]
            &rgb, reinterpret_cast<const char *>(&input_->points[cp]) + rgba_index, sizeof(int));
                                                                      ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:281:10: warning: variable 'min_covar_eigvalue' is not initialized [cppcoreguidelines-init-variables]
  double min_covar_eigvalue;
         ^
                            = NAN
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:319:18: warning: do not use reinterpret_cast [cppcoreguidelines-pro-type-reinterpret-cast]
          memcpy(reinterpret_cast<char *>(&output.points.back()) + rgba_index, &rgb, sizeof(float));
                 ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:319:66: warning: do not use pointer arithmetic [cppcoreguidelines-pro-bounds-pointer-arithmetic]
          memcpy(reinterpret_cast<char *>(&output.points.back()) + rgba_index, &rgb, sizeof(float));
                                                                 ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/voxel_grid_covariance_omp_impl.hpp:482:9: warning: function-like macro 'PCL_INSTANTIATE_VoxelGridCovariance' used; consider a 'constexpr' template function [cppcoreguidelines-macro-usage]
#define PCL_INSTANTIATE_VoxelGridCovariance(T) \
        ^
Suppressed 41060 warnings (41058 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
40942 warnings generated.
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/multigrid_pclomp/multi_voxel_grid_covariance_omp_impl.hpp:69:1: warning: constructor does not initialize these fields: thread_num_ [cppcoreguidelines-pro-type-member-init]
template <typename PointT>
^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/multigrid_pclomp/multi_voxel_grid_covariance_omp_impl.hpp:91:1: warning: constructor does not initialize these fields: thread_num_ [cppcoreguidelines-pro-type-member-init]
template <typename PointT>
^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/multigrid_pclomp/multi_voxel_grid_covariance_omp_impl.hpp:471:9: warning: function-like macro 'PCL_INSTANTIATE_VoxelGridCovariance' used; consider a 'constexpr' template function [cppcoreguidelines-macro-usage]
#define PCL_INSTANTIATE_VoxelGridCovariance(T) \
        ^
Suppressed 40941 warnings (40939 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
46001 warnings generated.
Suppressed 46003 warnings (46001 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
48876 warnings generated.
Suppressed 48878 warnings (48876 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
51361 warnings generated.
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/ndt_omp_impl.hpp:51:1: warning: constructor does not initialize these fields: nearest_voxel_transformation_likelihood_ [cppcoreguidelines-pro-type-member-init]
template <typename PointSource, typename PointTarget>
^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/ndt_omp_impl.hpp:72:10: warning: variable 'gauss_c1' is not initialized [cppcoreguidelines-init-variables]
  double gauss_c1;
         ^
                  = NAN
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/pclomp/ndt_omp_impl.hpp:73:10: warning: variable 'gauss_c2' is not initialized [cppcoreguidelines-init-variables]
  double gauss_c2;
         ^
                  = NAN
... (omitted)
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp:513:10: warning: variable 'sy' is not initialized [cppcoreguidelines-init-variables]
  double sy;
         ^
            = NAN
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp:514:10: warning: variable 'sz' is not initialized [cppcoreguidelines-init-variables]
  double sz;
         ^
            = NAN
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp:712:1: warning: OpenMP directive 'parallel for' does not specify 'default' clause, consider specifying 'default(none)' clause [openmp-use-default-none]
#pragma omp parallel for num_threads(params_.num_threads) schedule(guided, 8)
^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp:877:12: warning: variable 'a_t_next' is not initialized [cppcoreguidelines-init-variables]
    double a_t_next;
           ^
                    = NAN
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp:1076:1: warning: OpenMP directive 'parallel for' does not specify 'default' clause, consider specifying 'default(none)' clause [openmp-use-default-none]
#pragma omp parallel for num_threads(params_.num_threads) schedule(guided, 8)
^
/home/masakibaba/autoware/src/universe/external/ndt_omp/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp:1135:1: warning: OpenMP directive 'parallel for' does not specify 'default' clause, consider specifying 'default(none)' clause [openmp-use-default-none]
#pragma omp parallel for num_threads(params_.num_threads) schedule(guided, 8)
^
Suppressed 50676 warnings (50674 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
55407 warnings generated.
Suppressed 55409 warnings (55407 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
72133 warnings generated.
Suppressed 72135 warnings (72133 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
67689 warnings generated.
/home/masakibaba/autoware/src/universe/external/ndt_omp/apps/check_covariance.cpp:31:33: warning: do not use pointer arithmetic [cppcoreguidelines-pro-bounds-pointer-arithmetic]
  const std::string input_dir = argv[1];
                                ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/apps/check_covariance.cpp:32:34: warning: do not use pointer arithmetic [cppcoreguidelines-pro-bounds-pointer-arithmetic]
  const std::string output_dir = argv[2];
                                 ^
Suppressed 67689 warnings (67687 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
79453 warnings generated.
Suppressed 79455 warnings (79451 in non-user code, 2 NOLINT, 2 with check filters).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
76622 warnings generated.
Suppressed 76624 warnings (76622 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
73310 warnings generated.
Suppressed 73312 warnings (73310 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
66882 warnings generated.
/home/masakibaba/autoware/src/universe/external/ndt_omp/apps/regression_test.cpp:46:33: warning: do not use pointer arithmetic [cppcoreguidelines-pro-bounds-pointer-arithmetic]
  const std::string input_dir = argv[1];
                                ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/apps/regression_test.cpp:47:34: warning: do not use pointer arithmetic [cppcoreguidelines-pro-bounds-pointer-arithmetic]
  const std::string output_dir = argv[2];
                                 ^
Suppressed 66882 warnings (66880 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
111674 warnings generated.
/home/masakibaba/autoware/src/universe/external/ndt_omp/apps/align.cpp:47:28: warning: do not use pointer arithmetic [cppcoreguidelines-pro-bounds-pointer-arithmetic]
  std::string target_pcd = argv[1];
                           ^
/home/masakibaba/autoware/src/universe/external/ndt_omp/apps/align.cpp:48:28: warning: do not use pointer arithmetic [cppcoreguidelines-pro-bounds-pointer-arithmetic]
  std::string source_pcd = argv[2];
                           ^
Suppressed 111674 warnings (111672 in non-user code, 2 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
```
</details>

<details>
<summary>Check with cppcheck </summary>

```
(in .../ndt_omp)
$ cppcheck --enable=all --enable=style --enable=performance --enable=portability --enable=unusedFunction --inconclusive --check-level=exhaustive --suppressions-list=$HOME/autoware/src/universe/autoware.universe/.cppcheck_suppressions ./apps ./src/ -I include/

Checking apps/align.cpp ...
1/9 files checked 17% done
Checking apps/check_covariance.cpp ...
2/9 files checked 52% done
Checking apps/regression_test.cpp ...
3/9 files checked 69% done
Checking src/estimate_covariance/estimate_covariance.cpp ...
4/9 files checked 95% done
Checking src/multigrid_pclomp/multi_voxel_grid_covariance_omp.cpp ...
5/9 files checked 96% done
Checking src/multigrid_pclomp/multigrid_ndt_omp.cpp ...
6/9 files checked 97% done
Checking src/pclomp/gicp_omp.cpp ...
7/9 files checked 98% done
Checking src/pclomp/ndt_omp.cpp ...
8/9 files checked 99% done
Checking src/pclomp/voxel_grid_covariance_omp.cpp ...
9/9 files checked 100% done
```
</details>

## Test
- Confirmed regression_test passed.
- Successfully building the autoware and it can run the `ndt_scan_matcher`.
  - you need apply the interface change to `ndt_scan_matcher`
