### PR TITLE
fix(ndt_omp): update clang-format and format code

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,118 +1,47 @@
----
-Language:        Cpp
-# BasedOnStyle:  Google
-AccessModifierOffset: -2
-AlignAfterOpenBracket: Align
-AlignConsecutiveAssignments: false
-AlignConsecutiveDeclarations: false
-AlignEscapedNewlines: Left
-AlignOperands:   true
-AlignTrailingComments: true
-AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortBlocksOnASingleLine: false
-AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: Empty
-AllowShortIfStatementsOnASingleLine: true
-AllowShortLoopsOnASingleLine: true
-AlwaysBreakAfterDefinitionReturnType: None
-AlwaysBreakAfterReturnType: None
-AlwaysBreakBeforeMultilineStrings: true
-AlwaysBreakTemplateDeclarations: true
-BinPackArguments: true
-BinPackParameters: false
-BraceWrapping:
-  AfterClass:      false
-  AfterControlStatement: false
-  AfterEnum:       false
-  AfterFunction:   false
-  AfterNamespace:  false
-  AfterObjCDeclaration: false
-  AfterStruct:     false
-  AfterUnion:      false
-  AfterExternBlock: false
-  BeforeCatch:     false
-  BeforeElse:      false
-  IndentBraces:    false
-  SplitEmptyFunction: true
-  SplitEmptyRecord: true
-  SplitEmptyNamespace: true
-BreakBeforeBinaryOperators: None
-BreakBeforeBraces: Attach
-BreakBeforeInheritanceComma: false
-BreakBeforeTernaryOperators: true
-BreakConstructorInitializersBeforeComma: false
-BreakConstructorInitializers: BeforeColon
-BreakAfterJavaFieldAnnotations: false
-BreakStringLiterals: false
-ColumnLimit:     256
-CommentPragmas:  '^ IWYU pragma:'
-CompactNamespaces: false
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
-ConstructorInitializerIndentWidth: 4
-ContinuationIndentWidth: 4
-Cpp11BracedListStyle: true
-DerivePointerAlignment: true
-DisableFormat:   false
-ExperimentalAutoDetectBinPacking: false
-FixNamespaceComments: true
-ForEachMacros:
-  - foreach
-  - Q_FOREACH
-  - BOOST_FOREACH
-IncludeBlocks:   Preserve
-IncludeCategories:
-  - Regex:           '^<ext/.*\.h>'
-    Priority:        2
-  - Regex:           '^<.*\.h>'
-    Priority:        1
-  - Regex:           '^<.*'
-    Priority:        2
-  - Regex:           '.*'
-    Priority:        3
-IncludeIsMainRegex: '([-_](test|unittest))?$'
-IndentCaseLabels: true
-IndentPPDirectives: None
-IndentWidth:     2
-IndentWrappedFunctionNames: false
-JavaScriptQuotes: Leave
-JavaScriptWrapImports: true
-KeepEmptyLinesAtTheStartOfBlocks: false
-MacroBlockBegin: ''
-MacroBlockEnd:   ''
-MaxEmptyLinesToKeep: 1
-NamespaceIndentation: None
-ObjCBlockIndentWidth: 2
-ObjCSpaceAfterProperty: false
-ObjCSpaceBeforeProtocolList: false
-PenaltyBreakAssignment: 2
-PenaltyBreakBeforeFirstCallParameter: 1
-PenaltyBreakComment: 300
-PenaltyBreakFirstLessLess: 120
-PenaltyBreakString: 1000
-PenaltyExcessCharacter: 0
-PenaltyReturnTypeOnItsOwnLine: 200
-PointerAlignment: Left
-RawStringFormats:
-  - Language: TextProto
-    Delimiters:
-      - pb
-    BasedOnStyle: google
-ReflowComments:  true
-SortIncludes:    false
-SortUsingDeclarations: false
-SpaceAfterCStyleCast: false
-SpaceAfterTemplateKeyword: false
-SpaceBeforeAssignmentOperators: true
-SpaceBeforeParens: Never
-SpaceInEmptyParentheses: false
-SpacesBeforeTrailingComments: 2
-SpacesInAngles:  false
-SpacesInContainerLiterals: true
-SpacesInCStyleCastParentheses: false
-SpacesInParentheses: false
-SpacesInSquareBrackets: false
-Standard:        Auto
-TabWidth:        8
-UseTab:          Never
-...
+# Modified from https://github.com/ament/ament_lint/blob/master/ament_clang_format/ament_clang_format/configuration/.clang-format
+Language: Cpp
+BasedOnStyle: Google
 
+AccessModifierOffset: -2
+AlignAfterOpenBracket: AlwaysBreak
+AllowShortFunctionsOnASingleLine: InlineOnly
+BraceWrapping:
+  AfterClass: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterStruct: true
+BreakBeforeBraces: Custom
+ColumnLimit: 100
+ConstructorInitializerIndentWidth: 0
+ContinuationIndentWidth: 2
+DerivePointerAlignment: false
+PointerAlignment: Middle
+ReflowComments: true
+IncludeCategories:
+  # C++ system headers
+  - Regex: <[a-z_]*>
+    Priority: 6
+    CaseSensitive: true
+  # C system headers
+  - Regex: <.*\.h>
+    Priority: 5
+    CaseSensitive: true
+  # Boost headers
+  - Regex: boost/.*
+    Priority: 4
+    CaseSensitive: true
+  # Message headers
+  - Regex: .*_msgs/.*
+    Priority: 3
+    CaseSensitive: true
+  - Regex: .*_srvs/.*
+    Priority: 3
+    CaseSensitive: true
+  # Other Package headers
+  - Regex: <.*>
+    Priority: 2
+    CaseSensitive: true
+  # Local package headers
+  - Regex: '".*"'
+    Priority: 1
+    CaseSensitive: true

--- a/apps/align.cpp
+++ b/apps/align.cpp
@@ -1,19 +1,23 @@
-#include <iostream>
-#include <chrono>
-#include <pcl/io/pcd_io.h>
-#include <pcl/point_types.h>
-#include <pcl/point_cloud.h>
-#include <pcl/registration/ndt.h>
-#include <pcl/registration/gicp.h>
-#include <pcl/filters/voxel_grid.h>
-#include <pcl/visualization/pcl_visualizer.h>
-
-#include <pclomp/ndt_omp.h>
-#include <pclomp/gicp_omp.h>
 #include <multigrid_pclomp/multigrid_ndt_omp.h>
+#include <pcl/filters/voxel_grid.h>
+#include <pcl/io/pcd_io.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+#include <pcl/registration/gicp.h>
+#include <pcl/registration/ndt.h>
+#include <pcl/visualization/pcl_visualizer.h>
+#include <pclomp/gicp_omp.h>
+#include <pclomp/ndt_omp.h>
+
+#include <chrono>
+#include <iostream>
 
 // align point clouds and measure processing time
-pcl::PointCloud<pcl::PointXYZ>::Ptr align(pcl::Registration<pcl::PointXYZ, pcl::PointXYZ>::Ptr registration, const pcl::PointCloud<pcl::PointXYZ>::Ptr& target_cloud, const pcl::PointCloud<pcl::PointXYZ>::Ptr& source_cloud) {
+pcl::PointCloud<pcl::PointXYZ>::Ptr align(
+  pcl::Registration<pcl::PointXYZ, pcl::PointXYZ>::Ptr registration,
+  const pcl::PointCloud<pcl::PointXYZ>::Ptr & target_cloud,
+  const pcl::PointCloud<pcl::PointXYZ>::Ptr & source_cloud)
+{
   registration->setInputTarget(target_cloud);
   registration->setInputSource(source_cloud);
   pcl::PointCloud<pcl::PointXYZ>::Ptr aligned(new pcl::PointCloud<pcl::PointXYZ>());
@@ -23,7 +27,7 @@ pcl::PointCloud<pcl::PointXYZ>::Ptr align(pcl::Registration<pcl::PointXYZ, pcl::
   auto t2 = std::chrono::system_clock::now();
   std::cout << "single : " << (t2 - t1).count() / 1e6 << "[msec]" << std::endl;
 
-  for(int i = 0; i < 10; i++) {
+  for (int i = 0; i < 10; i++) {
     registration->align(*aligned);
   }
   auto t3 = std::chrono::system_clock::now();
@@ -33,8 +37,9 @@ pcl::PointCloud<pcl::PointXYZ>::Ptr align(pcl::Registration<pcl::PointXYZ, pcl::
   return aligned;
 }
 
-int main(int argc, char** argv) {
-  if(argc != 3) {
+int main(int argc, char ** argv)
+{
+  if (argc != 3) {
     std::cout << "usage: align target.pcd source.pcd" << std::endl;
     return 0;
   }
@@ -45,11 +50,11 @@ int main(int argc, char** argv) {
   pcl::PointCloud<pcl::PointXYZ>::Ptr target_cloud(new pcl::PointCloud<pcl::PointXYZ>());
   pcl::PointCloud<pcl::PointXYZ>::Ptr source_cloud(new pcl::PointCloud<pcl::PointXYZ>());
 
-  if(pcl::io::loadPCDFile(target_pcd, *target_cloud)) {
+  if (pcl::io::loadPCDFile(target_pcd, *target_cloud)) {
     std::cerr << "failed to load " << target_pcd << std::endl;
     return 0;
   }
-  if(pcl::io::loadPCDFile(source_pcd, *source_cloud)) {
+  if (pcl::io::loadPCDFile(source_pcd, *source_cloud)) {
     std::cerr << "failed to load " << source_pcd << std::endl;
     return 0;
   }
@@ -70,30 +75,37 @@ int main(int argc, char** argv) {
 
   // benchmark
   std::cout << "--- pcl::GICP ---" << std::endl;
-  pcl::GeneralizedIterativeClosestPoint<pcl::PointXYZ, pcl::PointXYZ>::Ptr gicp(new pcl::GeneralizedIterativeClosestPoint<pcl::PointXYZ, pcl::PointXYZ>());
+  pcl::GeneralizedIterativeClosestPoint<pcl::PointXYZ, pcl::PointXYZ>::Ptr gicp(
+    new pcl::GeneralizedIterativeClosestPoint<pcl::PointXYZ, pcl::PointXYZ>());
   pcl::PointCloud<pcl::PointXYZ>::Ptr aligned = align(gicp, target_cloud, source_cloud);
 
   std::cout << "--- pclomp::GICP ---" << std::endl;
-  pclomp::GeneralizedIterativeClosestPoint<pcl::PointXYZ, pcl::PointXYZ>::Ptr gicp_omp(new pclomp::GeneralizedIterativeClosestPoint<pcl::PointXYZ, pcl::PointXYZ>());
+  pclomp::GeneralizedIterativeClosestPoint<pcl::PointXYZ, pcl::PointXYZ>::Ptr gicp_omp(
+    new pclomp::GeneralizedIterativeClosestPoint<pcl::PointXYZ, pcl::PointXYZ>());
   aligned = align(gicp_omp, target_cloud, source_cloud);
 
   std::cout << "--- pcl::NDT ---" << std::endl;
-  pcl::NormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>::Ptr ndt(new pcl::NormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>());
+  pcl::NormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>::Ptr ndt(
+    new pcl::NormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>());
   ndt->setResolution(1.0);
   aligned = align(ndt, target_cloud, source_cloud);
 
   std::vector<int> num_threads = {1, omp_get_max_threads()};
-  std::vector<std::pair<std::string, pclomp::NeighborSearchMethod>> search_methods = {{"KDTREE", pclomp::KDTREE}, {"DIRECT7", pclomp::DIRECT7}, {"DIRECT1", pclomp::DIRECT1}};
+  std::vector<std::pair<std::string, pclomp::NeighborSearchMethod>> search_methods = {
+    {"KDTREE", pclomp::KDTREE}, {"DIRECT7", pclomp::DIRECT7}, {"DIRECT1", pclomp::DIRECT1}};
 
-  pclomp::NormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>::Ptr ndt_omp(new pclomp::NormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>());
+  pclomp::NormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>::Ptr ndt_omp(
+    new pclomp::NormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>());
   ndt_omp->setResolution(1.0);
 
-  pclomp::MultiGridNormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>::Ptr mg_ndt_omp(new pclomp::MultiGridNormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>());
+  pclomp::MultiGridNormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>::Ptr mg_ndt_omp(
+    new pclomp::MultiGridNormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>());
   mg_ndt_omp->setResolution(1.0);
 
-  for(int n : num_threads) {
-    for(const auto& search_method : search_methods) {
-      std::cout << "--- pclomp::NDT (" << search_method.first << ", " << n << " threads) ---" << std::endl;
+  for (int n : num_threads) {
+    for (const auto & search_method : search_methods) {
+      std::cout << "--- pclomp::NDT (" << search_method.first << ", " << n << " threads) ---"
+                << std::endl;
       ndt_omp->setNumThreads(n);
       ndt_omp->setNeighborhoodSearchMethod(search_method.second);
       aligned = align(ndt_omp, target_cloud, source_cloud);
@@ -106,9 +118,12 @@ int main(int argc, char** argv) {
 
   // visualization
   pcl::visualization::PCLVisualizer vis("vis");
-  pcl::visualization::PointCloudColorHandlerCustom<pcl::PointXYZ> target_handler(target_cloud, 255.0, 0.0, 0.0);
-  pcl::visualization::PointCloudColorHandlerCustom<pcl::PointXYZ> source_handler(source_cloud, 0.0, 255.0, 0.0);
-  pcl::visualization::PointCloudColorHandlerCustom<pcl::PointXYZ> aligned_handler(aligned, 0.0, 0.0, 255.0);
+  pcl::visualization::PointCloudColorHandlerCustom<pcl::PointXYZ> target_handler(
+    target_cloud, 255.0, 0.0, 0.0);
+  pcl::visualization::PointCloudColorHandlerCustom<pcl::PointXYZ> source_handler(
+    source_cloud, 0.0, 255.0, 0.0);
+  pcl::visualization::PointCloudColorHandlerCustom<pcl::PointXYZ> aligned_handler(
+    aligned, 0.0, 0.0, 255.0);
   vis.addPointCloud(target_cloud, target_handler, "target");
   vis.addPointCloud(source_cloud, source_handler, "source");
   vis.addPointCloud(aligned, aligned_handler, "aligned");

--- a/apps/check_covariance.cpp
+++ b/apps/check_covariance.cpp
@@ -1,24 +1,29 @@
-#include <iostream>
-#include <chrono>
-#include <pcl/io/pcd_io.h>
-#include <pcl/point_types.h>
-#include <pcl/point_cloud.h>
-#include <pcl/registration/ndt.h>
-#include <pcl/registration/gicp.h>
-#include <pcl/filters/voxel_grid.h>
-#include <pcl/visualization/pcl_visualizer.h>
-#include <omp.h>
-#include <glob.h>
-#include <filesystem>
-
-#include <pclomp/gicp_omp.h>
-#include <multigrid_pclomp/multigrid_ndt_omp.h>
 #include "estimate_covariance/estimate_covariance.hpp"
 
-#include "util.hpp"
+#include <glob.h>
+#include <multigrid_pclomp/multigrid_ndt_omp.h>
+#include <omp.h>
+#include <pcl/filters/voxel_grid.h>
+#include <pcl/io/pcd_io.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+#include <pcl/registration/gicp.h>
+#include <pcl/registration/ndt.h>
+#include <pcl/visualization/pcl_visualizer.h>
+#include <pclomp/gicp_omp.h>
 
-int main(int argc, char** argv) {
-  if(argc != 3) {
+// this must included after pcd_io.h
+// clang-format off
+#include "util.hpp"
+// clang-format on
+
+#include <chrono>
+#include <filesystem>
+#include <iostream>
+
+int main(int argc, char ** argv)
+{
+  if (argc != 3) {
     std::cout << "usage: ./regression_test <input_dir> <output_dir>" << std::endl;
     return 0;
   }
@@ -35,16 +40,18 @@ int main(int argc, char** argv) {
   const std::vector<std::string> source_pcd_list = glob(source_pcd_dir);
 
   // load kinematic_state.csv
-  const std::vector<Eigen::Matrix4f> initial_pose_list = load_pose_list(input_dir + "/kinematic_state.csv");
+  const std::vector<Eigen::Matrix4f> initial_pose_list =
+    load_pose_list(input_dir + "/kinematic_state.csv");
 
-  if(initial_pose_list.size() != source_pcd_list.size()) {
+  if (initial_pose_list.size() != source_pcd_list.size()) {
     std::cerr << "initial_pose_list.size() != source_pcd_list.size()" << std::endl;
     return 1;
   }
   const int64_t n_data = initial_pose_list.size();
 
   // prepare ndt
-  std::shared_ptr<pclomp::MultiGridNormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>> mg_ndt_omp(new pclomp::MultiGridNormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>());
+  std::shared_ptr<pclomp::MultiGridNormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>>
+    mg_ndt_omp(new pclomp::MultiGridNormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>());
   mg_ndt_omp->setInputTarget(target_cloud);
   mg_ndt_omp->setResolution(2.0);
   mg_ndt_omp->setNumThreads(4);
@@ -67,10 +74,14 @@ int main(int argc, char** argv) {
   ofs << "result_x,result_y,result_yaw,";
   ofs << "elapsed_la,cov_by_la_00,cov_by_la_01,cov_by_la_10,cov_by_la_11,";
   ofs << "elapsed_mndt,cov_by_mndt_00,cov_by_mndt_01,cov_by_mndt_10,cov_by_mndt_11,";
-  ofs << "elapsed_mndt_score,cov_by_mndt_score_00,cov_by_mndt_score_01,cov_by_mndt_score_10,cov_by_mndt_score_11,";
+  ofs << "elapsed_mndt_score,cov_by_mndt_score_00,cov_by_mndt_score_01,cov_by_mndt_score_10,cov_by_"
+         "mndt_score_11,";
   ofs << "cov_by_la_rotated_00,cov_by_la_rotated_01,cov_by_la_rotated_10,cov_by_la_rotated_11,";
-  ofs << "cov_by_mndt_rotated_00,cov_by_mndt_rotated_01,cov_by_mndt_rotated_10,cov_by_mndt_rotated_11,";
-  ofs << "cov_by_mndt_score_rotated_00,cov_by_mndt_score_rotated_01,cov_by_mndt_score_rotated_10,cov_by_mndt_score_rotated_11" << std::endl;
+  ofs << "cov_by_mndt_rotated_00,cov_by_mndt_rotated_01,cov_by_mndt_rotated_10,cov_by_mndt_rotated_"
+         "11,";
+  ofs << "cov_by_mndt_score_rotated_00,cov_by_mndt_score_rotated_01,cov_by_mndt_score_rotated_10,"
+         "cov_by_mndt_score_rotated_11"
+      << std::endl;
 
   const std::string multi_ndt_dir = output_dir + "/multi_ndt";
   std::filesystem::create_directories(multi_ndt_dir);
@@ -81,11 +92,11 @@ int main(int argc, char** argv) {
   auto t2 = std::chrono::system_clock::now();
 
   // execute align
-  for(int64_t i = 0; i < n_data; i++) {
+  for (int64_t i = 0; i < n_data; i++) {
     const Eigen::Matrix4f initial_pose = initial_pose_list[i];
-    const std::string& source_pcd = source_pcd_list[i];
+    const std::string & source_pcd = source_pcd_list[i];
     pcl::PointCloud<pcl::PointXYZ>::Ptr source_cloud(new pcl::PointCloud<pcl::PointXYZ>());
-    if(pcl::io::loadPCDFile(source_pcd, *source_cloud)) {
+    if (pcl::io::loadPCDFile(source_pcd, *source_cloud)) {
       std::cerr << "failed to load " << source_pcd << std::endl;
       return 1;
     }
@@ -94,49 +105,69 @@ int main(int argc, char** argv) {
     mg_ndt_omp->align(*aligned, initial_pose);
     const pclomp::NdtResult ndt_result = mg_ndt_omp->getResult();
     const double score = ndt_result.nearest_voxel_transformation_likelihood;
-    std::cout << source_pcd << ", num=" << std::setw(4) << source_cloud->size() << " points, score=" << score << std::endl;
+    std::cout << source_pcd << ", num=" << std::setw(4) << source_cloud->size()
+              << " points, score=" << score << std::endl;
 
-    const std::vector<Eigen::Matrix4f> poses_to_search = pclomp::propose_poses_to_search(ndt_result, offset_x, offset_y);
+    const std::vector<Eigen::Matrix4f> poses_to_search =
+      pclomp::propose_poses_to_search(ndt_result, offset_x, offset_y);
 
     // estimate covariance
     // (1) Laplace approximation
     t1 = std::chrono::system_clock::now();
-    const Eigen::Matrix2d cov_by_la = pclomp::estimate_xy_covariance_by_Laplace_approximation(ndt_result.hessian);
+    const Eigen::Matrix2d cov_by_la =
+      pclomp::estimate_xy_covariance_by_Laplace_approximation(ndt_result.hessian);
     t2 = std::chrono::system_clock::now();
-    const auto elapsed_la = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count() / 1000.0;
+    const auto elapsed_la =
+      std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count() / 1000.0;
 
     // (2) Multi NDT
     t1 = std::chrono::system_clock::now();
-    const pclomp::ResultOfMultiNdtCovarianceEstimation result_of_mndt = pclomp::estimate_xy_covariance_by_multi_ndt(ndt_result, mg_ndt_omp, poses_to_search);
-    const Eigen::Matrix2d cov_by_mndt = pclomp::adjust_diagonal_covariance(result_of_mndt.covariance, ndt_result.pose, 0.0225, 0.0225);
+    const pclomp::ResultOfMultiNdtCovarianceEstimation result_of_mndt =
+      pclomp::estimate_xy_covariance_by_multi_ndt(ndt_result, mg_ndt_omp, poses_to_search);
+    const Eigen::Matrix2d cov_by_mndt = pclomp::adjust_diagonal_covariance(
+      result_of_mndt.covariance, ndt_result.pose, 0.0225, 0.0225);
     t2 = std::chrono::system_clock::now();
-    const auto elapsed_mndt = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count() / 1000.0;
+    const auto elapsed_mndt =
+      std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count() / 1000.0;
 
     // (3) Multi NDT with score
     const double temperature = 0.1;
     t1 = std::chrono::system_clock::now();
-    const pclomp::ResultOfMultiNdtCovarianceEstimation result_of_mndt_score = pclomp::estimate_xy_covariance_by_multi_ndt_score(ndt_result, mg_ndt_omp, poses_to_search, temperature);
-    const Eigen::Matrix2d cov_by_mndt_score = pclomp::adjust_diagonal_covariance(result_of_mndt_score.covariance, ndt_result.pose, 0.0225, 0.0225);
+    const pclomp::ResultOfMultiNdtCovarianceEstimation result_of_mndt_score =
+      pclomp::estimate_xy_covariance_by_multi_ndt_score(
+        ndt_result, mg_ndt_omp, poses_to_search, temperature);
+    const Eigen::Matrix2d cov_by_mndt_score = pclomp::adjust_diagonal_covariance(
+      result_of_mndt_score.covariance, ndt_result.pose, 0.0225, 0.0225);
     t2 = std::chrono::system_clock::now();
-    const auto elapsed_mndt_score = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count() / 1000.0;
+    const auto elapsed_mndt_score =
+      std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count() / 1000.0;
 
     // output result
     const auto result_x = ndt_result.pose(0, 3);
     const auto result_y = ndt_result.pose(1, 3);
     const Eigen::Vector3f euler_initial = initial_pose.block<3, 3>(0, 0).eulerAngles(0, 1, 2);
     const Eigen::Vector3f euler_result = ndt_result.pose.block<3, 3>(0, 0).eulerAngles(0, 1, 2);
-    const Eigen::Matrix2d cov_by_la_rotated = pclomp::rotate_covariance_to_base_link(cov_by_la, ndt_result.pose);
-    const Eigen::Matrix2d cov_by_mndt_rotated = pclomp::rotate_covariance_to_base_link(cov_by_mndt, ndt_result.pose);
-    const Eigen::Matrix2d cov_by_mndt_score_rotated = pclomp::rotate_covariance_to_base_link(cov_by_mndt_score, ndt_result.pose);
+    const Eigen::Matrix2d cov_by_la_rotated =
+      pclomp::rotate_covariance_to_base_link(cov_by_la, ndt_result.pose);
+    const Eigen::Matrix2d cov_by_mndt_rotated =
+      pclomp::rotate_covariance_to_base_link(cov_by_mndt, ndt_result.pose);
+    const Eigen::Matrix2d cov_by_mndt_score_rotated =
+      pclomp::rotate_covariance_to_base_link(cov_by_mndt_score, ndt_result.pose);
     ofs << i << "," << score << ",";
     ofs << initial_pose(0, 3) << "," << initial_pose(1, 3) << "," << euler_initial(2) << ",";
     ofs << result_x << "," << result_y << "," << euler_result(2) << ",";
-    ofs << elapsed_la << "," << cov_by_la(0, 0) << "," << cov_by_la(0, 1) << "," << cov_by_la(1, 0) << "," << cov_by_la(1, 1) << ",";
-    ofs << elapsed_mndt << "," << cov_by_mndt(0, 0) << "," << cov_by_mndt(0, 1) << "," << cov_by_mndt(1, 0) << "," << cov_by_mndt(1, 1) << ",";
-    ofs << elapsed_mndt_score << "," << cov_by_mndt_score(0, 0) << "," << cov_by_mndt_score(0, 1) << "," << cov_by_mndt_score(1, 0) << "," << cov_by_mndt_score(1, 1) << ",";
-    ofs << cov_by_la_rotated(0, 0) << "," << cov_by_la_rotated(0, 1) << "," << cov_by_la_rotated(1, 0) << "," << cov_by_la_rotated(1, 1) << ",";
-    ofs << cov_by_mndt_rotated(0, 0) << "," << cov_by_mndt_rotated(0, 1) << "," << cov_by_mndt_rotated(1, 0) << "," << cov_by_mndt_rotated(1, 1) << ",";
-    ofs << cov_by_mndt_score_rotated(0, 0) << "," << cov_by_mndt_score_rotated(0, 1) << "," << cov_by_mndt_score_rotated(1, 0) << "," << cov_by_mndt_score_rotated(1, 1) << std::endl;
+    ofs << elapsed_la << "," << cov_by_la(0, 0) << "," << cov_by_la(0, 1) << "," << cov_by_la(1, 0)
+        << "," << cov_by_la(1, 1) << ",";
+    ofs << elapsed_mndt << "," << cov_by_mndt(0, 0) << "," << cov_by_mndt(0, 1) << ","
+        << cov_by_mndt(1, 0) << "," << cov_by_mndt(1, 1) << ",";
+    ofs << elapsed_mndt_score << "," << cov_by_mndt_score(0, 0) << "," << cov_by_mndt_score(0, 1)
+        << "," << cov_by_mndt_score(1, 0) << "," << cov_by_mndt_score(1, 1) << ",";
+    ofs << cov_by_la_rotated(0, 0) << "," << cov_by_la_rotated(0, 1) << ","
+        << cov_by_la_rotated(1, 0) << "," << cov_by_la_rotated(1, 1) << ",";
+    ofs << cov_by_mndt_rotated(0, 0) << "," << cov_by_mndt_rotated(0, 1) << ","
+        << cov_by_mndt_rotated(1, 0) << "," << cov_by_mndt_rotated(1, 1) << ",";
+    ofs << cov_by_mndt_score_rotated(0, 0) << "," << cov_by_mndt_score_rotated(0, 1) << ","
+        << cov_by_mndt_score_rotated(1, 0) << "," << cov_by_mndt_score_rotated(1, 1) << std::endl;
 
     std::stringstream filename_ss;
     filename_ss << std::setw(8) << std::setfill('0') << i << ".csv";
@@ -146,14 +177,15 @@ int main(int argc, char** argv) {
     const int n_mndt = result_of_mndt.ndt_results.size();
     ofs_mndt << "index,score,initial_x,initial_y,result_x,result_y" << std::endl;
     ofs_mndt << std::fixed;
-    for(int j = 0; j < n_mndt; j++) {
-      const pclomp::NdtResult& ndt_result = result_of_mndt.ndt_results[j];
+    for (int j = 0; j < n_mndt; j++) {
+      const pclomp::NdtResult & ndt_result = result_of_mndt.ndt_results[j];
       const auto nvtl = ndt_result.nearest_voxel_transformation_likelihood;
       const auto initial_x = result_of_mndt.ndt_initial_poses[j](0, 3);
       const auto initial_y = result_of_mndt.ndt_initial_poses[j](1, 3);
       const auto result_x = ndt_result.pose(0, 3);
       const auto result_y = ndt_result.pose(1, 3);
-      ofs_mndt << j << "," << nvtl << "," << initial_x << "," << initial_y << "," << result_x << "," << result_y << std::endl;
+      ofs_mndt << j << "," << nvtl << "," << initial_x << "," << initial_y << "," << result_x << ","
+               << result_y << std::endl;
     }
 
     // output multi ndt score result
@@ -161,14 +193,15 @@ int main(int argc, char** argv) {
     const int n_mndt_score = result_of_mndt_score.ndt_results.size();
     ofs_mndt_score << "index,score,initial_x,initial_y,result_x,result_y" << std::endl;
     ofs_mndt_score << std::fixed;
-    for(int j = 0; j < n_mndt_score; j++) {
-      const pclomp::NdtResult& ndt_result = result_of_mndt_score.ndt_results[j];
+    for (int j = 0; j < n_mndt_score; j++) {
+      const pclomp::NdtResult & ndt_result = result_of_mndt_score.ndt_results[j];
       const auto nvtl = ndt_result.nearest_voxel_transformation_likelihood;
       const auto initial_x = result_of_mndt_score.ndt_initial_poses[j](0, 3);
       const auto initial_y = result_of_mndt_score.ndt_initial_poses[j](1, 3);
       const auto result_x = ndt_result.pose(0, 3);
       const auto result_y = ndt_result.pose(1, 3);
-      ofs_mndt_score << j << "," << nvtl << "," << initial_x << "," << initial_y << "," << result_x << "," << result_y << std::endl;
+      ofs_mndt_score << j << "," << nvtl << "," << initial_x << "," << initial_y << "," << result_x
+                     << "," << result_y << std::endl;
     }
   }
 }

--- a/apps/pcd_map_grid_manager.hpp
+++ b/apps/pcd_map_grid_manager.hpp
@@ -21,21 +21,25 @@ using AddPair = std::pair<std::string, pcl::PointCloud<pcl::PointXYZ>::Ptr>;
 using AddResult = std::vector<AddPair>;
 using RemoveResult = std::vector<std::string>;
 
-class MapGridManager {
+class MapGridManager
+{
 public:
-  MapGridManager(const pcl::PointCloud<pcl::PointXYZ>::Ptr target_cloud) : target_cloud_(target_cloud) {
-    for(const auto& point : target_cloud_->points) {
+  MapGridManager(const pcl::PointCloud<pcl::PointXYZ>::Ptr target_cloud)
+  : target_cloud_(target_cloud)
+  {
+    for (const auto & point : target_cloud_->points) {
       const int x = static_cast<int>(std::ceil(point.x / resolution_));
       const int y = static_cast<int>(std::ceil(point.y / resolution_));
       const std::pair<int, int> key = std::make_pair(x, y);
-      if(map_grid_.count(key) == 0) {
+      if (map_grid_.count(key) == 0) {
         map_grid_[key].reset(new pcl::PointCloud<pcl::PointXYZ>());
       }
       map_grid_[key]->points.push_back(point);
     }
   }
 
-  std::pair<AddResult, RemoveResult> query(const Eigen::Matrix4f& pose) {
+  std::pair<AddResult, RemoveResult> query(const Eigen::Matrix4f & pose)
+  {
     // get around
     const float x = pose(0, 3);
     const float y = pose(1, 3);
@@ -44,9 +48,9 @@ public:
     const int y_min = static_cast<int>(std::ceil((y - get_around_) / resolution_));
     const int y_max = static_cast<int>(std::ceil((y + get_around_) / resolution_));
     std::vector<std::pair<int, int>> curr_keys;
-    for(int x = x_min; x <= x_max; x++) {
-      for(int y = y_min; y <= y_max; y++) {
-        if(map_grid_.count(std::make_pair(x, y)) == 0) {
+    for (int x = x_min; x <= x_max; x++) {
+      for (int y = y_min; y <= y_max; y++) {
+        if (map_grid_.count(std::make_pair(x, y)) == 0) {
           continue;
         }
         curr_keys.push_back(std::make_pair(x, y));
@@ -55,16 +59,16 @@ public:
 
     // get remove keys
     RemoveResult remove_result;
-    for(const auto& key : held_keys_) {
-      if(std::find(curr_keys.begin(), curr_keys.end(), key) == curr_keys.end()) {
+    for (const auto & key : held_keys_) {
+      if (std::find(curr_keys.begin(), curr_keys.end(), key) == curr_keys.end()) {
         remove_result.push_back(to_string_key(key));
       }
     }
 
     // get add keys
     AddResult add_result;
-    for(const auto& key : curr_keys) {
-      if(std::find(held_keys_.begin(), held_keys_.end(), key) == held_keys_.end()) {
+    for (const auto & key : curr_keys) {
+      if (std::find(held_keys_.begin(), held_keys_.end(), key) == held_keys_.end()) {
         add_result.push_back(std::make_pair(to_string_key(key), map_grid_[key]));
       }
     }
@@ -80,7 +84,8 @@ private:
   std::map<std::pair<int, int>, pcl::PointCloud<pcl::PointXYZ>::Ptr> map_grid_;
   std::vector<std::pair<int, int>> held_keys_;
 
-  std::string to_string_key(const std::pair<int, int>& key) {
+  std::string to_string_key(const std::pair<int, int> & key)
+  {
     return std::to_string(key.first) + "_" + std::to_string(key.second);
   }
 };

--- a/apps/timer.hpp
+++ b/apps/timer.hpp
@@ -16,19 +16,20 @@
 #define NDT_OMP__APPS__TIMER_HPP_
 
 #include <chrono>
-#include <string>
 #include <iomanip>
+#include <string>
 
-class Timer {
+class Timer
+{
 public:
-  void start() {
-    start_time_ = std::chrono::steady_clock::now();
-  }
+  void start() { start_time_ = std::chrono::steady_clock::now(); }
 
-  double elapsed_milliseconds() const {
+  double elapsed_milliseconds() const
+  {
     const auto end_time = std::chrono::steady_clock::now();
     const auto elapsed_time = end_time - start_time_;
-    const double microseconds = std::chrono::duration_cast<std::chrono::microseconds>(elapsed_time).count();
+    const double microseconds =
+      std::chrono::duration_cast<std::chrono::microseconds>(elapsed_time).count();
     return microseconds / 1000.0;
   }
 

--- a/apps/util.hpp
+++ b/apps/util.hpp
@@ -15,11 +15,12 @@
 #ifndef NDT_OMP__APPS__UTIL_HPP_
 #define NDT_OMP__APPS__UTIL_HPP_
 
-std::vector<std::string> glob(const std::string& input_dir) {
+std::vector<std::string> glob(const std::string & input_dir)
+{
   glob_t buffer;
   std::vector<std::string> files;
   glob((input_dir + "/*").c_str(), 0, NULL, &buffer);
-  for(size_t i = 0; i < buffer.gl_pathc; i++) {
+  for (size_t i = 0; i < buffer.gl_pathc; i++) {
     files.push_back(buffer.gl_pathv[i]);
   }
   globfree(&buffer);
@@ -27,16 +28,18 @@ std::vector<std::string> glob(const std::string& input_dir) {
   return files;
 }
 
-pcl::PointCloud<pcl::PointXYZ>::Ptr load_pcd(const std::string& path) {
+pcl::PointCloud<pcl::PointXYZ>::Ptr load_pcd(const std::string & path)
+{
   pcl::PointCloud<pcl::PointXYZ>::Ptr pcd(new pcl::PointCloud<pcl::PointXYZ>());
-  if(pcl::io::loadPCDFile(path, *pcd)) {
+  if (pcl::io::loadPCDFile(path, *pcd)) {
     std::cerr << "failed to load " << path << std::endl;
     std::exit(1);
   }
   return pcd;
 }
 
-std::vector<Eigen::Matrix4f> load_pose_list(const std::string& path) {
+std::vector<Eigen::Matrix4f> load_pose_list(const std::string & path)
+{
   /*
   timestamp,pose_x,pose_y,pose_z,quat_w,quat_x,quat_y,quat_z,twist_linear_x,twist_linear_y,twist_linear_z,twist_angular_x,twist_angular_y,twist_angular_z
   63.100010,81377.359702,49916.899866,41.232589,0.953768,0.000494,-0.007336,0.300453,0.000000,0.000000,0.000000,0.000000,0.000000,0.000000
@@ -47,11 +50,11 @@ std::vector<Eigen::Matrix4f> load_pose_list(const std::string& path) {
   std::string line;
   std::getline(ifs, line);  // skip header
   std::vector<Eigen::Matrix4f> pose_list;
-  while(std::getline(ifs, line)) {
+  while (std::getline(ifs, line)) {
     std::istringstream iss(line);
     std::string token;
     std::vector<std::string> tokens;
-    while(std::getline(iss, token, ',')) {
+    while (std::getline(iss, token, ',')) {
       tokens.push_back(token);
     }
     const double timestamp = std::stod(tokens[0]);

--- a/include/estimate_covariance/estimate_covariance.hpp
+++ b/include/estimate_covariance/estimate_covariance.hpp
@@ -1,12 +1,15 @@
 #ifndef NDT_OMP__ESTIMATE_COVARIANCE_HPP_
 #define NDT_OMP__ESTIMATE_COVARIANCE_HPP_
 
-#include <Eigen/Core>
 #include "multigrid_pclomp/multigrid_ndt_omp.h"
 
-namespace pclomp {
+#include <Eigen/Core>
 
-struct ResultOfMultiNdtCovarianceEstimation {
+namespace pclomp
+{
+
+struct ResultOfMultiNdtCovarianceEstimation
+{
   Eigen::Vector2d mean;
   Eigen::Matrix2d covariance;
   std::vector<Eigen::Matrix4f> ndt_initial_poses;
@@ -14,38 +17,55 @@ struct ResultOfMultiNdtCovarianceEstimation {
 };
 
 /** \brief Estimate functions */
-Eigen::Matrix2d estimate_xy_covariance_by_Laplace_approximation(const Eigen::Matrix<double, 6, 6>& hessian);
-ResultOfMultiNdtCovarianceEstimation estimate_xy_covariance_by_multi_ndt(const NdtResult& ndt_result, std::shared_ptr<pclomp::MultiGridNormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>> ndt_ptr, const std::vector<Eigen::Matrix4f>& poses_to_search);
-ResultOfMultiNdtCovarianceEstimation estimate_xy_covariance_by_multi_ndt_score(const NdtResult& ndt_result, std::shared_ptr<pclomp::MultiGridNormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>> ndt_ptr, const std::vector<Eigen::Matrix4f>& poses_to_search, const double temperature);
+Eigen::Matrix2d estimate_xy_covariance_by_Laplace_approximation(
+  const Eigen::Matrix<double, 6, 6> & hessian);
+ResultOfMultiNdtCovarianceEstimation estimate_xy_covariance_by_multi_ndt(
+  const NdtResult & ndt_result,
+  std::shared_ptr<pclomp::MultiGridNormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>>
+    ndt_ptr,
+  const std::vector<Eigen::Matrix4f> & poses_to_search);
+ResultOfMultiNdtCovarianceEstimation estimate_xy_covariance_by_multi_ndt_score(
+  const NdtResult & ndt_result,
+  std::shared_ptr<pclomp::MultiGridNormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>>
+    ndt_ptr,
+  const std::vector<Eigen::Matrix4f> & poses_to_search, const double temperature);
 
 /** \brief Find rotation matrix aligning covariance to principal axes
  * (1) Compute eigenvalues and eigenvectors
  * (2) Compute angle for first eigenvector
  * (3) Return rotation matrix
  */
-Eigen::Matrix2d find_rotation_matrix_aligning_covariance_to_principal_axes(const Eigen::Matrix2d& matrix);
+Eigen::Matrix2d find_rotation_matrix_aligning_covariance_to_principal_axes(
+  const Eigen::Matrix2d & matrix);
 
 /** \brief Propose poses to search.
  * (1) Compute covariance by Laplace approximation
  * (2) Find rotation matrix aligning covariance to principal axes
  * (3) Propose search points by adding offset_x and offset_y to the center_pose
  */
-std::vector<Eigen::Matrix4f> propose_poses_to_search(const NdtResult& ndt_result, const std::vector<double>& offset_x, const std::vector<double>& offset_y);
+std::vector<Eigen::Matrix4f> propose_poses_to_search(
+  const NdtResult & ndt_result, const std::vector<double> & offset_x,
+  const std::vector<double> & offset_y);
 
 /** \brief Calculate weights by exponential */
-std::vector<double> calc_weight_vec(const std::vector<double>& score_vec, double temperature);
+std::vector<double> calc_weight_vec(const std::vector<double> & score_vec, double temperature);
 
 /** \brief Calculate weighted mean and covariance */
-std::pair<Eigen::Vector2d, Eigen::Matrix2d> calculate_weighted_mean_and_cov(const std::vector<Eigen::Vector2d>& pose_2d_vec, const std::vector<double>& weight_vec);
+std::pair<Eigen::Vector2d, Eigen::Matrix2d> calculate_weighted_mean_and_cov(
+  const std::vector<Eigen::Vector2d> & pose_2d_vec, const std::vector<double> & weight_vec);
 
 /** \brief Rotate covariance to base_link coordinate */
-Eigen::Matrix2d rotate_covariance_to_base_link(const Eigen::Matrix2d& covariance, const Eigen::Matrix4f& pose);
+Eigen::Matrix2d rotate_covariance_to_base_link(
+  const Eigen::Matrix2d & covariance, const Eigen::Matrix4f & pose);
 
 /** \brief Rotate covariance to map coordinate */
-Eigen::Matrix2d rotate_covariance_to_map(const Eigen::Matrix2d& covariance, const Eigen::Matrix4f& pose);
+Eigen::Matrix2d rotate_covariance_to_map(
+  const Eigen::Matrix2d & covariance, const Eigen::Matrix4f & pose);
 
 /** \brief  Adjust diagonal covariance */
-Eigen::Matrix2d adjust_diagonal_covariance(const Eigen::Matrix2d& covariance, const Eigen::Matrix4f& pose, const double fixed_cov00, const double fixed_cov11);
+Eigen::Matrix2d adjust_diagonal_covariance(
+  const Eigen::Matrix2d & covariance, const Eigen::Matrix4f & pose, const double fixed_cov00,
+  const double fixed_cov11);
 
 }  // namespace pclomp
 

--- a/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp
+++ b/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp
@@ -57,31 +57,41 @@
 
 #include "multigrid_pclomp/multigrid_ndt_omp.h"
 
-namespace pclomp {
+namespace pclomp
+{
 
-template<typename PointSource, typename PointTarget>
-MultiGridNormalDistributionsTransform<PointSource, PointTarget>::MultiGridNormalDistributionsTransform(const MultiGridNormalDistributionsTransform &other) : BaseRegType(other), target_cells_(other.target_cells_) {
+template <typename PointSource, typename PointTarget>
+MultiGridNormalDistributionsTransform<PointSource, PointTarget>::
+  MultiGridNormalDistributionsTransform(const MultiGridNormalDistributionsTransform & other)
+: BaseRegType(other), target_cells_(other.target_cells_)
+{
   params_ = other.params_;
   outlier_ratio_ = other.outlier_ratio_;
   gauss_d1_ = other.gauss_d1_;
   gauss_d2_ = other.gauss_d2_;
   gauss_d3_ = other.gauss_d3_;
   trans_probability_ = other.trans_probability_;
-  // No need to copy j_ang_ and h_ang_, as those matrices are re-computed on every computeDerivatives() call
+  // No need to copy j_ang_ and h_ang_, as those matrices are re-computed on every
+  // computeDerivatives() call
 
   hessian_ = other.hessian_;
   transformation_array_ = other.transformation_array_;
   transform_probability_array_ = other.transform_probability_array_;
-  nearest_voxel_transformation_likelihood_array_ = other.nearest_voxel_transformation_likelihood_array_;
+  nearest_voxel_transformation_likelihood_array_ =
+    other.nearest_voxel_transformation_likelihood_array_;
   nearest_voxel_transformation_likelihood_ = other.nearest_voxel_transformation_likelihood_;
 
   regularization_pose_ = other.regularization_pose_;
   regularization_pose_translation_ = other.regularization_pose_translation_;
 }
 
-template<typename PointSource, typename PointTarget>
-MultiGridNormalDistributionsTransform<PointSource, PointTarget>::MultiGridNormalDistributionsTransform(MultiGridNormalDistributionsTransform &&other)
-    : BaseRegType(std::move(other)), target_cells_(std::move(other.target_cells_)), params_(std::move(other.params_)) {
+template <typename PointSource, typename PointTarget>
+MultiGridNormalDistributionsTransform<PointSource, PointTarget>::
+  MultiGridNormalDistributionsTransform(MultiGridNormalDistributionsTransform && other)
+: BaseRegType(std::move(other)),
+  target_cells_(std::move(other.target_cells_)),
+  params_(std::move(other.params_))
+{
   outlier_ratio_ = other.outlier_ratio_;
   gauss_d1_ = other.gauss_d1_;
   gauss_d2_ = other.gauss_d2_;
@@ -91,15 +101,19 @@ MultiGridNormalDistributionsTransform<PointSource, PointTarget>::MultiGridNormal
   hessian_ = other.hessian_;
   transformation_array_ = other.transformation_array_;
   transform_probability_array_ = other.transform_probability_array_;
-  nearest_voxel_transformation_likelihood_array_ = other.nearest_voxel_transformation_likelihood_array_;
+  nearest_voxel_transformation_likelihood_array_ =
+    other.nearest_voxel_transformation_likelihood_array_;
   nearest_voxel_transformation_likelihood_ = other.nearest_voxel_transformation_likelihood_;
 
   regularization_pose_ = other.regularization_pose_;
   regularization_pose_translation_ = other.regularization_pose_translation_;
 }
 
-template<typename PointSource, typename PointTarget>
-MultiGridNormalDistributionsTransform<PointSource, PointTarget> &MultiGridNormalDistributionsTransform<PointSource, PointTarget>::operator=(const MultiGridNormalDistributionsTransform &other) {
+template <typename PointSource, typename PointTarget>
+MultiGridNormalDistributionsTransform<PointSource, PointTarget> &
+MultiGridNormalDistributionsTransform<PointSource, PointTarget>::operator=(
+  const MultiGridNormalDistributionsTransform & other)
+{
   BaseRegType::operator=(other);
 
   target_cells_ = other.target_cells_;
@@ -114,7 +128,8 @@ MultiGridNormalDistributionsTransform<PointSource, PointTarget> &MultiGridNormal
   hessian_ = other.hessian_;
   transformation_array_ = other.transformation_array_;
   transform_probability_array_ = other.transform_probability_array_;
-  nearest_voxel_transformation_likelihood_array_ = other.nearest_voxel_transformation_likelihood_array_;
+  nearest_voxel_transformation_likelihood_array_ =
+    other.nearest_voxel_transformation_likelihood_array_;
   nearest_voxel_transformation_likelihood_ = other.nearest_voxel_transformation_likelihood_;
 
   regularization_pose_ = other.regularization_pose_;
@@ -123,8 +138,11 @@ MultiGridNormalDistributionsTransform<PointSource, PointTarget> &MultiGridNormal
   return *this;
 }
 
-template<typename PointSource, typename PointTarget>
-MultiGridNormalDistributionsTransform<PointSource, PointTarget> &MultiGridNormalDistributionsTransform<PointSource, PointTarget>::operator=(MultiGridNormalDistributionsTransform &&other) {
+template <typename PointSource, typename PointTarget>
+MultiGridNormalDistributionsTransform<PointSource, PointTarget> &
+MultiGridNormalDistributionsTransform<PointSource, PointTarget>::operator=(
+  MultiGridNormalDistributionsTransform && other)
+{
   BaseRegType::operator=(std::move(other));
 
   target_cells_ = std::move(other.target_cells_);
@@ -139,7 +157,8 @@ MultiGridNormalDistributionsTransform<PointSource, PointTarget> &MultiGridNormal
   hessian_ = other.hessian_;
   transformation_array_ = other.transformation_array_;
   transform_probability_array_ = other.transform_probability_array_;
-  nearest_voxel_transformation_likelihood_array_ = other.nearest_voxel_transformation_likelihood_array_;
+  nearest_voxel_transformation_likelihood_array_ =
+    other.nearest_voxel_transformation_likelihood_array_;
   nearest_voxel_transformation_likelihood_ = other.nearest_voxel_transformation_likelihood_;
 
   regularization_pose_ = other.regularization_pose_;
@@ -149,8 +168,17 @@ MultiGridNormalDistributionsTransform<PointSource, PointTarget> &MultiGridNormal
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget>
-MultiGridNormalDistributionsTransform<PointSource, PointTarget>::MultiGridNormalDistributionsTransform() : target_cells_(), outlier_ratio_(0.55), gauss_d1_(), gauss_d2_(), gauss_d3_(), trans_probability_(), regularization_pose_(boost::none) {
+template <typename PointSource, typename PointTarget>
+MultiGridNormalDistributionsTransform<
+  PointSource, PointTarget>::MultiGridNormalDistributionsTransform()
+: target_cells_(),
+  outlier_ratio_(0.55),
+  gauss_d1_(),
+  gauss_d2_(),
+  gauss_d3_(),
+  trans_probability_(),
+  regularization_pose_(boost::none)
+{
   reg_name_ = "MultiGridNormalDistributionsTransform";
 
   params_.trans_epsilon = 0.1;
@@ -173,8 +201,10 @@ MultiGridNormalDistributionsTransform<PointSource, PointTarget>::MultiGridNormal
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget>
-void MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeTransformation(PointCloudSource &output, const Eigen::Matrix4f &guess) {
+template <typename PointSource, typename PointTarget>
+void MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeTransformation(
+  PointCloudSource & output, const Eigen::Matrix4f & guess)
+{
   nr_iterations_ = 0;
   converged_ = false;
 
@@ -187,7 +217,7 @@ void MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeTra
   gauss_d1_ = -log(gauss_c1 + gauss_c2) - gauss_d3_;
   gauss_d2_ = -2.0 * log((-log(gauss_c1 * exp(-0.5) + gauss_c2) - gauss_d3_) / gauss_d1_);
 
-  if(guess != Eigen::Matrix4f::Identity()) {
+  if (guess != Eigen::Matrix4f::Identity()) {
     // Initialise final transformation to the guessed one
     final_transformation_ = guess;
     // Apply guessed transformation prior to search for neighbours
@@ -208,36 +238,39 @@ void MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeTra
   Eigen::Vector3f init_translation = eig_transformation.translation();
   Eigen::Vector3f init_rotation = eig_transformation.rotation().eulerAngles(0, 1, 2);
 
-  p << init_translation(0), init_translation(1), init_translation(2), init_rotation(0), init_rotation(1), init_rotation(2);
+  p << init_translation(0), init_translation(1), init_translation(2), init_rotation(0),
+    init_rotation(1), init_rotation(2);
 
   Eigen::Matrix<double, 6, 6> hessian;
 
   double score = 0;
   double delta_p_norm;
 
-  if(regularization_pose_) {
+  if (regularization_pose_) {
     Eigen::Transform<float, 3, Eigen::Affine, Eigen::ColMajor> regularization_pose_transformation;
     regularization_pose_transformation.matrix() = regularization_pose_.get();
     regularization_pose_translation_ = regularization_pose_transformation.translation();
   }
 
-  // Calculate derivatives of initial transform vector, subsequent derivative calculations are done in the step length determination.
+  // Calculate derivatives of initial transform vector, subsequent derivative calculations are done
+  // in the step length determination.
   score = computeDerivatives(score_gradient, hessian, output, p);
 
-  while(!converged_) {
+  while (!converged_) {
     // Store previous transformation
     previous_transformation_ = transformation_;
 
     // Solve for decent direction using newton method, line 23 in Algorithm 2 [Magnusson 2009]
-    Eigen::JacobiSVD<Eigen::Matrix<double, 6, 6>> sv(hessian, Eigen::ComputeFullU | Eigen::ComputeFullV);
+    Eigen::JacobiSVD<Eigen::Matrix<double, 6, 6>> sv(
+      hessian, Eigen::ComputeFullU | Eigen::ComputeFullV);
     // Negative for maximization as opposed to minimization
     delta_p = sv.solve(-score_gradient);
 
     // Calculate step length with guaranteed sufficient decrease [More, Thuente 1994]
     delta_p_norm = delta_p.norm();
 
-    if(delta_p_norm == 0 || delta_p_norm != delta_p_norm) {
-      if(input_->empty()) {
+    if (delta_p_norm == 0 || delta_p_norm != delta_p_norm) {
+      if (input_->empty()) {
         trans_probability_ = 0.0f;
       } else {
         trans_probability_ = score / static_cast<double>(input_->size());
@@ -248,29 +281,40 @@ void MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeTra
     }
 
     delta_p.normalize();
-    delta_p_norm = computeStepLengthMT(p, delta_p, delta_p_norm, params_.step_size, params_.trans_epsilon / 2.0, score, score_gradient, hessian, output);
+    delta_p_norm = computeStepLengthMT(
+      p, delta_p, delta_p_norm, params_.step_size, params_.trans_epsilon / 2.0, score,
+      score_gradient, hessian, output);
     delta_p *= delta_p_norm;
 
-    transformation_ = (Eigen::Translation<float, 3>(static_cast<float>(delta_p(0)), static_cast<float>(delta_p(1)), static_cast<float>(delta_p(2))) * Eigen::AngleAxis<float>(static_cast<float>(delta_p(3)), Eigen::Vector3f::UnitX()) * Eigen::AngleAxis<float>(static_cast<float>(delta_p(4)), Eigen::Vector3f::UnitY()) * Eigen::AngleAxis<float>(static_cast<float>(delta_p(5)), Eigen::Vector3f::UnitZ()))
-                          .matrix();
+    transformation_ =
+      (Eigen::Translation<float, 3>(
+         static_cast<float>(delta_p(0)), static_cast<float>(delta_p(1)),
+         static_cast<float>(delta_p(2))) *
+       Eigen::AngleAxis<float>(static_cast<float>(delta_p(3)), Eigen::Vector3f::UnitX()) *
+       Eigen::AngleAxis<float>(static_cast<float>(delta_p(4)), Eigen::Vector3f::UnitY()) *
+       Eigen::AngleAxis<float>(static_cast<float>(delta_p(5)), Eigen::Vector3f::UnitZ()))
+        .matrix();
 
     transformation_array_.push_back(final_transformation_);
 
     p = p + delta_p;
 
     // Update Visualizer (untested)
-    if(update_visualizer_ != 0) update_visualizer_(output, std::vector<int>(), *target_, std::vector<int>());
+    if (update_visualizer_ != 0)
+      update_visualizer_(output, std::vector<int>(), *target_, std::vector<int>());
 
     nr_iterations_++;
 
-    if(nr_iterations_ >= params_.max_iterations || (nr_iterations_ && (std::fabs(delta_p_norm) < params_.trans_epsilon))) {
+    if (
+      nr_iterations_ >= params_.max_iterations ||
+      (nr_iterations_ && (std::fabs(delta_p_norm) < params_.trans_epsilon))) {
       converged_ = true;
     }
   }
 
-  // Store transformation probability. The relative differences within each scan registration are accurate
-  // but the normalization constants need to be modified for it to be globally accurate
-  if(input_->empty()) {
+  // Store transformation probability. The relative differences within each scan registration are
+  // accurate but the normalization constants need to be modified for it to be globally accurate
+  if (input_->empty()) {
     trans_probability_ = 0.0f;
   } else {
     trans_probability_ = score / static_cast<double>(input_->size());
@@ -280,17 +324,22 @@ void MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeTra
 }
 
 #ifndef _OPENMP
-int omp_get_max_threads() {
+int omp_get_max_threads()
+{
   return 1;
 }
-int omp_get_thread_num() {
+int omp_get_thread_num()
+{
   return 0;
 }
 #endif
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget>
-double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeDerivatives(Eigen::Matrix<double, 6, 1> &score_gradient, Eigen::Matrix<double, 6, 6> &hessian, PointCloudSource &trans_cloud, Eigen::Matrix<double, 6, 1> &p, bool compute_hessian) {
+template <typename PointSource, typename PointTarget>
+double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeDerivatives(
+  Eigen::Matrix<double, 6, 1> & score_gradient, Eigen::Matrix<double, 6, 6> & hessian,
+  PointCloudSource & trans_cloud, Eigen::Matrix<double, 6, 1> & p, bool compute_hessian)
+{
   score_gradient.setZero();
   hessian.setZero();
 
@@ -302,15 +351,17 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeD
   std::vector<double> scores(params_.num_threads);
   std::vector<double> nearest_voxel_scores(params_.num_threads);
   std::vector<size_t> found_neigborhood_voxel_nums(params_.num_threads);
-  std::vector<Eigen::Matrix<double, 6, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 6, 1>>> score_gradients(params_.num_threads);
-  std::vector<Eigen::Matrix<double, 6, 6>, Eigen::aligned_allocator<Eigen::Matrix<double, 6, 6>>> hessians(params_.num_threads);
+  std::vector<Eigen::Matrix<double, 6, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 6, 1>>>
+    score_gradients(params_.num_threads);
+  std::vector<Eigen::Matrix<double, 6, 6>, Eigen::aligned_allocator<Eigen::Matrix<double, 6, 6>>>
+    hessians(params_.num_threads);
   std::vector<int> neighborhood_counts(params_.num_threads);
 
   // Pre-allocate thread-wise point derivative matrices to avoid reallocate too many times
   std::vector<Eigen::Matrix<double, 4, 6>> t_point_gradients(params_.num_threads);
   std::vector<Eigen::Matrix<double, 24, 6>> t_point_hessians(params_.num_threads);
 
-  for(size_t i = 0; i < params_.num_threads; ++i) {
+  for (size_t i = 0; i < params_.num_threads; ++i) {
     scores[i] = 0;
     nearest_voxel_scores[i] = 0;
     found_neigborhood_voxel_nums[i] = 0;
@@ -329,28 +380,29 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeD
 
   // Update gradient and hessian for each point, line 17 in Algorithm 2 [Magnusson 2009]
 #pragma omp parallel for num_threads(params_.num_threads) schedule(guided, 8)
-  for(size_t idx = 0; idx < input_->size(); ++idx) {
+  for (size_t idx = 0; idx < input_->size(); ++idx) {
     int tid = omp_get_thread_num();
     // Searching for neighbors of the current transformed point
-    auto &x_trans_pt = trans_cloud[idx];
+    auto & x_trans_pt = trans_cloud[idx];
     std::vector<TargetGridLeafConstPtr> neighborhood;
 
     // Neighborhood search method other than kdtree is disabled in multigrid_ndt_omp
     target_cells_.radiusSearch(x_trans_pt, params_.resolution, neighborhood);
 
-    if(neighborhood.empty()) {
+    if (neighborhood.empty()) {
       continue;
     }
 
     // Original Point
-    auto &x_pt = (*input_)[idx];
+    auto & x_pt = (*input_)[idx];
     // Original Point and Transformed Point (for math)
     Eigen::Vector3d x(x_pt.x, x_pt.y, x_pt.z);
     // Current Point Gradient and Hessian
-    auto &point_gradient = t_point_gradients[tid];
-    auto &point_hessian = t_point_hessians[tid];
+    auto & point_gradient = t_point_gradients[tid];
+    auto & point_hessian = t_point_hessians[tid];
 
-    // Compute derivative of transform function w.r.t. transform vector, J_E and H_E in Equations 6.18 and 6.20 [Magnusson 2009]
+    // Compute derivative of transform function w.r.t. transform vector, J_E and H_E in
+    // Equations 6.18 and 6.20 [Magnusson 2009]
     computePointDerivatives(x, point_gradient, point_hessian);
 
     // Denorm point, x_k' in Equations 6.12 and 6.13 [Magnusson 2009]
@@ -358,15 +410,18 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeD
 
     double sum_score_pt = 0;
     double nearest_voxel_score_pt = 0;
-    auto &score_gradient_pt = score_gradients[tid];
-    auto &hessian_pt = hessians[tid];
+    auto & score_gradient_pt = score_gradients[tid];
+    auto & hessian_pt = hessians[tid];
 
-    for(auto &cell : neighborhood) {
-      // Update score, gradient and hessian, lines 19-21 in Algorithm 2, according to Equations 6.10, 6.12 and 6.13, respectively [Magnusson 2009]
-      double score_pt = updateDerivatives(score_gradient_pt, hessian_pt, point_gradient, point_hessian, x_trans - cell->getMean(), cell->getInverseCov(), compute_hessian);
+    for (auto & cell : neighborhood) {
+      // Update score, gradient and hessian, lines 19-21 in Algorithm 2, according to
+      // Equations 6.10, 6.12 and 6.13, respectively [Magnusson 2009]
+      double score_pt = updateDerivatives(
+        score_gradient_pt, hessian_pt, point_gradient, point_hessian, x_trans - cell->getMean(),
+        cell->getInverseCov(), compute_hessian);
       sum_score_pt += score_pt;
 
-      if(score_pt > nearest_voxel_score_pt) {
+      if (score_pt > nearest_voxel_score_pt) {
         nearest_voxel_score_pt = score_pt;
       }
     }
@@ -379,7 +434,7 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeD
   }
 
   // Ensure that the result is invariant against the summing up order
-  for(size_t i = 0; i < params_.num_threads; ++i) {
+  for (size_t i = 0; i < params_.num_threads; ++i) {
     score += scores[i];
     nearest_voxel_score += nearest_voxel_scores[i];
     found_neigborhood_voxel_num += found_neigborhood_voxel_nums[i];
@@ -388,7 +443,7 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeD
     total_neighborhood_count += neighborhood_counts[i];
   }
 
-  if(regularization_pose_) {
+  if (regularization_pose_) {
     float regularization_score = 0.0f;
     Eigen::Matrix<double, 6, 1> regularization_gradient = Eigen::Matrix<double, 6, 1>::Zero();
     Eigen::Matrix<double, 6, 6> regularization_hessian = Eigen::Matrix<double, 6, 6>::Zero();
@@ -400,14 +455,22 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeD
     const float longitudinal_distance = dy * sin_yaw + dx * cos_yaw;
     const auto neighborhood_count_weight = static_cast<float>(total_neighborhood_count);
 
-    regularization_score = -params_.regularization_scale_factor * neighborhood_count_weight * longitudinal_distance * longitudinal_distance;
+    regularization_score = -params_.regularization_scale_factor * neighborhood_count_weight *
+                           longitudinal_distance * longitudinal_distance;
 
-    regularization_gradient(0, 0) = params_.regularization_scale_factor * neighborhood_count_weight * 2.0f * cos_yaw * longitudinal_distance;
-    regularization_gradient(1, 0) = params_.regularization_scale_factor * neighborhood_count_weight * 2.0f * sin_yaw * longitudinal_distance;
+    regularization_gradient(0, 0) = params_.regularization_scale_factor *
+                                    neighborhood_count_weight * 2.0f * cos_yaw *
+                                    longitudinal_distance;
+    regularization_gradient(1, 0) = params_.regularization_scale_factor *
+                                    neighborhood_count_weight * 2.0f * sin_yaw *
+                                    longitudinal_distance;
 
-    regularization_hessian(0, 0) = -params_.regularization_scale_factor * neighborhood_count_weight * 2.0f * cos_yaw * cos_yaw;
-    regularization_hessian(0, 1) = -params_.regularization_scale_factor * neighborhood_count_weight * 2.0f * cos_yaw * sin_yaw;
-    regularization_hessian(1, 1) = -params_.regularization_scale_factor * neighborhood_count_weight * 2.0f * sin_yaw * sin_yaw;
+    regularization_hessian(0, 0) =
+      -params_.regularization_scale_factor * neighborhood_count_weight * 2.0f * cos_yaw * cos_yaw;
+    regularization_hessian(0, 1) =
+      -params_.regularization_scale_factor * neighborhood_count_weight * 2.0f * cos_yaw * sin_yaw;
+    regularization_hessian(1, 1) =
+      -params_.regularization_scale_factor * neighborhood_count_weight * 2.0f * sin_yaw * sin_yaw;
     regularization_hessian(1, 0) = regularization_hessian(0, 1);
 
     score += regularization_score;
@@ -415,23 +478,28 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeD
     hessian += regularization_hessian;
   }
 
-  if(found_neigborhood_voxel_num != 0) {
-    nearest_voxel_transformation_likelihood_ = nearest_voxel_score / static_cast<double>(found_neigborhood_voxel_num);
+  if (found_neigborhood_voxel_num != 0) {
+    nearest_voxel_transformation_likelihood_ =
+      nearest_voxel_score / static_cast<double>(found_neigborhood_voxel_num);
   } else {
     nearest_voxel_transformation_likelihood_ = 0.0;
   }
-  nearest_voxel_transformation_likelihood_array_.push_back(nearest_voxel_transformation_likelihood_);
-  const float transform_probability = (input_->points.empty() ? 0.0f : score / static_cast<double>(input_->points.size()));
+  nearest_voxel_transformation_likelihood_array_.push_back(
+    nearest_voxel_transformation_likelihood_);
+  const float transform_probability =
+    (input_->points.empty() ? 0.0f : score / static_cast<double>(input_->points.size()));
   transform_probability_array_.push_back(transform_probability);
   return (score);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget>
-void MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeAngleDerivatives(Eigen::Matrix<double, 6, 1> &p, bool compute_hessian) {
+template <typename PointSource, typename PointTarget>
+void MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeAngleDerivatives(
+  Eigen::Matrix<double, 6, 1> & p, bool compute_hessian)
+{
   // Simplified math for near 0 angles
   double cx, cy, cz, sx, sy, sz;
-  if(fabs(p(3)) < 10e-5) {
+  if (fabs(p(3)) < 10e-5) {
     // p(3) = 0;
     cx = 1.0;
     sx = 0.0;
@@ -439,7 +507,7 @@ void MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeAng
     cx = cos(p(3));
     sx = sin(p(3));
   }
-  if(fabs(p(4)) < 10e-5) {
+  if (fabs(p(4)) < 10e-5) {
     // p(4) = 0;
     cy = 1.0;
     sy = 0.0;
@@ -448,7 +516,7 @@ void MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeAng
     sy = sin(p(4));
   }
 
-  if(fabs(p(5)) < 10e-5) {
+  if (fabs(p(5)) < 10e-5) {
     // p(5) = 0;
     cz = 1.0;
     sz = 0.0;
@@ -469,8 +537,9 @@ void MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeAng
   j_ang_.row(6) << (cx * cz - sx * sy * sz), (-cx * sz - sx * sy * cz), 0.0f, 0.0f;
   j_ang_.row(7) << (sx * cz + cx * sy * sz), (cx * sy * cz - sx * sz), 0.0f, 0.0f;
 
-  if(compute_hessian) {
-    // Precomputed angular hessian components. Letters correspond to Equation 6.21 and numbers correspond to row index [Magnusson 2009]
+  if (compute_hessian) {
+    // Precomputed angular hessian components. Letters correspond to Equation 6.21 and numbers
+    // correspond to row index [Magnusson 2009]
     h_ang_.setZero();
 
     h_ang_.row(0) << (-cx * sz - sx * sy * cz), (-cx * cz + sx * sy * sz), sx * cy, 0.0f;     // a2
@@ -497,12 +566,16 @@ void MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeAng
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget>
-void MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computePointDerivatives(Eigen::Vector3d &x, Eigen::Matrix<double, 4, 6> &point_gradient, Eigen::Matrix<double, 24, 6> &point_hessian, bool compute_hessian) const {
+template <typename PointSource, typename PointTarget>
+void MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computePointDerivatives(
+  Eigen::Vector3d & x, Eigen::Matrix<double, 4, 6> & point_gradient,
+  Eigen::Matrix<double, 24, 6> & point_hessian, bool compute_hessian) const
+{
   Eigen::Vector4d x4(x[0], x[1], x[2], 0.0f);
 
   // Calculate first derivative of Transformation Equation 6.17 w.r.t. transform vector p.
-  // Derivative w.r.t. ith element of transform vector corresponds to column i, Equation 6.18 and 6.19 [Magnusson 2009]
+  // Derivative w.r.t. ith element of transform vector corresponds to column i, Equation 6.18
+  // and 6.19 [Magnusson 2009]
   auto x_j_ang = j_ang_ * x4;
 
   point_gradient(1, 3) = x_j_ang[0];
@@ -514,7 +587,7 @@ void MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computePoi
   point_gradient(1, 5) = x_j_ang[6];
   point_gradient(2, 5) = x_j_ang[7];
 
-  if(compute_hessian) {
+  if (compute_hessian) {
     auto x_h_ang = h_ang_ * x4;
 
     // Vectors from Equation 6.21 [Magnusson 2009]
@@ -526,7 +599,8 @@ void MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computePoi
     Eigen::Vector4d f(x_h_ang[12], x_h_ang[13], x_h_ang[14], 0.0f);
 
     // Calculate second derivative of Transformation Equation 6.17 w.r.t. transform vector p.
-    // Derivative w.r.t. ith and jth elements of transform vector corresponds to the 3x1 block matrix starting at (3i,j), Equation 6.20 and 6.21 [Magnusson 2009]
+    // Derivative w.r.t. ith and jth elements of transform vector corresponds to the 3x1 block
+    // matrix starting at (3i,j), Equation 6.20 and 6.21 [Magnusson 2009]
     point_hessian.block<4, 1>(12, 3) = a;
     point_hessian.block<4, 1>(16, 3) = b;
     point_hessian.block<4, 1>(20, 3) = c;
@@ -540,8 +614,13 @@ void MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computePoi
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget>
-double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::updateDerivatives(Eigen::Matrix<double, 6, 1> &score_gradient, Eigen::Matrix<double, 6, 6> &hessian, const Eigen::Matrix<double, 4, 6> &point_gradient, const Eigen::Matrix<double, 24, 6> &point_hessian, const Eigen::Vector3d &x_trans, const Eigen::Matrix3d &c_inv, bool compute_hessian) const {
+template <typename PointSource, typename PointTarget>
+double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::updateDerivatives(
+  Eigen::Matrix<double, 6, 1> & score_gradient, Eigen::Matrix<double, 6, 6> & hessian,
+  const Eigen::Matrix<double, 4, 6> & point_gradient,
+  const Eigen::Matrix<double, 24, 6> & point_hessian, const Eigen::Vector3d & x_trans,
+  const Eigen::Matrix3d & c_inv, bool compute_hessian) const
+{
   Eigen::Matrix<double, 1, 4> x_trans4(x_trans[0], x_trans[1], x_trans[2], 0.0f);
   Eigen::Matrix4d c_inv4 = Eigen::Matrix4d::Zero();
 
@@ -555,29 +634,36 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::updateDe
   e_x_cov_x = gauss_d2_ * e_x_cov_x;
 
   // Error checking for invalid values.
-  if(e_x_cov_x > 1 || e_x_cov_x < 0 || e_x_cov_x != e_x_cov_x) return (0);
+  if (e_x_cov_x > 1 || e_x_cov_x < 0 || e_x_cov_x != e_x_cov_x) return (0);
 
   // Reusable portion of Equation 6.12 and 6.13 [Magnusson 2009]
   e_x_cov_x *= gauss_d1_;
 
   Eigen::Matrix<double, 4, 6> c_inv4_x_point_gradient4 = c_inv4 * point_gradient;
-  Eigen::Matrix<double, 6, 1> x_trans4_dot_c_inv4_x_point_gradient4 = x_trans4 * c_inv4_x_point_gradient4;
+  Eigen::Matrix<double, 6, 1> x_trans4_dot_c_inv4_x_point_gradient4 =
+    x_trans4 * c_inv4_x_point_gradient4;
 
   score_gradient.noalias() += (e_x_cov_x * x_trans4_dot_c_inv4_x_point_gradient4).cast<double>();
 
-  if(compute_hessian) {
+  if (compute_hessian) {
     Eigen::Matrix<double, 1, 4> x_trans4_x_c_inv4 = x_trans4 * c_inv4;
-    Eigen::Matrix<double, 6, 6> point_gradient4_colj_dot_c_inv4_x_point_gradient4_col_i = point_gradient.transpose() * c_inv4_x_point_gradient4;
+    Eigen::Matrix<double, 6, 6> point_gradient4_colj_dot_c_inv4_x_point_gradient4_col_i =
+      point_gradient.transpose() * c_inv4_x_point_gradient4;
     Eigen::Matrix<double, 6, 1> x_trans4_dot_c_inv4_x_ext_point_hessian_4ij;
 
-    for(int i = 0; i < 6; ++i) {
+    for (int i = 0; i < 6; ++i) {
       // Sigma_k^-1 d(T(x,p))/dpi, Reusable portion of Equation 6.12 and 6.13 [Magnusson 2009]
       // Update gradient, Equation 6.12 [Magnusson 2009]
-      x_trans4_dot_c_inv4_x_ext_point_hessian_4ij.noalias() = x_trans4_x_c_inv4 * point_hessian.block<4, 6>(i * 4, 0);
+      x_trans4_dot_c_inv4_x_ext_point_hessian_4ij.noalias() =
+        x_trans4_x_c_inv4 * point_hessian.block<4, 6>(i * 4, 0);
 
-      for(int j = 0; j < hessian.cols(); j++) {
+      for (int j = 0; j < hessian.cols(); j++) {
         // Update hessian, Equation 6.13 [Magnusson 2009]
-        hessian(i, j) += e_x_cov_x * (-gauss_d2_ * x_trans4_dot_c_inv4_x_point_gradient4(i) * x_trans4_dot_c_inv4_x_point_gradient4(j) + x_trans4_dot_c_inv4_x_ext_point_hessian_4ij(j) + point_gradient4_colj_dot_c_inv4_x_point_gradient4_col_i(j, i));
+        hessian(i, j) +=
+          e_x_cov_x * (-gauss_d2_ * x_trans4_dot_c_inv4_x_point_gradient4(i) *
+                         x_trans4_dot_c_inv4_x_point_gradient4(j) +
+                       x_trans4_dot_c_inv4_x_ext_point_hessian_4ij(j) +
+                       point_gradient4_colj_dot_c_inv4_x_point_gradient4_col_i(j, i));
       }
     }
   }
@@ -586,15 +672,18 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::updateDe
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget>
-void MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeHessian(Eigen::Matrix<double, 6, 6> &hessian, PointCloudSource &trans_cloud, Eigen::Matrix<double, 6, 1> &) {
+template <typename PointSource, typename PointTarget>
+void MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeHessian(
+  Eigen::Matrix<double, 6, 6> & hessian, PointCloudSource & trans_cloud,
+  Eigen::Matrix<double, 6, 1> &)
+{
   // Initialize Point Gradient and Hessian
   // Pre-allocate thread-wise point gradients and point hessians
   std::vector<Eigen::Matrix<double, 4, 6>> t_point_gradients(params_.num_threads);
   std::vector<Eigen::Matrix<double, 24, 6>> t_point_hessians(params_.num_threads);
   std::vector<Eigen::Matrix<double, 6, 6>> t_hessians(params_.num_threads);
 
-  for(int i = 0; i < params_.num_threads; ++i) {
+  for (int i = 0; i < params_.num_threads; ++i) {
     t_point_gradients[i].setZero();
     t_point_gradients[i].block<3, 3>(0, 0).setIdentity();
     t_point_hessians[i].setZero();
@@ -603,13 +692,14 @@ void MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeHes
 
   hessian.setZero();
 
-  // Precompute Angular Derivatives unnecessary because only used after regular derivative calculation
+  // Precompute Angular Derivatives unnecessary because only used after regular derivative
+  // calculation
 
   // Update hessian for each point, line 17 in Algorithm 2 [Magnusson 2009]
 #pragma omp parallel for num_threads(params_.num_threads) schedule(guided, 8)
-  for(size_t idx = 0; idx < input_->size(); ++idx) {
+  for (size_t idx = 0; idx < input_->size(); ++idx) {
     int tid = omp_get_thread_num();
-    auto &x_trans_pt = trans_cloud[idx];
+    auto & x_trans_pt = trans_cloud[idx];
 
     // Find neighbors (Radius search has been experimentally faster than direct neighbor checking.
     std::vector<TargetGridLeafConstPtr> neighborhood;
@@ -617,79 +707,93 @@ void MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeHes
     // Neighborhood search method other than kdtree is disabled in multigrid_ndt_omp
     target_cells_.radiusSearch(x_trans_pt, params_.resolution, neighborhood);
 
-    if(neighborhood.empty()) {
+    if (neighborhood.empty()) {
       continue;
     }
 
-    auto &x_pt = (*input_)[idx];
+    auto & x_pt = (*input_)[idx];
     // For math
     Eigen::Vector3d x(x_pt.x, x_pt.y, x_pt.z);
     const Eigen::Vector3d x_trans(x_trans_pt.x, x_trans_pt.y, x_trans_pt.z);
 
-    auto &point_gradient = t_point_gradients[tid];
-    auto &point_hessian = t_point_hessians[tid];
-    auto &tmp_hessian = t_hessians[tid];
+    auto & point_gradient = t_point_gradients[tid];
+    auto & point_hessian = t_point_hessians[tid];
+    auto & tmp_hessian = t_hessians[tid];
 
-    // Compute derivative of transform function w.r.t. transform vector, J_E and H_E in Equations 6.18 and 6.20 [Magnusson 2009]
+    // Compute derivative of transform function w.r.t. transform vector, J_E and H_E in
+    // Equations 6.18 and 6.20 [Magnusson 2009]
     computePointDerivatives(x, point_gradient, point_hessian);
 
-    for(auto &cell : neighborhood) {
-      // Update hessian, lines 21 in Algorithm 2, according to Equations 6.10, 6.12 and 6.13, respectively [Magnusson 2009]
-      updateHessian(tmp_hessian, point_gradient, point_hessian, x_trans - cell->getMean(), cell->getInverseCov());
+    for (auto & cell : neighborhood) {
+      // Update hessian, lines 21 in Algorithm 2, according to Equations 6.10, 6.12 and 6.13,
+      // respectively [Magnusson 2009]
+      updateHessian(
+        tmp_hessian, point_gradient, point_hessian, x_trans - cell->getMean(),
+        cell->getInverseCov());
     }
   }
 
   // Sum over t_hessians
-  for(auto &th : t_hessians) {
+  for (auto & th : t_hessians) {
     hessian += th;
   }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget>
-void MultiGridNormalDistributionsTransform<PointSource, PointTarget>::updateHessian(Eigen::Matrix<double, 6, 6> &hessian, const Eigen::Matrix<double, 4, 6> &point_gradient, const Eigen::Matrix<double, 24, 6> &point_hessian, const Eigen::Vector3d &x_trans, const Eigen::Matrix3d &c_inv) const {
+template <typename PointSource, typename PointTarget>
+void MultiGridNormalDistributionsTransform<PointSource, PointTarget>::updateHessian(
+  Eigen::Matrix<double, 6, 6> & hessian, const Eigen::Matrix<double, 4, 6> & point_gradient,
+  const Eigen::Matrix<double, 24, 6> & point_hessian, const Eigen::Vector3d & x_trans,
+  const Eigen::Matrix3d & c_inv) const
+{
   Eigen::Vector3d cov_dxd_pi;
   // e^(-d_2/2 * (x_k - mu_k)^T Sigma_k^-1 (x_k - mu_k)) Equation 6.9 [Magnusson 2009]
   double e_x_cov_x = gauss_d2_ * exp(-gauss_d2_ * x_trans.dot(c_inv * x_trans) / 2);
 
   // Error checking for invalid values.
-  if(e_x_cov_x > 1 || e_x_cov_x < 0 || e_x_cov_x != e_x_cov_x) return;
+  if (e_x_cov_x > 1 || e_x_cov_x < 0 || e_x_cov_x != e_x_cov_x) return;
 
   // Reusable portion of Equation 6.12 and 6.13 [Magnusson 2009]
   e_x_cov_x *= gauss_d1_;
 
-  for(int i = 0; i < 6; ++i) {
+  for (int i = 0; i < 6; ++i) {
     // Sigma_k^-1 d(T(x,p))/dpi, Reusable portion of Equation 6.12 and 6.13 [Magnusson 2009]
     cov_dxd_pi = c_inv * point_gradient.block<3, 1>(0, i);
 
-    for(int j = 0; j < hessian.cols(); j++) {
+    for (int j = 0; j < hessian.cols(); j++) {
       // Update hessian, Equation 6.13 [Magnusson 2009]
       Eigen::Vector3d pg_col = point_gradient.block<3, 1>(0, j);
 
-      hessian(i, j) += e_x_cov_x * (-gauss_d2_ * x_trans.dot(cov_dxd_pi) * x_trans.dot(c_inv * pg_col) + x_trans.dot(c_inv * point_hessian.block<3, 1>(3 * i, j)) + pg_col.dot(cov_dxd_pi));
+      hessian(i, j) +=
+        e_x_cov_x *
+        (-gauss_d2_ * x_trans.dot(cov_dxd_pi) * x_trans.dot(c_inv * pg_col) +
+         x_trans.dot(c_inv * point_hessian.block<3, 1>(3 * i, j)) + pg_col.dot(cov_dxd_pi));
     }
   }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget>
-bool MultiGridNormalDistributionsTransform<PointSource, PointTarget>::updateIntervalMT(double &a_l, double &f_l, double &g_l, double &a_u, double &f_u, double &g_u, double a_t, double f_t, double g_t) {
+template <typename PointSource, typename PointTarget>
+bool MultiGridNormalDistributionsTransform<PointSource, PointTarget>::updateIntervalMT(
+  double & a_l, double & f_l, double & g_l, double & a_u, double & f_u, double & g_u, double a_t,
+  double f_t, double g_t)
+{
   // Case U1 in Update Algorithm and Case a in Modified Update Algorithm [More, Thuente 1994]
-  if(f_t > f_l) {
+  if (f_t > f_l) {
     a_u = a_t;
     f_u = f_t;
     g_u = g_t;
     return (false);
   }
   // Case U2 in Update Algorithm and Case b in Modified Update Algorithm [More, Thuente 1994]
-  else if(g_t * (a_l - a_t) > 0) {
+  else if (g_t * (a_l - a_t) > 0) {
     a_l = a_t;
     f_l = f_t;
     g_l = g_t;
     return (false);
   }
   // Case U3 in Update Algorithm and Case c in Modified Update Algorithm [More, Thuente 1994]
-  else if(g_t * (a_l - a_t) < 0) {
+  else if (g_t * (a_l - a_t) < 0) {
     a_u = a_l;
     f_u = f_l;
     g_u = g_l;
@@ -705,10 +809,13 @@ bool MultiGridNormalDistributionsTransform<PointSource, PointTarget>::updateInte
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget>
-double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::trialValueSelectionMT(double a_l, double f_l, double g_l, double a_u, double f_u, double g_u, double a_t, double f_t, double g_t) {
+template <typename PointSource, typename PointTarget>
+double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::trialValueSelectionMT(
+  double a_l, double f_l, double g_l, double a_u, double f_u, double g_u, double a_t, double f_t,
+  double g_t)
+{
   // Case 1 in Trial Value Selection [More, Thuente 1994]
-  if(f_t > f_l) {
+  if (f_t > f_l) {
     // Calculate the minimizer of the cubic that interpolates f_l, f_t, g_l and g_t
     // Equation 2.4.52 [Sun, Yuan 2006]
     double z = 3 * (f_t - f_l) / (a_t - a_l) - g_t - g_l;
@@ -720,13 +827,13 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::trialVal
     // Equation 2.4.2 [Sun, Yuan 2006]
     double a_q = a_l - 0.5 * (a_l - a_t) * g_l / (g_l - (f_l - f_t) / (a_l - a_t));
 
-    if(std::fabs(a_c - a_l) < std::fabs(a_q - a_l))
+    if (std::fabs(a_c - a_l) < std::fabs(a_q - a_l))
       return (a_c);
     else
       return (0.5 * (a_q + a_c));
   }
   // Case 2 in Trial Value Selection [More, Thuente 1994]
-  else if(g_t * g_l < 0) {
+  else if (g_t * g_l < 0) {
     // Calculate the minimizer of the cubic that interpolates f_l, f_t, g_l and g_t
     // Equation 2.4.52 [Sun, Yuan 2006]
     double z = 3 * (f_t - f_l) / (a_t - a_l) - g_t - g_l;
@@ -738,13 +845,13 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::trialVal
     // Equation 2.4.5 [Sun, Yuan 2006]
     double a_s = a_l - (a_l - a_t) / (g_l - g_t) * g_l;
 
-    if(std::fabs(a_c - a_t) >= std::fabs(a_s - a_t))
+    if (std::fabs(a_c - a_t) >= std::fabs(a_s - a_t))
       return (a_c);
     else
       return (a_s);
   }
   // Case 3 in Trial Value Selection [More, Thuente 1994]
-  else if(std::fabs(g_t) <= std::fabs(g_l)) {
+  else if (std::fabs(g_t) <= std::fabs(g_l)) {
     // Calculate the minimizer of the cubic that interpolates f_l, f_t, g_l and g_t
     // Equation 2.4.52 [Sun, Yuan 2006]
     double z = 3 * (f_t - f_l) / (a_t - a_l) - g_t - g_l;
@@ -757,12 +864,12 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::trialVal
 
     double a_t_next;
 
-    if(std::fabs(a_c - a_t) < std::fabs(a_s - a_t))
+    if (std::fabs(a_c - a_t) < std::fabs(a_s - a_t))
       a_t_next = a_c;
     else
       a_t_next = a_s;
 
-    if(a_t > a_l)
+    if (a_t > a_l)
       return (std::min(a_t + 0.66 * (a_u - a_t), a_t_next));
     else
       return (std::max(a_t + 0.66 * (a_u - a_t), a_t_next));
@@ -779,8 +886,12 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::trialVal
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget>
-double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeStepLengthMT(const Eigen::Matrix<double, 6, 1> &x, Eigen::Matrix<double, 6, 1> &step_dir, double step_init, double step_max, double step_min, double &score, Eigen::Matrix<double, 6, 1> &score_gradient, Eigen::Matrix<double, 6, 6> &hessian, PointCloudSource &trans_cloud) {
+template <typename PointSource, typename PointTarget>
+double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeStepLengthMT(
+  const Eigen::Matrix<double, 6, 1> & x, Eigen::Matrix<double, 6, 1> & step_dir, double step_init,
+  double step_max, double step_min, double & score, Eigen::Matrix<double, 6, 1> & score_gradient,
+  Eigen::Matrix<double, 6, 6> & hessian, PointCloudSource & trans_cloud)
+{
   // Set the value of phi(0), Equation 1.3 [More, Thuente 1994]
   double phi_0 = -score;
   // Set the value of phi'(0), Equation 1.3 [More, Thuente 1994]
@@ -788,9 +899,9 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeS
 
   Eigen::Matrix<double, 6, 1> x_t;
 
-  if(d_phi_0 >= 0) {
+  if (d_phi_0 >= 0) {
     // Not a decent direction
-    if(d_phi_0 == 0)
+    if (d_phi_0 == 0)
       return 0;
     else {
       // Reverse step direction and calculate optimal step.
@@ -812,14 +923,16 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeS
   // Initial endpoints of Interval I,
   double a_l = 0, a_u = 0;
 
-  // Auxiliary function psi is used until I is determined ot be a closed interval, Equation 2.1 [More, Thuente 1994]
+  // Auxiliary function psi is used until I is determined ot be a closed interval, Equation 2.1
+  // [More, Thuente 1994]
   double f_l = auxiliaryFunction_PsiMT(a_l, phi_0, phi_0, d_phi_0, mu);
   double g_l = auxiliaryFunction_dPsiMT(d_phi_0, d_phi_0, mu);
 
   double f_u = auxiliaryFunction_PsiMT(a_u, phi_0, phi_0, d_phi_0, mu);
   double g_u = auxiliaryFunction_dPsiMT(d_phi_0, d_phi_0, mu);
 
-  // Check used to allow More-Thuente step length calculation to be skipped by making step_min == step_max
+  // Check used to allow More-Thuente step length calculation to be skipped by making step_min ==
+  // step_max
   bool interval_converged = (step_max - step_min) < 0, open_interval = true;
 
   double a_t = step_init;
@@ -828,26 +941,33 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeS
 
   x_t = x + step_dir * a_t;
 
-  final_transformation_ = (Eigen::Translation<float, 3>(static_cast<float>(x_t(0)), static_cast<float>(x_t(1)), static_cast<float>(x_t(2))) * Eigen::AngleAxis<float>(static_cast<float>(x_t(3)), Eigen::Vector3f::UnitX()) * Eigen::AngleAxis<float>(static_cast<float>(x_t(4)), Eigen::Vector3f::UnitY()) * Eigen::AngleAxis<float>(static_cast<float>(x_t(5)), Eigen::Vector3f::UnitZ()))
-                              .matrix();
+  final_transformation_ =
+    (Eigen::Translation<float, 3>(
+       static_cast<float>(x_t(0)), static_cast<float>(x_t(1)), static_cast<float>(x_t(2))) *
+     Eigen::AngleAxis<float>(static_cast<float>(x_t(3)), Eigen::Vector3f::UnitX()) *
+     Eigen::AngleAxis<float>(static_cast<float>(x_t(4)), Eigen::Vector3f::UnitY()) *
+     Eigen::AngleAxis<float>(static_cast<float>(x_t(5)), Eigen::Vector3f::UnitZ()))
+      .matrix();
 
   // New transformed point cloud
   transformPointCloud(*input_, trans_cloud, final_transformation_);
 
-  // Updates score, gradient and hessian.  Hessian calculation is unnecessary but testing showed that most step calculations use the
-  // initial step suggestion and recalculation the reusable portions of the hessian would intail more computation time.
+  // Updates score, gradient and hessian.  Hessian calculation is unnecessary but testing showed
+  // that most step calculations use the initial step suggestion and recalculation the reusable
+  // portions of the hessian would intail more computation time.
   score = computeDerivatives(score_gradient, hessian, trans_cloud, x_t, true);
 
   // --------------------------------------------------------------------------------------------------------------------------------
   // FIXME(YamatoAndo):
   // Currently, using LineSearch causes the following problems:
   // It may converge to a local solution.
-  // There are cases where a loop process is executed without changing the variable values, resulting in unnecessary processing time.
-  // As better convergence results are obtained without using LineSearch, we have decided to disable this feature.
-  // If you have any suggestions on how to solve these issues, we would appreciate it if you could contribute.
+  // There are cases where a loop process is executed without changing the variable values,
+  // resulting in unnecessary processing time. As better convergence results are obtained without
+  // using LineSearch, we have decided to disable this feature. If you have any suggestions on how
+  // to solve these issues, we would appreciate it if you could contribute.
   // --------------------------------------------------------------------------------------------------------------------------------
 
-  if(params_.use_line_search) {
+  if (params_.use_line_search) {
     // Calculate phi(alpha_t)
     double phi_t = -score;
     // Calculate phi'(alpha_t)
@@ -858,10 +978,13 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeS
     // Calculate psi'(alpha_t)
     double d_psi_t = auxiliaryFunction_dPsiMT(d_phi_t, d_phi_0, mu);
 
-    // Iterate until max number of iterations, interval convergence or a value satisfies the sufficient decrease, Equation 1.1, and curvature condition, Equation 1.2 [More, Thuente 1994]
-    while(!interval_converged && step_iterations < max_step_iterations && !(psi_t <= 0 /*Sufficient Decrease*/ && d_phi_t <= -nu * d_phi_0 /*Curvature Condition*/)) {
+    // Iterate until max number of iterations, interval convergence or a value satisfies the
+    // sufficient decrease, Equation 1.1, and curvature condition, Equation 1.2 [More, Thuente 1994]
+    while (
+      !interval_converged && step_iterations < max_step_iterations &&
+      !(psi_t <= 0 /*Sufficient Decrease*/ && d_phi_t <= -nu * d_phi_0 /*Curvature Condition*/)) {
       // Use auxiliary function if interval I is not closed
-      if(open_interval) {
+      if (open_interval) {
         a_t = trialValueSelectionMT(a_l, f_l, g_l, a_u, f_u, g_u, a_t, psi_t, d_psi_t);
       } else {
         a_t = trialValueSelectionMT(a_l, f_l, g_l, a_u, f_u, g_u, a_t, phi_t, d_phi_t);
@@ -872,8 +995,13 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeS
 
       x_t = x + step_dir * a_t;
 
-      final_transformation_ = (Eigen::Translation<float, 3>(static_cast<float>(x_t(0)), static_cast<float>(x_t(1)), static_cast<float>(x_t(2))) * Eigen::AngleAxis<float>(static_cast<float>(x_t(3)), Eigen::Vector3f::UnitX()) * Eigen::AngleAxis<float>(static_cast<float>(x_t(4)), Eigen::Vector3f::UnitY()) * Eigen::AngleAxis<float>(static_cast<float>(x_t(5)), Eigen::Vector3f::UnitZ()))
-                                  .matrix();
+      final_transformation_ =
+        (Eigen::Translation<float, 3>(
+           static_cast<float>(x_t(0)), static_cast<float>(x_t(1)), static_cast<float>(x_t(2))) *
+         Eigen::AngleAxis<float>(static_cast<float>(x_t(3)), Eigen::Vector3f::UnitX()) *
+         Eigen::AngleAxis<float>(static_cast<float>(x_t(4)), Eigen::Vector3f::UnitY()) *
+         Eigen::AngleAxis<float>(static_cast<float>(x_t(5)), Eigen::Vector3f::UnitZ()))
+          .matrix();
 
       // New transformed point cloud
       // Done on final cloud to prevent wasted computation
@@ -893,7 +1021,7 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeS
       d_psi_t = auxiliaryFunction_dPsiMT(d_phi_t, d_phi_0, mu);
 
       // Check if I is now a closed interval
-      if(open_interval && (psi_t <= 0 && d_psi_t >= 0)) {
+      if (open_interval && (psi_t <= 0 && d_psi_t >= 0)) {
         open_interval = false;
 
         // Converts f_l and g_l from psi to phi
@@ -905,7 +1033,7 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeS
         g_u = g_u + mu * d_phi_0;
       }
 
-      if(open_interval) {
+      if (open_interval) {
         // Update interval end points using Updating Algorithm [More, Thuente 1994]
         interval_converged = updateIntervalMT(a_l, f_l, g_l, a_u, f_u, g_u, a_t, psi_t, d_psi_t);
       } else {
@@ -920,20 +1048,23 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeS
   // If inner loop was run then hessian needs to be calculated.
   // Hessian is unnecessary for step length determination but gradients are required
   // so derivative and transform data is stored for the next iteration.
-  if(step_iterations) computeHessian(hessian, trans_cloud, x_t);
+  if (step_iterations) computeHessian(hessian, trans_cloud, x_t);
 
   return (a_t);
 }
 
-template<typename PointSource, typename PointTarget>
-double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::calculateTransformationProbability(const PointCloudSource &trans_cloud) const {
+template <typename PointSource, typename PointTarget>
+double
+MultiGridNormalDistributionsTransform<PointSource, PointTarget>::calculateTransformationProbability(
+  const PointCloudSource & trans_cloud) const
+{
   double score = 0;
 
   // Score per thread
   std::vector<double> t_scores(params_.num_threads, 0);
 
 #pragma omp parallel for num_threads(params_.num_threads) schedule(guided, 8)
-  for(size_t idx = 0; idx < trans_cloud.size(); ++idx) {
+  for (size_t idx = 0; idx < trans_cloud.size(); ++idx) {
     int tid = omp_get_thread_num();
     PointSource x_trans_pt = trans_cloud[idx];
 
@@ -943,13 +1074,13 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::calculat
     // Neighborhood search method other than kdtree is disabled in multigrid_ndt_omp
     target_cells_.radiusSearch(x_trans_pt, params_.resolution, neighborhood);
 
-    if(neighborhood.empty()) {
+    if (neighborhood.empty()) {
       continue;
     }
 
     double tmp_score = 0;
 
-    for(auto &cell : neighborhood) {
+    for (auto & cell : neighborhood) {
       Eigen::Vector3d x_trans(x_trans_pt.x, x_trans_pt.y, x_trans_pt.z);
 
       // Denorm point, x_k' in Equations 6.12 and 6.13 [Magnusson 2009]
@@ -964,19 +1095,21 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::calculat
   }
 
   // Sum the point-wise scores
-  for(auto &ts : t_scores) {
+  for (auto & ts : t_scores) {
     score += ts;
   }
 
   double output_score = 0;
-  if(!trans_cloud.empty()) {
+  if (!trans_cloud.empty()) {
     output_score = (score) / static_cast<double>(trans_cloud.size());
   }
   return output_score;
 }
 
-template<typename PointSource, typename PointTarget>
-double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::calculateNearestVoxelTransformationLikelihood(const PointCloudSource &trans_cloud) const {
+template <typename PointSource, typename PointTarget>
+double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::
+  calculateNearestVoxelTransformationLikelihood(const PointCloudSource & trans_cloud) const
+{
   double nearest_voxel_score = 0;
   size_t found_neighborhood_voxel_num = 0;
 
@@ -984,13 +1117,13 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::calculat
   std::vector<double> t_nvs(params_.num_threads);
   std::vector<size_t> t_found_nnvn(params_.num_threads);
 
-  for(int i = 0; i < params_.num_threads; ++i) {
+  for (int i = 0; i < params_.num_threads; ++i) {
     t_nvs[i] = 0;
     t_found_nnvn[i] = 0;
   }
 
 #pragma omp parallel for num_threads(params_.num_threads) schedule(guided, 8)
-  for(size_t idx = 0; idx < trans_cloud.size(); ++idx) {
+  for (size_t idx = 0; idx < trans_cloud.size(); ++idx) {
     int tid = omp_get_thread_num();
     PointSource x_trans_pt = trans_cloud[idx];
 
@@ -1000,13 +1133,13 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::calculat
     // Neighborhood search method other than kdtree is disabled in multigrid_ndt_omp
     target_cells_.radiusSearch(x_trans_pt, params_.resolution, neighborhood);
 
-    if(neighborhood.empty()) {
+    if (neighborhood.empty()) {
       continue;
     }
 
     double nearest_voxel_score_pt = 0;
 
-    for(auto &cell : neighborhood) {
+    for (auto & cell : neighborhood) {
       Eigen::Vector3d x_trans(x_trans_pt.x, x_trans_pt.y, x_trans_pt.z);
 
       // Denorm point, x_k' in Equations 6.12 and 6.13 [Magnusson 2009]
@@ -1017,7 +1150,7 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::calculat
       // Calculate probability of transformed points existence, Equation 6.9 [Magnusson 2009]
       double score_inc = -gauss_d1_ * e_x_cov_x;
 
-      if(score_inc > nearest_voxel_score_pt) {
+      if (score_inc > nearest_voxel_score_pt) {
         nearest_voxel_score_pt = score_inc;
       }
     }
@@ -1027,14 +1160,14 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::calculat
   }
 
   // Sum up point-wise scores
-  for(size_t idx = 0; idx < params_.num_threads; ++idx) {
+  for (size_t idx = 0; idx < params_.num_threads; ++idx) {
     found_neighborhood_voxel_num += t_found_nnvn[idx];
     nearest_voxel_score += t_nvs[idx];
   }
 
   double output_score = 0;
 
-  if(found_neighborhood_voxel_num != 0) {
+  if (found_neighborhood_voxel_num != 0) {
     output_score = nearest_voxel_score / static_cast<double>(found_neighborhood_voxel_num);
   }
   return output_score;

--- a/include/pclomp/gicp_omp.h
+++ b/include/pclomp/gicp_omp.h
@@ -41,10 +41,11 @@
 #ifndef PCL_GICP_OMP_H_
 #define PCL_GICP_OMP_H_
 
-#include <pcl/registration/icp.h>
 #include <pcl/registration/bfgs.h>
+#include <pcl/registration/icp.h>
 
-namespace pclomp {
+namespace pclomp
+{
 /** \brief GeneralizedIterativeClosestPoint is an ICP variant that implements the
  * generalized iterative closest point algorithm as described by Alex Segal et al. in
  * http://www.robots.ox.ac.uk/~avsegal/resources/papers/Generalized_ICP.pdf
@@ -55,8 +56,9 @@ namespace pclomp {
  * \author Nizar Sallem
  * \ingroup registration
  */
-template<typename PointSource, typename PointTarget>
-class GeneralizedIterativeClosestPoint : public pcl::IterativeClosestPoint<PointSource, PointTarget> {
+template <typename PointSource, typename PointTarget>
+class GeneralizedIterativeClosestPoint : public pcl::IterativeClosestPoint<PointSource, PointTarget>
+{
 public:
   using pcl::IterativeClosestPoint<PointSource, PointTarget>::reg_name_;
   using pcl::IterativeClosestPoint<PointSource, PointTarget>::getClassName;
@@ -98,40 +100,56 @@ public:
   using MatricesVectorConstPtr = pcl::shared_ptr<const MatricesVector>;
 
   using Ptr = pcl::shared_ptr<GeneralizedIterativeClosestPoint<PointSource, PointTarget> >;
-  using ConstPtr = pcl::shared_ptr<const GeneralizedIterativeClosestPoint<PointSource, PointTarget> >;
+  using ConstPtr =
+    pcl::shared_ptr<const GeneralizedIterativeClosestPoint<PointSource, PointTarget> >;
 #else
   using MatricesVectorPtr = boost::shared_ptr<MatricesVector>;
   using MatricesVectorConstPtr = boost::shared_ptr<const MatricesVector>;
 
   using Ptr = boost::shared_ptr<GeneralizedIterativeClosestPoint<PointSource, PointTarget> >;
-  using ConstPtr = boost::shared_ptr<const GeneralizedIterativeClosestPoint<PointSource, PointTarget> >;
+  using ConstPtr =
+    boost::shared_ptr<const GeneralizedIterativeClosestPoint<PointSource, PointTarget> >;
 #endif
 
   using Vector6d = Eigen::Matrix<double, 6, 1>;
 
   /** \brief Empty constructor. */
-  GeneralizedIterativeClosestPoint() : k_correspondences_(20), gicp_epsilon_(0.001), rotation_epsilon_(2e-3), mahalanobis_(0), max_inner_iterations_(20) {
+  GeneralizedIterativeClosestPoint()
+  : k_correspondences_(20),
+    gicp_epsilon_(0.001),
+    rotation_epsilon_(2e-3),
+    mahalanobis_(0),
+    max_inner_iterations_(20)
+  {
     min_number_correspondences_ = 4;
     reg_name_ = "GeneralizedIterativeClosestPoint";
     max_iterations_ = 200;
     transformation_epsilon_ = 5e-4;
     corr_dist_threshold_ = 5.;
-    rigid_transformation_estimation_ = [this](const PointCloudSource &cloud_src, const std::vector<int> &indices_src, const PointCloudTarget &cloud_tgt, const std::vector<int> &indices_tgt, Eigen::Matrix4f &transformation_matrix) {
-      estimateRigidTransformationBFGS(cloud_src, indices_src, cloud_tgt, indices_tgt, transformation_matrix);
-    };
+    rigid_transformation_estimation_ =
+      [this](
+        const PointCloudSource & cloud_src, const std::vector<int> & indices_src,
+        const PointCloudTarget & cloud_tgt, const std::vector<int> & indices_tgt,
+        Eigen::Matrix4f & transformation_matrix) {
+        estimateRigidTransformationBFGS(
+          cloud_src, indices_src, cloud_tgt, indices_tgt, transformation_matrix);
+      };
   }
 
   /** \brief Provide a pointer to the input dataset
    * \param cloud the const boost shared pointer to a PointCloud message
    */
-  inline void setInputSource(const PointCloudSourceConstPtr &cloud) override {
-    if(cloud->points.empty()) {
-      PCL_ERROR("[pcl::%s::setInputSource] Invalid or empty point cloud dataset given!\n", getClassName().c_str());
+  inline void setInputSource(const PointCloudSourceConstPtr & cloud) override
+  {
+    if (cloud->points.empty()) {
+      PCL_ERROR(
+        "[pcl::%s::setInputSource] Invalid or empty point cloud dataset given!\n",
+        getClassName().c_str());
       return;
     }
     PointCloudSource input = *cloud;
     // Set all the point.data[3] values to 1 to aid the rigid transformation
-    for(size_t i = 0; i < input.size(); ++i) input[i].data[3] = 1.0;
+    for (size_t i = 0; i < input.size(); ++i) input[i].data[3] = 1.0;
 
     pcl::IterativeClosestPoint<PointSource, PointTarget>::setInputSource(cloud);
     input_covariances_.reset();
@@ -139,42 +157,48 @@ public:
 
   /** \brief Provide a pointer to the covariances of the input source (if computed externally!).
    * If not set, GeneralizedIterativeClosestPoint will compute the covariances itself.
-   * Make sure to set the covariances AFTER setting the input source point cloud (setting the input source point cloud will reset the covariances).
-   * \param[in] target the input point cloud target
+   * Make sure to set the covariances AFTER setting the input source point cloud (setting the input
+   * source point cloud will reset the covariances). \param[in] target the input point cloud target
    */
-  inline void setSourceCovariances(const MatricesVectorPtr &covariances) {
+  inline void setSourceCovariances(const MatricesVectorPtr & covariances)
+  {
     input_covariances_ = covariances;
   }
 
-  /** \brief Provide a pointer to the input target (e.g., the point cloud that we want to align the input source to)
-   * \param[in] target the input point cloud target
+  /** \brief Provide a pointer to the input target (e.g., the point cloud that we want to align the
+   * input source to) \param[in] target the input point cloud target
    */
-  inline void setInputTarget(const PointCloudTargetConstPtr &target) override {
+  inline void setInputTarget(const PointCloudTargetConstPtr & target) override
+  {
     pcl::IterativeClosestPoint<PointSource, PointTarget>::setInputTarget(target);
     target_covariances_.reset();
   }
 
   /** \brief Provide a pointer to the covariances of the input target (if computed externally!).
    * If not set, GeneralizedIterativeClosestPoint will compute the covariances itself.
-   * Make sure to set the covariances AFTER setting the input source point cloud (setting the input source point cloud will reset the covariances).
-   * \param[in] target the input point cloud target
+   * Make sure to set the covariances AFTER setting the input source point cloud (setting the input
+   * source point cloud will reset the covariances). \param[in] target the input point cloud target
    */
-  inline void setTargetCovariances(const MatricesVectorPtr &covariances) {
+  inline void setTargetCovariances(const MatricesVectorPtr & covariances)
+  {
     target_covariances_ = covariances;
   }
 
-  /** \brief Estimate a rigid rotation transformation between a source and a target point cloud using an iterative
-   * non-linear Levenberg-Marquardt approach.
-   * \param[in] cloud_src the source point cloud dataset
-   * \param[in] indices_src the vector of indices describing the points of interest in \a cloud_src
-   * \param[in] cloud_tgt the target point cloud dataset
-   * \param[in] indices_tgt the vector of indices describing the correspondences of the interest points from \a indices_src
-   * \param[out] transformation_matrix the resultant transformation matrix
+  /** \brief Estimate a rigid rotation transformation between a source and a target point cloud
+   * using an iterative non-linear Levenberg-Marquardt approach. \param[in] cloud_src the source
+   * point cloud dataset \param[in] indices_src the vector of indices describing the points of
+   * interest in \a cloud_src \param[in] cloud_tgt the target point cloud dataset \param[in]
+   * indices_tgt the vector of indices describing the correspondences of the interest points from \a
+   * indices_src \param[out] transformation_matrix the resultant transformation matrix
    */
-  void estimateRigidTransformationBFGS(const PointCloudSource &cloud_src, const std::vector<int> &indices_src, const PointCloudTarget &cloud_tgt, const std::vector<int> &indices_tgt, Eigen::Matrix4f &transformation_matrix);
+  void estimateRigidTransformationBFGS(
+    const PointCloudSource & cloud_src, const std::vector<int> & indices_src,
+    const PointCloudTarget & cloud_tgt, const std::vector<int> & indices_tgt,
+    Eigen::Matrix4f & transformation_matrix);
 
   /** \brief \return Mahalanobis distance matrix for the given point index */
-  inline const Eigen::Matrix4f &mahalanobis(size_t index) const {
+  inline const Eigen::Matrix4f & mahalanobis(size_t index) const
+  {
     assert(index < mahalanobis_.size());
     return mahalanobis_[index];
   }
@@ -186,23 +210,19 @@ public:
    * param R rotation matrix
    * param g gradient vector
    */
-  void computeRDerivative(const Vector6d &x, const Eigen::Matrix3d &R, Vector6d &g) const;
+  void computeRDerivative(const Vector6d & x, const Eigen::Matrix3d & R, Vector6d & g) const;
 
   /** \brief Set the rotation epsilon (maximum allowable difference between two
    * consecutive rotations) in order for an optimization to be considered as having
    * converged to the final solution.
    * \param epsilon the rotation epsilon
    */
-  inline void setRotationEpsilon(double epsilon) {
-    rotation_epsilon_ = epsilon;
-  }
+  inline void setRotationEpsilon(double epsilon) { rotation_epsilon_ = epsilon; }
 
   /** \brief Get the rotation epsilon (maximum allowable difference between two
    * consecutive rotations) as set by the user.
    */
-  inline double getRotationEpsilon() {
-    return (rotation_epsilon_);
-  }
+  inline double getRotationEpsilon() { return (rotation_epsilon_); }
 
   /** \brief Set the number of neighbors used when selecting a point neighbourhood
    * to compute covariances.
@@ -210,28 +230,20 @@ public:
    * covariances computation slower.
    * \param k the number of neighbors to use when computing covariances
    */
-  void setCorrespondenceRandomness(int k) {
-    k_correspondences_ = k;
-  }
+  void setCorrespondenceRandomness(int k) { k_correspondences_ = k; }
 
   /** \brief Get the number of neighbors used when computing covariances as set by
    * the user
    */
-  int getCorrespondenceRandomness() {
-    return (k_correspondences_);
-  }
+  int getCorrespondenceRandomness() { return (k_correspondences_); }
 
   /** set maximum number of iterations at the optimization step
    * \param[in] max maximum number of iterations for the optimizer
    */
-  void setMaximumOptimizerIterations(int max) {
-    max_inner_iterations_ = max;
-  }
+  void setMaximumOptimizerIterations(int max) { max_inner_iterations_ = max; }
 
   ///\return maximum number of iterations at the optimization step
-  int getMaximumOptimizerIterations() {
-    return (max_inner_iterations_);
-  }
+  int getMaximumOptimizerIterations() { return (max_inner_iterations_); }
 
 protected:
   /** \brief The number of neighbors used for covariances computation.
@@ -255,16 +267,16 @@ protected:
   Eigen::Matrix4f base_transformation_;
 
   /** \brief Temporary pointer to the source dataset. */
-  const PointCloudSource *tmp_src_;
+  const PointCloudSource * tmp_src_;
 
   /** \brief Temporary pointer to the target dataset. */
-  const PointCloudTarget *tmp_tgt_;
+  const PointCloudTarget * tmp_tgt_;
 
   /** \brief Temporary pointer to the source dataset indices. */
-  const std::vector<int> *tmp_idx_src_;
+  const std::vector<int> * tmp_idx_src_;
 
   /** \brief Temporary pointer to the target dataset indices. */
-  const std::vector<int> *tmp_idx_tgt_;
+  const std::vector<int> * tmp_idx_tgt_;
 
   /** \brief Input cloud points covariances. */
   MatricesVectorPtr input_covariances_;
@@ -284,19 +296,22 @@ protected:
    * \param tree KD tree performer for nearest neighbors search
    * \param[out] cloud_covariances covariances matrices for each point in the cloud
    */
-  template<typename PointT>
-  void computeCovariances(typename pcl::PointCloud<PointT>::ConstPtr cloud, const typename pcl::search::KdTree<PointT>::ConstPtr tree, MatricesVector &cloud_covariances);
+  template <typename PointT>
+  void computeCovariances(
+    typename pcl::PointCloud<PointT>::ConstPtr cloud,
+    const typename pcl::search::KdTree<PointT>::ConstPtr tree, MatricesVector & cloud_covariances);
 
   /** \return trace of mat1^t . mat2
    * \param mat1 matrix of dimension nxm
    * \param mat2 matrix of dimension nxp
    */
-  inline double matricesInnerProd(const Eigen::MatrixXd &mat1, const Eigen::MatrixXd &mat2) const {
+  inline double matricesInnerProd(const Eigen::MatrixXd & mat1, const Eigen::MatrixXd & mat2) const
+  {
     double r = 0.;
     size_t n = mat1.rows();
     // tr(mat1^t.mat2)
-    for(size_t i = 0; i < n; i++)
-      for(size_t j = 0; j < n; j++) r += mat1(j, i) * mat2(i, j);
+    for (size_t i = 0; i < n; i++)
+      for (size_t j = 0; j < n; j++) r += mat1(j, i) * mat2(i, j);
     return r;
   }
 
@@ -304,33 +319,43 @@ protected:
    * \param output the transformed input point cloud dataset using the rigid transformation found
    * \param guess the initial guess of the transformation to compute
    */
-  void computeTransformation(PointCloudSource &output, const Eigen::Matrix4f &guess) override;
+  void computeTransformation(PointCloudSource & output, const Eigen::Matrix4f & guess) override;
 
   /** \brief Search for the closest nearest neighbor of a given point.
    * \param query the point to search a nearest neighbour for
    * \param index vector of size 1 to store the index of the nearest neighbour found
    * \param distance vector of size 1 to store the distance to nearest neighbour found
    */
-  inline bool searchForNeighbors(const PointSource &query, std::vector<int> &index, std::vector<float> &distance) const {
+  inline bool searchForNeighbors(
+    const PointSource & query, std::vector<int> & index, std::vector<float> & distance) const
+  {
     int k = tree_->nearestKSearch(query, 1, index, distance);
-    if(k == 0) return (false);
+    if (k == 0) return (false);
     return (true);
   }
 
   /// \brief compute transformation matrix from transformation matrix
-  void applyState(Eigen::Matrix4f &t, const Vector6d &x) const;
+  void applyState(Eigen::Matrix4f & t, const Vector6d & x) const;
 
   /// \brief optimization functor structure
-  struct OptimizationFunctorWithIndices : public BFGSDummyFunctor<double, 6> {
-    OptimizationFunctorWithIndices(const GeneralizedIterativeClosestPoint *gicp) : BFGSDummyFunctor<double, 6>(), gicp_(gicp) {}
-    double operator()(const Vector6d &x) override;
-    void df(const Vector6d &x, Vector6d &df) override;
-    void fdf(const Vector6d &x, double &f, Vector6d &df) override;
+  struct OptimizationFunctorWithIndices : public BFGSDummyFunctor<double, 6>
+  {
+    OptimizationFunctorWithIndices(const GeneralizedIterativeClosestPoint * gicp)
+    : BFGSDummyFunctor<double, 6>(), gicp_(gicp)
+    {
+    }
+    double operator()(const Vector6d & x) override;
+    void df(const Vector6d & x, Vector6d & df) override;
+    void fdf(const Vector6d & x, double & f, Vector6d & df) override;
 
-    const GeneralizedIterativeClosestPoint *gicp_;
+    const GeneralizedIterativeClosestPoint * gicp_;
   };
 
-  std::function<void(const pcl::PointCloud<PointSource> &cloud_src, const std::vector<int> &src_indices, const pcl::PointCloud<PointTarget> &cloud_tgt, const std::vector<int> &tgt_indices, Eigen::Matrix4f &transformation_matrix)> rigid_transformation_estimation_;
+  std::function<void(
+    const pcl::PointCloud<PointSource> & cloud_src, const std::vector<int> & src_indices,
+    const pcl::PointCloud<PointTarget> & cloud_tgt, const std::vector<int> & tgt_indices,
+    Eigen::Matrix4f & transformation_matrix)>
+    rigid_transformation_estimation_;
 };
 }  // namespace pclomp
 

--- a/include/pclomp/gicp_omp_impl.hpp
+++ b/include/pclomp/gicp_omp_impl.hpp
@@ -40,33 +40,40 @@
 #ifndef PCL_REGISTRATION_IMPL_GICP_OMP_HPP_
 #define PCL_REGISTRATION_IMPL_GICP_OMP_HPP_
 
-#include <atomic>
 #include <pcl/registration/boost.h>
 #include <pcl/registration/exceptions.h>
 
+#include <atomic>
+
 ////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget>
-template<typename PointT>
-void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeCovariances(typename pcl::PointCloud<PointT>::ConstPtr cloud, const typename pcl::search::KdTree<PointT>::ConstPtr kdtree, MatricesVector& cloud_covariances) {
-  if(k_correspondences_ > int(cloud->size())) {
-    PCL_ERROR("[pcl::GeneralizedIterativeClosestPoint::computeCovariances] Number of points in cloud (%lu) is less than k_correspondences_ (%lu)!\n", cloud->size(), k_correspondences_);
+template <typename PointSource, typename PointTarget>
+template <typename PointT>
+void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeCovariances(
+  typename pcl::PointCloud<PointT>::ConstPtr cloud,
+  const typename pcl::search::KdTree<PointT>::ConstPtr kdtree, MatricesVector & cloud_covariances)
+{
+  if (k_correspondences_ > int(cloud->size())) {
+    PCL_ERROR(
+      "[pcl::GeneralizedIterativeClosestPoint::computeCovariances] Number of points in cloud (%lu) "
+      "is less than k_correspondences_ (%lu)!\n",
+      cloud->size(), k_correspondences_);
     return;
   }
 
   // We should never get there but who knows
-  if(cloud_covariances.size() < cloud->size()) cloud_covariances.resize(cloud->size());
+  if (cloud_covariances.size() < cloud->size()) cloud_covariances.resize(cloud->size());
 
   std::vector<std::vector<int>> nn_indices_array(omp_get_max_threads());
   std::vector<std::vector<float>> nn_dist_sq_array(omp_get_max_threads());
 
 #pragma omp parallel for
-  for(std::size_t i = 0; i < cloud->size(); i++) {
-    auto& nn_indices = nn_indices_array[omp_get_thread_num()];
-    auto& nn_dist_sq = nn_dist_sq_array[omp_get_thread_num()];
+  for (std::size_t i = 0; i < cloud->size(); i++) {
+    auto & nn_indices = nn_indices_array[omp_get_thread_num()];
+    auto & nn_dist_sq = nn_dist_sq_array[omp_get_thread_num()];
 
-    const PointT& query_point = cloud->at(i);
+    const PointT & query_point = cloud->at(i);
     Eigen::Vector3d mean = Eigen::Vector3d::Zero();
-    Eigen::Matrix3d& cov = cloud_covariances[i];
+    Eigen::Matrix3d & cov = cloud_covariances[i];
     // Zero out the cov and mean
     cov.setZero();
 
@@ -74,8 +81,8 @@ void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::compute
     kdtree->nearestKSearch(query_point, k_correspondences_, nn_indices, nn_dist_sq);
 
     // Find the covariance matrix
-    for(int j = 0; j < k_correspondences_; j++) {
-      const PointT& pt = (*cloud)[nn_indices[j]];
+    for (int j = 0; j < k_correspondences_; j++) {
+      const PointT & pt = (*cloud)[nn_indices[j]];
 
       mean[0] += pt.x;
       mean[1] += pt.y;
@@ -93,8 +100,8 @@ void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::compute
 
     mean /= static_cast<double>(k_correspondences_);
     // Get the actual covariance
-    for(int k = 0; k < 3; k++)
-      for(int l = 0; l <= k; l++) {
+    for (int k = 0; k < 3; k++)
+      for (int l = 0; l <= k; l++) {
         cov(k, l) /= static_cast<double>(k_correspondences_);
         cov(k, l) -= mean[k] * mean[l];
         cov(l, k) = cov(k, l);
@@ -104,11 +111,12 @@ void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::compute
     Eigen::JacobiSVD<Eigen::Matrix3d> svd(cov, Eigen::ComputeFullU);
     cov.setZero();
     Eigen::Matrix3d U = svd.matrixU();
-    // Reconstitute the covariance matrix with modified singular values using the column     // vectors in V.
-    for(int k = 0; k < 3; k++) {
+    // Reconstitute the covariance matrix with modified singular values using the column     //
+    // vectors in V.
+    for (int k = 0; k < 3; k++) {
       Eigen::Vector3d col = U.col(k);
       double v = 1.;  // biggest 2 singular values replaced by 1
-      if(k == 2)      // smallest singular value replaced by gicp_epsilon
+      if (k == 2)     // smallest singular value replaced by gicp_epsilon
         v = gicp_epsilon_;
       cov += v * col * col.transpose();
     }
@@ -116,8 +124,10 @@ void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::compute
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget>
-void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeRDerivative(const Vector6d& x, const Eigen::Matrix3d& R, Vector6d& g) const {
+template <typename PointSource, typename PointTarget>
+void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeRDerivative(
+  const Vector6d & x, const Eigen::Matrix3d & R, Vector6d & g) const
+{
   Eigen::Matrix3d dR_dPhi;
   Eigen::Matrix3d dR_dTheta;
   Eigen::Matrix3d dR_dPsi;
@@ -170,11 +180,20 @@ void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::compute
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget>
-void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::estimateRigidTransformationBFGS(const PointCloudSource& cloud_src, const std::vector<int>& indices_src, const PointCloudTarget& cloud_tgt, const std::vector<int>& indices_tgt, Eigen::Matrix4f& transformation_matrix) {
-  if(indices_src.size() < 4)  // need at least 4 samples
+template <typename PointSource, typename PointTarget>
+void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::
+  estimateRigidTransformationBFGS(
+    const PointCloudSource & cloud_src, const std::vector<int> & indices_src,
+    const PointCloudTarget & cloud_tgt, const std::vector<int> & indices_tgt,
+    Eigen::Matrix4f & transformation_matrix)
+{
+  if (indices_src.size() < 4)  // need at least 4 samples
   {
-    PCL_THROW_EXCEPTION(pcl::NotEnoughPointsException, "[pcl::GeneralizedIterativeClosestPoint::estimateRigidTransformationBFGS] Need at least 4 points to estimate a transform! Source and target have " << indices_src.size() << " points!");
+    PCL_THROW_EXCEPTION(
+      pcl::NotEnoughPointsException,
+      "[pcl::GeneralizedIterativeClosestPoint::estimateRigidTransformationBFGS] Need at least 4 "
+      "points to estimate a transform! Source and target have "
+        << indices_src.size() << " points!");
     return;
   }
   // Set the initial solution
@@ -209,23 +228,31 @@ void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::estimat
   do {
     inner_iterations_++;
     result = bfgs.minimizeOneStep(x);
-    if(result) {
+    if (result) {
       break;
     }
     result = bfgs.testGradient(gradient_tol);
-  } while(result == BFGSSpace::Running && inner_iterations_ < max_inner_iterations_);
-  if(result == BFGSSpace::NoProgress || result == BFGSSpace::Success || inner_iterations_ == max_inner_iterations_) {
+  } while (result == BFGSSpace::Running && inner_iterations_ < max_inner_iterations_);
+  if (
+    result == BFGSSpace::NoProgress || result == BFGSSpace::Success ||
+    inner_iterations_ == max_inner_iterations_) {
     PCL_DEBUG("[pcl::registration::TransformationEstimationBFGS::estimateRigidTransformation]");
     PCL_DEBUG("BFGS solver finished with exit code %i \n", result);
     transformation_matrix.setIdentity();
     applyState(transformation_matrix, x);
   } else
-    PCL_THROW_EXCEPTION(pcl::SolverDidntConvergeException, "[pcl::" << getClassName() << "::TransformationEstimationBFGS::estimateRigidTransformation] BFGS solver didn't converge!");
+    PCL_THROW_EXCEPTION(
+      pcl::SolverDidntConvergeException,
+      "[pcl::" << getClassName()
+               << "::TransformationEstimationBFGS::estimateRigidTransformation] BFGS solver didn't "
+                  "converge!");
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget>
-inline double pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::OptimizationFunctorWithIndices::operator()(const Vector6d& x) {
+template <typename PointSource, typename PointTarget>
+inline double pclomp::GeneralizedIterativeClosestPoint<
+  PointSource, PointTarget>::OptimizationFunctorWithIndices::operator()(const Vector6d & x)
+{
   Eigen::Matrix4f transformation_matrix = gicp_->base_transformation_;
   gicp_->applyState(transformation_matrix, x);
   double f = 0;
@@ -233,11 +260,13 @@ inline double pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>
 
   int m = static_cast<int>(gicp_->tmp_idx_src_->size());
 #pragma omp parallel for
-  for(int i = 0; i < m; ++i) {
+  for (int i = 0; i < m; ++i) {
     // The last coordinate, p_src[3] is guaranteed to be set to 1.0 in registration.hpp
-    pcl::Vector4fMapConst p_src = gicp_->tmp_src_->points[(*gicp_->tmp_idx_src_)[i]].getVector4fMap();
+    pcl::Vector4fMapConst p_src =
+      gicp_->tmp_src_->points[(*gicp_->tmp_idx_src_)[i]].getVector4fMap();
     // The last coordinate, p_tgt[3] is guaranteed to be set to 1.0 in registration.hpp
-    pcl::Vector4fMapConst p_tgt = gicp_->tmp_tgt_->points[(*gicp_->tmp_idx_tgt_)[i]].getVector4fMap();
+    pcl::Vector4fMapConst p_tgt =
+      gicp_->tmp_tgt_->points[(*gicp_->tmp_idx_tgt_)[i]].getVector4fMap();
     // Estimate the distance (cost function)
     // The last coordinate is still guaranteed to be set to 1.0
     // Eigen::AlignedVector3<double> res(pp[0] - p_tgt[0], pp[1] - p_tgt[1], pp[2] - p_tgt[2]);
@@ -245,8 +274,8 @@ inline double pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>
     Eigen::Vector4f res = transformation_matrix * p_src - p_tgt;
     Eigen::Matrix4f maha = gicp_->mahalanobis((*gicp_->tmp_idx_src_)[i]);
     // Eigen::Vector4d temp(maha * res);
-    // increment= res'*temp/num_matches = temp'*M*temp/num_matches (we postpone 1/num_matches after the loop closes)
-    // double ret = double(res.transpose() * temp);
+    // increment= res'*temp/num_matches = temp'*M*temp/num_matches (we postpone 1/num_matches after
+    // the loop closes) double ret = double(res.transpose() * temp);
     double ret = res.dot(maha * res);
     f_array[omp_get_thread_num()] += ret;
   }
@@ -255,26 +284,32 @@ inline double pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget>
-inline void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::OptimizationFunctorWithIndices::df(const Vector6d& x, Vector6d& g) {
+template <typename PointSource, typename PointTarget>
+inline void pclomp::GeneralizedIterativeClosestPoint<
+  PointSource, PointTarget>::OptimizationFunctorWithIndices::df(const Vector6d & x, Vector6d & g)
+{
   Eigen::Matrix4f transformation_matrix = gicp_->base_transformation_;
   gicp_->applyState(transformation_matrix, x);
   // Eigen::Vector3d g_t = g.head<3> ();
-  std::vector<Eigen::Matrix4d, Eigen::aligned_allocator<Eigen::Matrix4d>> R_array(omp_get_max_threads());
-  std::vector<Eigen::Vector4d, Eigen::aligned_allocator<Eigen::Vector4d>> g_array(omp_get_max_threads());
+  std::vector<Eigen::Matrix4d, Eigen::aligned_allocator<Eigen::Matrix4d>> R_array(
+    omp_get_max_threads());
+  std::vector<Eigen::Vector4d, Eigen::aligned_allocator<Eigen::Vector4d>> g_array(
+    omp_get_max_threads());
 
-  for(std::size_t i = 0; i < R_array.size(); i++) {
+  for (std::size_t i = 0; i < R_array.size(); i++) {
     R_array[i].setZero();
     g_array[i].setZero();
   }
 
   int m = static_cast<int>(gicp_->tmp_idx_src_->size());
 #pragma omp parallel for
-  for(int i = 0; i < m; ++i) {
+  for (int i = 0; i < m; ++i) {
     // The last coordinate, p_src[3] is guaranteed to be set to 1.0 in registration.hpp
-    pcl::Vector4fMapConst p_src = gicp_->tmp_src_->points[(*gicp_->tmp_idx_src_)[i]].getVector4fMap();
+    pcl::Vector4fMapConst p_src =
+      gicp_->tmp_src_->points[(*gicp_->tmp_idx_src_)[i]].getVector4fMap();
     // The last coordinate, p_tgt[3] is guaranteed to be set to 1.0 in registration.hpp
-    pcl::Vector4fMapConst p_tgt = gicp_->tmp_tgt_->points[(*gicp_->tmp_idx_tgt_)[i]].getVector4fMap();
+    pcl::Vector4fMapConst p_tgt =
+      gicp_->tmp_tgt_->points[(*gicp_->tmp_idx_tgt_)[i]].getVector4fMap();
 
     Eigen::Vector4f pp(transformation_matrix * p_src);
     // The last coordinate is still guaranteed to be set to 1.0
@@ -296,7 +331,7 @@ inline void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::
 
   g.setZero();
   Eigen::Matrix4d R = Eigen::Matrix4d::Zero();
-  for(std::size_t i = 0; i < R_array.size(); i++) {
+  for (std::size_t i = 0; i < R_array.size(); i++) {
     R += R_array[i];
     g.head<3>() += g_array[i].head<3>();
   }
@@ -308,24 +343,32 @@ inline void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget>
-inline void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::OptimizationFunctorWithIndices::fdf(const Vector6d& x, double& f, Vector6d& g) {
+template <typename PointSource, typename PointTarget>
+inline void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::
+  OptimizationFunctorWithIndices::fdf(const Vector6d & x, double & f, Vector6d & g)
+{
   Eigen::Matrix4f transformation_matrix = gicp_->base_transformation_;
   gicp_->applyState(transformation_matrix, x);
   f = 0;
   g.setZero();
   Eigen::Matrix3d R = Eigen::Matrix3d::Zero();
   const auto m = static_cast<int>(gicp_->tmp_idx_src_->size());
-  for(int i = 0; i < m; ++i) {
+  for (int i = 0; i < m; ++i) {
     // The last coordinate, p_src[3] is guaranteed to be set to 1.0 in registration.hpp
-    pcl::Vector4fMapConst p_src = gicp_->tmp_src_->points[(*gicp_->tmp_idx_src_)[i]].getVector4fMap();
+    pcl::Vector4fMapConst p_src =
+      gicp_->tmp_src_->points[(*gicp_->tmp_idx_src_)[i]].getVector4fMap();
     // The last coordinate, p_tgt[3] is guaranteed to be set to 1.0 in registration.hpp
-    pcl::Vector4fMapConst p_tgt = gicp_->tmp_tgt_->points[(*gicp_->tmp_idx_tgt_)[i]].getVector4fMap();
+    pcl::Vector4fMapConst p_tgt =
+      gicp_->tmp_tgt_->points[(*gicp_->tmp_idx_tgt_)[i]].getVector4fMap();
     Eigen::Vector4f pp(transformation_matrix * p_src);
     // The last coordinate is still guaranteed to be set to 1.0
     Eigen::Vector3d res(pp[0] - p_tgt[0], pp[1] - p_tgt[1], pp[2] - p_tgt[2]);
     // temp = M*res
-    Eigen::Vector3d temp(gicp_->mahalanobis((*gicp_->tmp_idx_src_)[i]).template block<3, 3>(0, 0).template cast<double>() * res);
+    Eigen::Vector3d temp(
+      gicp_->mahalanobis((*gicp_->tmp_idx_src_)[i])
+        .template block<3, 3>(0, 0)
+        .template cast<double>() *
+      res);
     // Increment total error
     f += double(res.transpose() * temp);
     // Increment translation gradient
@@ -343,8 +386,11 @@ inline void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget>
-inline void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeTransformation(PointCloudSource& output, const Eigen::Matrix4f& guess) {
+template <typename PointSource, typename PointTarget>
+inline void
+pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeTransformation(
+  PointCloudSource & output, const Eigen::Matrix4f & guess)
+{
   pcl::IterativeClosestPoint<PointSource, PointTarget>::initComputeReciprocal();
   using namespace std;
   // Difference between consecutive transforms
@@ -354,12 +400,12 @@ inline void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::
   // Set the mahalanobis matrices to identity
   mahalanobis_.resize(N, Eigen::Matrix4f::Identity());
   // Compute target cloud covariance matrices
-  if((!target_covariances_) || (target_covariances_->empty())) {
+  if ((!target_covariances_) || (target_covariances_->empty())) {
     target_covariances_.reset(new MatricesVector);
     computeCovariances<PointTarget>(target_, tree_, *target_covariances_);
   }
   // Compute input cloud covariance matrices
-  if((!input_covariances_) || (input_covariances_->empty())) {
+  if ((!input_covariances_) || (input_covariances_->empty())) {
     input_covariances_.reset(new MatricesVector);
     computeCovariances<PointSource>(input_, tree_reciprocal_, *input_covariances_);
   }
@@ -372,14 +418,14 @@ inline void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::
 
   std::vector<std::vector<int>> nn_indices_array(omp_get_max_threads());
   std::vector<std::vector<float>> nn_dists_array(omp_get_max_threads());
-  for(auto& nn_indices : nn_indices_array) {
+  for (auto & nn_indices : nn_indices_array) {
     nn_indices.resize(1);
   }
-  for(auto& nn_dists : nn_dists_array) {
+  for (auto & nn_dists : nn_dists_array) {
     nn_dists.resize(1);
   }
 
-  while(!converged_) {
+  while (!converged_) {
     std::atomic<size_t> cnt;
     cnt = 0;
     std::vector<int> source_indices(indices_->size());
@@ -387,30 +433,34 @@ inline void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::
 
     // guess corresponds to base_t and transformation_ to t
     Eigen::Matrix4d transform_R = Eigen::Matrix4d::Zero();
-    for(size_t i = 0; i < 4; i++)
-      for(size_t j = 0; j < 4; j++)
-        for(size_t k = 0; k < 4; k++) transform_R(i, j) += double(transformation_(i, k)) * double(guess(k, j));
+    for (size_t i = 0; i < 4; i++)
+      for (size_t j = 0; j < 4; j++)
+        for (size_t k = 0; k < 4; k++)
+          transform_R(i, j) += double(transformation_(i, k)) * double(guess(k, j));
 
     const Eigen::Matrix3d R = transform_R.topLeftCorner<3, 3>();
 
 #pragma omp parallel for
-    for(std::size_t i = 0; i < N; i++) {
-      auto& nn_indices = nn_indices_array[omp_get_thread_num()];
-      auto& nn_dists = nn_dists_array[omp_get_thread_num()];
+    for (std::size_t i = 0; i < N; i++) {
+      auto & nn_indices = nn_indices_array[omp_get_thread_num()];
+      auto & nn_dists = nn_dists_array[omp_get_thread_num()];
 
       PointSource query = output[i];
       query.getVector4fMap() = transformation_ * query.getVector4fMap();
 
-      if(!searchForNeighbors(query, nn_indices, nn_dists)) {
-        PCL_ERROR("[pcl::%s::computeTransformation] Unable to find a nearest neighbor in the target dataset for point %d in the source!\n", getClassName().c_str(), (*indices_)[i]);
+      if (!searchForNeighbors(query, nn_indices, nn_dists)) {
+        PCL_ERROR(
+          "[pcl::%s::computeTransformation] Unable to find a nearest neighbor in the target "
+          "dataset for point %d in the source!\n",
+          getClassName().c_str(), (*indices_)[i]);
         continue;
       }
 
       // Check if the distance to the nearest neighbor is smaller than the user imposed threshold
-      if(nn_dists[0] < dist_threshold) {
-        const Eigen::Matrix3d& C1 = (*input_covariances_)[i];
-        const Eigen::Matrix3d& C2 = (*target_covariances_)[nn_indices[0]];
-        Eigen::Matrix4f& M_ = mahalanobis_[i];
+      if (nn_dists[0] < dist_threshold) {
+        const Eigen::Matrix3d & C1 = (*input_covariances_)[i];
+        const Eigen::Matrix3d & C2 = (*target_covariances_)[nn_indices[0]];
+        Eigen::Matrix4f & M_ = mahalanobis_[i];
         M_.setZero();
 
         Eigen::Matrix3d M = M_.block<3, 3>(0, 0).cast<double>();
@@ -432,14 +482,18 @@ inline void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::
     target_indices.resize(cnt);
 
     std::vector<std::pair<int, int>> indices(source_indices.size());
-    for(std::size_t i = 0; i < source_indices.size(); i++) {
+    for (std::size_t i = 0; i < source_indices.size(); i++) {
       indices[i].first = source_indices[i];
       indices[i].second = target_indices[i];
     }
 
-    std::sort(indices.begin(), indices.end(), [=](const std::pair<int, int>& lhs, const std::pair<int, int>& rhs) { return lhs.first < rhs.first; });
+    std::sort(
+      indices.begin(), indices.end(),
+      [=](const std::pair<int, int> & lhs, const std::pair<int, int> & rhs) {
+        return lhs.first < rhs.first;
+      });
 
-    for(std::size_t i = 0; i < source_indices.size(); i++) {
+    for (std::size_t i = 0; i < source_indices.size(); i++) {
       source_indices[i] = indices[i].first;
       target_indices[i] = indices[i].second;
     }
@@ -448,30 +502,37 @@ inline void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::
     previous_transformation_ = transformation_;
     // optimization right here
     try {
-      rigid_transformation_estimation_(output, source_indices, *target_, target_indices, transformation_);
+      rigid_transformation_estimation_(
+        output, source_indices, *target_, target_indices, transformation_);
       /* compute the delta from this iteration */
       delta = 0.;
-      for(int k = 0; k < 4; k++) {
-        for(int l = 0; l < 4; l++) {
+      for (int k = 0; k < 4; k++) {
+        for (int l = 0; l < 4; l++) {
           double ratio = 1;
-          if(k < 3 && l < 3)  // rotation part of the transform
+          if (k < 3 && l < 3)  // rotation part of the transform
             ratio = 1. / rotation_epsilon_;
           else
             ratio = 1. / transformation_epsilon_;
           double c_delta = ratio * std::abs(previous_transformation_(k, l) - transformation_(k, l));
-          if(c_delta > delta) delta = c_delta;
+          if (c_delta > delta) delta = c_delta;
         }
       }
-    } catch(pcl::PCLException& e) {
-      PCL_DEBUG("[pcl::%s::computeTransformation] Optimization issue %s\n", getClassName().c_str(), e.what());
+    } catch (pcl::PCLException & e) {
+      PCL_DEBUG(
+        "[pcl::%s::computeTransformation] Optimization issue %s\n", getClassName().c_str(),
+        e.what());
       break;
     }
     nr_iterations_++;
     // Check for convergence
-    if(nr_iterations_ >= max_iterations_ || delta < 1) {
+    if (nr_iterations_ >= max_iterations_ || delta < 1) {
       converged_ = true;
       previous_transformation_ = transformation_;
-      PCL_DEBUG("[pcl::%s::computeTransformation] Convergence reached. Number of iterations: %d out of %d. Transformation difference: %f\n", getClassName().c_str(), nr_iterations_, max_iterations_, (transformation_ - previous_transformation_).array().abs().sum());
+      PCL_DEBUG(
+        "[pcl::%s::computeTransformation] Convergence reached. Number of iterations: %d out of %d. "
+        "Transformation difference: %f\n",
+        getClassName().c_str(), nr_iterations_, max_iterations_,
+        (transformation_ - previous_transformation_).array().abs().sum());
     } else
       PCL_DEBUG("[pcl::%s::computeTransformation] Convergence failed\n", getClassName().c_str());
   }
@@ -481,13 +542,18 @@ inline void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::
   pcl::transformPointCloud(*input_, output, final_transformation_);
 }
 
-template<typename PointSource, typename PointTarget>
-void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::applyState(Eigen::Matrix4f& t, const Vector6d& x) const {
+template <typename PointSource, typename PointTarget>
+void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::applyState(
+  Eigen::Matrix4f & t, const Vector6d & x) const
+{
   // !!! CAUTION Stanford GICP uses the Z Y X euler angles convention
   Eigen::Matrix3f R;
-  R = Eigen::AngleAxisf(static_cast<float>(x[5]), Eigen::Vector3f::UnitZ()) * Eigen::AngleAxisf(static_cast<float>(x[4]), Eigen::Vector3f::UnitY()) * Eigen::AngleAxisf(static_cast<float>(x[3]), Eigen::Vector3f::UnitX());
+  R = Eigen::AngleAxisf(static_cast<float>(x[5]), Eigen::Vector3f::UnitZ()) *
+      Eigen::AngleAxisf(static_cast<float>(x[4]), Eigen::Vector3f::UnitY()) *
+      Eigen::AngleAxisf(static_cast<float>(x[3]), Eigen::Vector3f::UnitX());
   t.topLeftCorner<3, 3>().matrix() = R * t.topLeftCorner<3, 3>().matrix();
-  Eigen::Vector4f T(static_cast<float>(x[0]), static_cast<float>(x[1]), static_cast<float>(x[2]), 0.0f);
+  Eigen::Vector4f T(
+    static_cast<float>(x[0]), static_cast<float>(x[1]), static_cast<float>(x[2]), 0.0f);
   t.col(3) += T;
 }
 

--- a/include/pclomp/ndt_omp.h
+++ b/include/pclomp/ndt_omp.h
@@ -41,16 +41,18 @@
 #ifndef PCL_REGISTRATION_NDT_OMP_H_
 #define PCL_REGISTRATION_NDT_OMP_H_
 
+#include "ndt_struct.hpp"
+#include "voxel_grid_covariance_omp.h"
+
+#include <pcl/search/impl/search.hpp>
+#include <unsupported/Eigen/NonLinearOptimization>
+
 #include "boost/optional.hpp"
 
 #include <pcl/registration/registration.h>
-#include <pcl/search/impl/search.hpp>
-#include "voxel_grid_covariance_omp.h"
-#include "ndt_struct.hpp"
 
-#include <unsupported/Eigen/NonLinearOptimization>
-
-namespace pclomp {
+namespace pclomp
+{
 
 /** \brief A 3D Normal Distribution Transform registration implementation for point cloud data.
  * \note For more information please see
@@ -63,8 +65,9 @@ namespace pclomp {
  * \note Math refactored by Todor Stoyanov.
  * \author Brian Okorn (Space and Naval Warfare Systems Center Pacific)
  */
-template<typename PointSource, typename PointTarget>
-class NormalDistributionsTransform : public pcl::Registration<PointSource, PointTarget> {
+template <typename PointSource, typename PointTarget>
+class NormalDistributionsTransform : public pcl::Registration<PointSource, PointTarget>
+{
 protected:
   typedef typename pcl::Registration<PointSource, PointTarget>::PointCloudSource PointCloudSource;
   typedef typename PointCloudSource::Ptr PointCloudSourcePtr;
@@ -80,9 +83,9 @@ protected:
   /** \brief Typename of searchable voxel grid containing mean and covariance. */
   typedef pclomp::VoxelGridCovariance<PointTarget> TargetGrid;
   /** \brief Typename of pointer to searchable voxel grid. */
-  typedef TargetGrid *TargetGridPtr;
+  typedef TargetGrid * TargetGridPtr;
   /** \brief Typename of const pointer to searchable voxel grid. */
-  typedef const TargetGrid *TargetGridConstPtr;
+  typedef const TargetGrid * TargetGridConstPtr;
   /** \brief Typename of const pointer to searchable voxel grid leaf. */
   typedef typename TargetGrid::LeafConstPtr TargetGridLeafConstPtr;
 
@@ -103,18 +106,15 @@ public:
   /** \brief Empty destructor */
   virtual ~NormalDistributionsTransform() {}
 
-  void setNumThreads(int n) {
-    params_.num_threads = n;
-  }
+  void setNumThreads(int n) { params_.num_threads = n; }
 
-  inline int getNumThreads() const {
-    return params_.num_threads;
-  }
+  inline int getNumThreads() const { return params_.num_threads; }
 
-  /** \brief Provide a pointer to the input target (e.g., the point cloud that we want to align the input source to).
-   * \param[in] cloud the input point cloud target
+  /** \brief Provide a pointer to the input target (e.g., the point cloud that we want to align the
+   * input source to). \param[in] cloud the input point cloud target
    */
-  inline void setInputTarget(const PointCloudTargetConstPtr &cloud) {
+  inline void setInputTarget(const PointCloudTargetConstPtr & cloud)
+  {
     pcl::Registration<PointSource, PointTarget>::setInputTarget(cloud);
     init();
   }
@@ -122,82 +122,69 @@ public:
   /** \brief Set/change the voxel grid resolution.
    * \param[in] resolution side length of voxels
    */
-  inline void setResolution(float resolution) {
+  inline void setResolution(float resolution)
+  {
     // Prevents unnecessary voxel initiations
-    if(params_.resolution != resolution) {
+    if (params_.resolution != resolution) {
       params_.resolution = resolution;
-      if(input_) init();
+      if (input_) init();
     }
   }
 
   /** \brief Get voxel grid resolution.
    * \return side length of voxels
    */
-  inline float getResolution() const {
-    return (params_.resolution);
-  }
+  inline float getResolution() const { return (params_.resolution); }
 
   /** \brief Get the newton line search maximum step length.
    * \return maximum step length
    */
-  inline double getStepSize() const {
-    return (params_.step_size);
-  }
+  inline double getStepSize() const { return (params_.step_size); }
 
   /** \brief Set/change the newton line search maximum step length.
    * \param[in] step_size maximum step length
    */
-  inline void setStepSize(double step_size) {
-    params_.step_size = step_size;
-  }
+  inline void setStepSize(double step_size) { params_.step_size = step_size; }
 
   /** \brief Get the point cloud outlier ratio.
    * \return outlier ratio
    */
-  inline double getOutlierRatio() const {
-    return (outlier_ratio_);
-  }
+  inline double getOutlierRatio() const { return (outlier_ratio_); }
 
   /** \brief Set/change the point cloud outlier ratio.
    * \param[in] outlier_ratio outlier ratio
    */
-  inline void setOutlierRatio(double outlier_ratio) {
-    outlier_ratio_ = outlier_ratio;
-  }
+  inline void setOutlierRatio(double outlier_ratio) { outlier_ratio_ = outlier_ratio; }
 
-  inline void setNeighborhoodSearchMethod(NeighborSearchMethod method) {
+  inline void setNeighborhoodSearchMethod(NeighborSearchMethod method)
+  {
     params_.search_method = method;
   }
 
-  inline NeighborSearchMethod getNeighborhoodSearchMethod() const {
-    return params_.search_method;
-  }
+  inline NeighborSearchMethod getNeighborhoodSearchMethod() const { return params_.search_method; }
 
   /** \brief Get the registration alignment probability.
    * \return transformation probability
    */
-  inline double getTransformationProbability() const {
-    return (trans_probability_);
-  }
+  inline double getTransformationProbability() const { return (trans_probability_); }
 
-  inline double getNearestVoxelTransformationLikelihood() const {
+  inline double getNearestVoxelTransformationLikelihood() const
+  {
     return nearest_voxel_transformation_likelihood_;
   }
 
   /** \brief Get the number of iterations required to calculate alignment.
    * \return final number of iterations
    */
-  inline int getFinalNumIteration() const {
-    return (nr_iterations_);
-  }
+  inline int getFinalNumIteration() const { return (nr_iterations_); }
 
   /** \brief Return the hessian matrix */
-  inline Eigen::Matrix<double, 6, 6> getHessian() const {
-    return hessian_;
-  }
+  inline Eigen::Matrix<double, 6, 6> getHessian() const { return hessian_; }
 
   /** \brief Return the transformation array */
-  inline const std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f>> getFinalTransformationArray() const {
+  inline const std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f>>
+  getFinalTransformationArray() const
+  {
     return transformation_array_;
   }
 
@@ -205,15 +192,20 @@ public:
    * \param[in] x transformation vector of the form [x, y, z, roll, pitch, yaw]
    * \param[out] trans affine transform corresponding to given transformation vector
    */
-  static void convertTransform(const Eigen::Matrix<double, 6, 1> &x, Eigen::Affine3f &trans) {
-    trans = Eigen::Translation<float, 3>(float(x(0)), float(x(1)), float(x(2))) * Eigen::AngleAxis<float>(float(x(3)), Eigen::Vector3f::UnitX()) * Eigen::AngleAxis<float>(float(x(4)), Eigen::Vector3f::UnitY()) * Eigen::AngleAxis<float>(float(x(5)), Eigen::Vector3f::UnitZ());
+  static void convertTransform(const Eigen::Matrix<double, 6, 1> & x, Eigen::Affine3f & trans)
+  {
+    trans = Eigen::Translation<float, 3>(float(x(0)), float(x(1)), float(x(2))) *
+            Eigen::AngleAxis<float>(float(x(3)), Eigen::Vector3f::UnitX()) *
+            Eigen::AngleAxis<float>(float(x(4)), Eigen::Vector3f::UnitY()) *
+            Eigen::AngleAxis<float>(float(x(5)), Eigen::Vector3f::UnitZ());
   }
 
   /** \brief Convert 6 element transformation vector to transformation matrix.
    * \param[in] x transformation vector of the form [x, y, z, roll, pitch, yaw]
    * \param[out] trans 4x4 transformation matrix corresponding to given transformation vector
    */
-  static void convertTransform(const Eigen::Matrix<double, 6, 1> &x, Eigen::Matrix4f &trans) {
+  static void convertTransform(const Eigen::Matrix<double, 6, 1> & x, Eigen::Matrix4f & trans)
+  {
     Eigen::Affine3f _affine;
     convertTransform(x, _affine);
     trans = _affine.matrix();
@@ -221,23 +213,24 @@ public:
 
   // negative log likelihood function
   // lower is better
-  double calculateScore(const PointCloudSource &cloud) const;
-  double calculateTransformationProbability(const PointCloudSource &cloud) const;
-  double calculateNearestVoxelTransformationLikelihood(const PointCloudSource &cloud) const;
+  double calculateScore(const PointCloudSource & cloud) const;
+  double calculateTransformationProbability(const PointCloudSource & cloud) const;
+  double calculateNearestVoxelTransformationLikelihood(const PointCloudSource & cloud) const;
 
-  inline void setRegularizationScaleFactor(float regularization_scale_factor) {
+  inline void setRegularizationScaleFactor(float regularization_scale_factor)
+  {
     params_.regularization_scale_factor = regularization_scale_factor;
   }
 
-  inline void setRegularizationPose(Eigen::Matrix4f regularization_pose) {
+  inline void setRegularizationPose(Eigen::Matrix4f regularization_pose)
+  {
     regularization_pose_ = regularization_pose;
   }
 
-  inline void unsetRegularizationPose() {
-    regularization_pose_ = boost::none;
-  }
+  inline void unsetRegularizationPose() { regularization_pose_ = boost::none; }
 
-  NdtResult getResult() {
+  NdtResult getResult()
+  {
     NdtResult ndt_result;
     ndt_result.pose = this->getFinalTransformation();
     ndt_result.transformation_array = getFinalTransformationArray();
@@ -254,31 +247,19 @@ public:
    * transformation epsilon in order for an optimization to be considered as having
    * converged to the final solution.
    */
-  inline void setTransformationEpsilon(double epsilon) {
-    params_.trans_epsilon = epsilon;
-  }
+  inline void setTransformationEpsilon(double epsilon) { params_.trans_epsilon = epsilon; }
 
   /** \brief Get the transformation epsilon (maximum allowable translation squared
    * difference between two consecutive transformations) as set by the user.
    */
-  inline double getTransformationEpsilon() {
-    return (params_.trans_epsilon);
-  }
+  inline double getTransformationEpsilon() { return (params_.trans_epsilon); }
 
-  inline void setMaximumIterations(int max_iterations) {
-    params_.max_iterations = max_iterations;
-  }
-  inline int getMaxIterations() const {
-    return params_.max_iterations;
-  }
+  inline void setMaximumIterations(int max_iterations) { params_.max_iterations = max_iterations; }
+  inline int getMaxIterations() const { return params_.max_iterations; }
 
-  void setParams(const NdtParams &ndt_params) {
-    params_ = ndt_params;
-  }
+  void setParams(const NdtParams & ndt_params) { params_ = ndt_params; }
 
-  NdtParams getParams() const {
-    return params_;
-  }
+  NdtParams getParams() const { return params_; }
 
 protected:
   using pcl::Registration<PointSource, PointTarget>::reg_name_;
@@ -299,7 +280,8 @@ protected:
   /** \brief Estimate the transformation and returns the transformed source (input) as output.
    * \param[out] output the resultant input transformed point cloud dataset
    */
-  virtual void computeTransformation(PointCloudSource &output) {
+  virtual void computeTransformation(PointCloudSource & output)
+  {
     computeTransformation(output, Eigen::Matrix4f::Identity());
   }
 
@@ -307,10 +289,11 @@ protected:
    * \param[out] output the resultant input transformed point cloud dataset
    * \param[in] guess the initial gross estimation of the transformation
    */
-  virtual void computeTransformation(PointCloudSource &output, const Eigen::Matrix4f &guess);
+  virtual void computeTransformation(PointCloudSource & output, const Eigen::Matrix4f & guess);
 
   /** \brief Initiate covariance voxel structure. */
-  void inline init() {
+  void inline init()
+  {
     target_cells_.setLeafSize(params_.resolution, params_.resolution, params_.resolution);
     target_cells_.setInputCloud(target_);
     // Initiate voxel structure.
@@ -319,104 +302,135 @@ protected:
 
   /** \brief Compute derivatives of probability function w.r.t. the transformation vector.
    * \note Equation 6.10, 6.12 and 6.13 [Magnusson 2009].
-   * \param[out] score_gradient the gradient vector of the probability function w.r.t. the transformation vector
-   * \param[out] hessian the hessian matrix of the probability function w.r.t. the transformation vector
-   * \param[in] trans_cloud transformed point cloud
-   * \param[in] p the current transform vector
-   * \param[in] compute_hessian flag to calculate hessian, unnecessary for step calculation.
+   * \param[out] score_gradient the gradient vector of the probability function w.r.t. the
+   * transformation vector \param[out] hessian the hessian matrix of the probability function w.r.t.
+   * the transformation vector \param[in] trans_cloud transformed point cloud \param[in] p the
+   * current transform vector \param[in] compute_hessian flag to calculate hessian, unnecessary for
+   * step calculation.
    */
-  double computeDerivatives(Eigen::Matrix<double, 6, 1> &score_gradient, Eigen::Matrix<double, 6, 6> &hessian, PointCloudSource &trans_cloud, Eigen::Matrix<double, 6, 1> &p, bool compute_hessian = true);
+  double computeDerivatives(
+    Eigen::Matrix<double, 6, 1> & score_gradient, Eigen::Matrix<double, 6, 6> & hessian,
+    PointCloudSource & trans_cloud, Eigen::Matrix<double, 6, 1> & p, bool compute_hessian = true);
 
-  /** \brief Compute individual point contributions to derivatives of probability function w.r.t. the transformation vector.
-   * \note Equation 6.10, 6.12 and 6.13 [Magnusson 2009].
-   * \param[in,out] score_gradient the gradient vector of the probability function w.r.t. the transformation vector
-   * \param[in,out] hessian the hessian matrix of the probability function w.r.t. the transformation vector
-   * \param[in] x_trans transformed point minus mean of occupied covariance voxel
-   * \param[in] c_inv covariance of occupied covariance voxel
-   * \param[in] compute_hessian flag to calculate hessian, unnecessary for step calculation.
+  /** \brief Compute individual point contributions to derivatives of probability function w.r.t.
+   * the transformation vector. \note Equation 6.10, 6.12 and 6.13 [Magnusson 2009]. \param[in,out]
+   * score_gradient the gradient vector of the probability function w.r.t. the transformation vector
+   * \param[in,out] hessian the hessian matrix of the probability function w.r.t. the transformation
+   * vector \param[in] x_trans transformed point minus mean of occupied covariance voxel \param[in]
+   * c_inv covariance of occupied covariance voxel \param[in] compute_hessian flag to calculate
+   * hessian, unnecessary for step calculation.
    */
-  double updateDerivatives(Eigen::Matrix<double, 6, 1> &score_gradient, Eigen::Matrix<double, 6, 6> &hessian, const Eigen::Matrix<float, 4, 6> &point_gradient_, const Eigen::Matrix<float, 24, 6> &point_hessian_, const Eigen::Vector3d &x_trans, const Eigen::Matrix3d &c_inv, bool compute_hessian = true) const;
+  double updateDerivatives(
+    Eigen::Matrix<double, 6, 1> & score_gradient, Eigen::Matrix<double, 6, 6> & hessian,
+    const Eigen::Matrix<float, 4, 6> & point_gradient_,
+    const Eigen::Matrix<float, 24, 6> & point_hessian_, const Eigen::Vector3d & x_trans,
+    const Eigen::Matrix3d & c_inv, bool compute_hessian = true) const;
 
   /** \brief Precompute angular components of derivatives.
    * \note Equation 6.19 and 6.21 [Magnusson 2009].
    * \param[in] p the current transform vector
    * \param[in] compute_hessian flag to calculate hessian, unnecessary for step calculation.
    */
-  void computeAngleDerivatives(Eigen::Matrix<double, 6, 1> &p, bool compute_hessian = true);
+  void computeAngleDerivatives(Eigen::Matrix<double, 6, 1> & p, bool compute_hessian = true);
 
   /** \brief Compute point derivatives.
    * \note Equation 6.18-21 [Magnusson 2009].
    * \param[in] x point from the input cloud
    * \param[in] compute_hessian flag to calculate hessian, unnecessary for step calculation.
    */
-  void computePointDerivatives(Eigen::Vector3d &x, Eigen::Matrix<double, 3, 6> &point_gradient_, Eigen::Matrix<double, 18, 6> &point_hessian_, bool compute_hessian = true) const;
+  void computePointDerivatives(
+    Eigen::Vector3d & x, Eigen::Matrix<double, 3, 6> & point_gradient_,
+    Eigen::Matrix<double, 18, 6> & point_hessian_, bool compute_hessian = true) const;
 
-  void computePointDerivatives(Eigen::Vector3d &x, Eigen::Matrix<float, 4, 6> &point_gradient_, Eigen::Matrix<float, 24, 6> &point_hessian_, bool compute_hessian = true) const;
+  void computePointDerivatives(
+    Eigen::Vector3d & x, Eigen::Matrix<float, 4, 6> & point_gradient_,
+    Eigen::Matrix<float, 24, 6> & point_hessian_, bool compute_hessian = true) const;
 
   /** \brief Compute hessian of probability function w.r.t. the transformation vector.
    * \note Equation 6.13 [Magnusson 2009].
-   * \param[out] hessian the hessian matrix of the probability function w.r.t. the transformation vector
-   * \param[in] trans_cloud transformed point cloud
-   * \param[in] p the current transform vector
+   * \param[out] hessian the hessian matrix of the probability function w.r.t. the transformation
+   * vector \param[in] trans_cloud transformed point cloud \param[in] p the current transform vector
    */
-  void computeHessian(Eigen::Matrix<double, 6, 6> &hessian, PointCloudSource &trans_cloud, Eigen::Matrix<double, 6, 1> &p);
+  void computeHessian(
+    Eigen::Matrix<double, 6, 6> & hessian, PointCloudSource & trans_cloud,
+    Eigen::Matrix<double, 6, 1> & p);
 
-  /** \brief Compute individual point contributions to hessian of probability function w.r.t. the transformation vector.
-   * \note Equation 6.13 [Magnusson 2009].
-   * \param[in,out] hessian the hessian matrix of the probability function w.r.t. the transformation vector
-   * \param[in] x_trans transformed point minus mean of occupied covariance voxel
-   * \param[in] c_inv covariance of occupied covariance voxel
+  /** \brief Compute individual point contributions to hessian of probability function w.r.t. the
+   * transformation vector. \note Equation 6.13 [Magnusson 2009]. \param[in,out] hessian the hessian
+   * matrix of the probability function w.r.t. the transformation vector \param[in] x_trans
+   * transformed point minus mean of occupied covariance voxel \param[in] c_inv covariance of
+   * occupied covariance voxel
    */
-  void updateHessian(Eigen::Matrix<double, 6, 6> &hessian, const Eigen::Matrix<double, 3, 6> &point_gradient_, const Eigen::Matrix<double, 18, 6> &point_hessian_, const Eigen::Vector3d &x_trans, const Eigen::Matrix3d &c_inv) const;
+  void updateHessian(
+    Eigen::Matrix<double, 6, 6> & hessian, const Eigen::Matrix<double, 3, 6> & point_gradient_,
+    const Eigen::Matrix<double, 18, 6> & point_hessian_, const Eigen::Vector3d & x_trans,
+    const Eigen::Matrix3d & c_inv) const;
 
-  /** \brief Compute line search step length and update transform and probability derivatives using More-Thuente method.
-   * \note Search Algorithm [More, Thuente 1994]
-   * \param[in] x initial transformation vector, \f$ x \f$ in Equation 1.3 (Moore, Thuente 1994) and \f$ \vec{p} \f$ in Algorithm 2 [Magnusson 2009]
-   * \param[in] step_dir descent direction, \f$ p \f$ in Equation 1.3 (Moore, Thuente 1994) and \f$ \delta \vec{p} \f$ normalized in Algorithm 2 [Magnusson 2009]
-   * \param[in] step_init initial step length estimate, \f$ \alpha_0 \f$ in Moore-Thuente (1994) and the normal of \f$ \delta \vec{p} \f$ in Algorithm 2 [Magnusson 2009]
-   * \param[in] step_max maximum step length, \f$ \alpha_max \f$ in Moore-Thuente (1994)
-   * \param[in] step_min minimum step length, \f$ \alpha_min \f$ in Moore-Thuente (1994)
-   * \param[out] score final score function value, \f$ f(x + \alpha p) \f$ in Equation 1.3 (Moore, Thuente 1994) and \f$ score \f$ in Algorithm 2 [Magnusson 2009]
-   * \param[in,out] score_gradient gradient of score function w.r.t. transformation vector, \f$ f'(x + \alpha p) \f$ in Moore-Thuente (1994) and \f$ \vec{g} \f$ in Algorithm 2 [Magnusson 2009]
-   * \param[out] hessian hessian of score function w.r.t. transformation vector, \f$ f''(x + \alpha p) \f$ in Moore-Thuente (1994) and \f$ H \f$ in Algorithm 2 [Magnusson 2009]
-   * \param[in,out] trans_cloud transformed point cloud, \f$ X \f$ transformed by \f$ T(\vec{p},\vec{x}) \f$ in Algorithm 2 [Magnusson 2009]
-   * \return final step length
+  /** \brief Compute line search step length and update transform and probability derivatives using
+   * More-Thuente method. \note Search Algorithm [More, Thuente 1994] \param[in] x initial
+   * transformation vector, \f$ x \f$ in Equation 1.3 (Moore, Thuente 1994) and \f$ \vec{p} \f$ in
+   * Algorithm 2 [Magnusson 2009] \param[in] step_dir descent direction, \f$ p \f$ in Equation 1.3
+   * (Moore, Thuente 1994) and \f$ \delta \vec{p} \f$ normalized in Algorithm 2 [Magnusson 2009]
+   * \param[in] step_init initial step length estimate, \f$ \alpha_0 \f$ in Moore-Thuente (1994) and
+   * the normal of \f$ \delta \vec{p} \f$ in Algorithm 2 [Magnusson 2009] \param[in] step_max
+   * maximum step length, \f$ \alpha_max \f$ in Moore-Thuente (1994) \param[in] step_min minimum
+   * step length, \f$ \alpha_min \f$ in Moore-Thuente (1994) \param[out] score final score function
+   * value, \f$ f(x + \alpha p) \f$ in Equation 1.3 (Moore, Thuente 1994) and \f$ score \f$ in
+   * Algorithm 2 [Magnusson 2009] \param[in,out] score_gradient gradient of score function w.r.t.
+   * transformation vector, \f$ f'(x + \alpha p) \f$ in Moore-Thuente (1994) and \f$ \vec{g} \f$ in
+   * Algorithm 2 [Magnusson 2009] \param[out] hessian hessian of score function w.r.t.
+   * transformation vector, \f$ f''(x + \alpha p) \f$ in Moore-Thuente (1994) and \f$ H \f$ in
+   * Algorithm 2 [Magnusson 2009] \param[in,out] trans_cloud transformed point cloud, \f$ X \f$
+   * transformed by \f$ T(\vec{p},\vec{x}) \f$ in Algorithm 2 [Magnusson 2009] \return final step
+   * length
    */
-  double computeStepLengthMT(const Eigen::Matrix<double, 6, 1> &x, Eigen::Matrix<double, 6, 1> &step_dir, double step_init, double step_max, double step_min, double &score, Eigen::Matrix<double, 6, 1> &score_gradient, Eigen::Matrix<double, 6, 6> &hessian, PointCloudSource &trans_cloud);
+  double computeStepLengthMT(
+    const Eigen::Matrix<double, 6, 1> & x, Eigen::Matrix<double, 6, 1> & step_dir, double step_init,
+    double step_max, double step_min, double & score, Eigen::Matrix<double, 6, 1> & score_gradient,
+    Eigen::Matrix<double, 6, 6> & hessian, PointCloudSource & trans_cloud);
 
-  /** \brief Update interval of possible step lengths for More-Thuente method, \f$ I \f$ in More-Thuente (1994)
-   * \note Updating Algorithm until some value satisfies \f$ \psi(\alpha_k) \leq 0 \f$ and \f$ \phi'(\alpha_k) \geq 0 \f$
-   * and Modified Updating Algorithm from then on [More, Thuente 1994].
-   * \param[in,out] a_l first endpoint of interval \f$ I \f$, \f$ \alpha_l \f$ in Moore-Thuente (1994)
-   * \param[in,out] f_l value at first endpoint, \f$ f_l \f$ in Moore-Thuente (1994), \f$ \psi(\alpha_l) \f$ for Update Algorithm and \f$ \phi(\alpha_l) \f$ for Modified Update Algorithm
-   * \param[in,out] g_l derivative at first endpoint, \f$ g_l \f$ in Moore-Thuente (1994), \f$ \psi'(\alpha_l) \f$ for Update Algorithm and \f$ \phi'(\alpha_l) \f$ for Modified Update Algorithm
-   * \param[in,out] a_u second endpoint of interval \f$ I \f$, \f$ \alpha_u \f$ in Moore-Thuente (1994)
-   * \param[in,out] f_u value at second endpoint, \f$ f_u \f$ in Moore-Thuente (1994), \f$ \psi(\alpha_u) \f$ for Update Algorithm and \f$ \phi(\alpha_u) \f$ for Modified Update Algorithm
-   * \param[in,out] g_u derivative at second endpoint, \f$ g_u \f$ in Moore-Thuente (1994), \f$ \psi'(\alpha_u) \f$ for Update Algorithm and \f$ \phi'(\alpha_u) \f$ for Modified Update Algorithm
-   * \param[in] a_t trial value, \f$ \alpha_t \f$ in Moore-Thuente (1994)
-   * \param[in] f_t value at trial value, \f$ f_t \f$ in Moore-Thuente (1994), \f$ \psi(\alpha_t) \f$ for Update Algorithm and \f$ \phi(\alpha_t) \f$ for Modified Update Algorithm
-   * \param[in] g_t derivative at trial value, \f$ g_t \f$ in Moore-Thuente (1994), \f$ \psi'(\alpha_t) \f$ for Update Algorithm and \f$ \phi'(\alpha_t) \f$ for Modified Update Algorithm
-   * \return if interval converges
+  /** \brief Update interval of possible step lengths for More-Thuente method, \f$ I \f$ in
+   * More-Thuente (1994) \note Updating Algorithm until some value satisfies \f$ \psi(\alpha_k) \leq
+   * 0 \f$ and \f$ \phi'(\alpha_k) \geq 0 \f$ and Modified Updating Algorithm from then on [More,
+   * Thuente 1994]. \param[in,out] a_l first endpoint of interval \f$ I \f$, \f$ \alpha_l \f$ in
+   * Moore-Thuente (1994) \param[in,out] f_l value at first endpoint, \f$ f_l \f$ in Moore-Thuente
+   * (1994), \f$ \psi(\alpha_l) \f$ for Update Algorithm and \f$ \phi(\alpha_l) \f$ for Modified
+   * Update Algorithm \param[in,out] g_l derivative at first endpoint, \f$ g_l \f$ in Moore-Thuente
+   * (1994), \f$ \psi'(\alpha_l) \f$ for Update Algorithm and \f$ \phi'(\alpha_l) \f$ for Modified
+   * Update Algorithm \param[in,out] a_u second endpoint of interval \f$ I \f$, \f$ \alpha_u \f$ in
+   * Moore-Thuente (1994) \param[in,out] f_u value at second endpoint, \f$ f_u \f$ in Moore-Thuente
+   * (1994), \f$ \psi(\alpha_u) \f$ for Update Algorithm and \f$ \phi(\alpha_u) \f$ for Modified
+   * Update Algorithm \param[in,out] g_u derivative at second endpoint, \f$ g_u \f$ in Moore-Thuente
+   * (1994), \f$ \psi'(\alpha_u) \f$ for Update Algorithm and \f$ \phi'(\alpha_u) \f$ for Modified
+   * Update Algorithm \param[in] a_t trial value, \f$ \alpha_t \f$ in Moore-Thuente (1994)
+   * \param[in] f_t value at trial value, \f$ f_t \f$ in Moore-Thuente (1994), \f$ \psi(\alpha_t)
+   * \f$ for Update Algorithm and \f$ \phi(\alpha_t) \f$ for Modified Update Algorithm \param[in]
+   * g_t derivative at trial value, \f$ g_t \f$ in Moore-Thuente (1994), \f$ \psi'(\alpha_t) \f$ for
+   * Update Algorithm and \f$ \phi'(\alpha_t) \f$ for Modified Update Algorithm \return if interval
+   * converges
    */
-  bool updateIntervalMT(double &a_l, double &f_l, double &g_l, double &a_u, double &f_u, double &g_u, double a_t, double f_t, double g_t);
+  bool updateIntervalMT(
+    double & a_l, double & f_l, double & g_l, double & a_u, double & f_u, double & g_u, double a_t,
+    double f_t, double g_t);
 
   /** \brief Select new trial value for More-Thuente method.
-   * \note Trial Value Selection [More, Thuente 1994], \f$ \psi(\alpha_k) \f$ is used for \f$ f_k \f$ and \f$ g_k \f$
-   * until some value satisfies the test \f$ \psi(\alpha_k) \leq 0 \f$ and \f$ \phi'(\alpha_k) \geq 0 \f$
-   * then \f$ \phi(\alpha_k) \f$ is used from then on.
-   * \note Interpolation Minimizer equations from Optimization Theory and Methods: Nonlinear Programming By Wenyu Sun, Ya-xiang Yuan (89-100).
-   * \param[in] a_l first endpoint of interval \f$ I \f$, \f$ \alpha_l \f$ in Moore-Thuente (1994)
-   * \param[in] f_l value at first endpoint, \f$ f_l \f$ in Moore-Thuente (1994)
-   * \param[in] g_l derivative at first endpoint, \f$ g_l \f$ in Moore-Thuente (1994)
-   * \param[in] a_u second endpoint of interval \f$ I \f$, \f$ \alpha_u \f$ in Moore-Thuente (1994)
-   * \param[in] f_u value at second endpoint, \f$ f_u \f$ in Moore-Thuente (1994)
-   * \param[in] g_u derivative at second endpoint, \f$ g_u \f$ in Moore-Thuente (1994)
-   * \param[in] a_t previous trial value, \f$ \alpha_t \f$ in Moore-Thuente (1994)
-   * \param[in] f_t value at previous trial value, \f$ f_t \f$ in Moore-Thuente (1994)
-   * \param[in] g_t derivative at previous trial value, \f$ g_t \f$ in Moore-Thuente (1994)
-   * \return new trial value
+   * \note Trial Value Selection [More, Thuente 1994], \f$ \psi(\alpha_k) \f$ is used for \f$ f_k
+   * \f$ and \f$ g_k \f$ until some value satisfies the test \f$ \psi(\alpha_k) \leq 0 \f$ and \f$
+   * \phi'(\alpha_k) \geq 0 \f$ then \f$ \phi(\alpha_k) \f$ is used from then on. \note
+   * Interpolation Minimizer equations from Optimization Theory and Methods: Nonlinear Programming
+   * By Wenyu Sun, Ya-xiang Yuan (89-100). \param[in] a_l first endpoint of interval \f$ I \f$, \f$
+   * \alpha_l \f$ in Moore-Thuente (1994) \param[in] f_l value at first endpoint, \f$ f_l \f$ in
+   * Moore-Thuente (1994) \param[in] g_l derivative at first endpoint, \f$ g_l \f$ in Moore-Thuente
+   * (1994) \param[in] a_u second endpoint of interval \f$ I \f$, \f$ \alpha_u \f$ in Moore-Thuente
+   * (1994) \param[in] f_u value at second endpoint, \f$ f_u \f$ in Moore-Thuente (1994) \param[in]
+   * g_u derivative at second endpoint, \f$ g_u \f$ in Moore-Thuente (1994) \param[in] a_t previous
+   * trial value, \f$ \alpha_t \f$ in Moore-Thuente (1994) \param[in] f_t value at previous trial
+   * value, \f$ f_t \f$ in Moore-Thuente (1994) \param[in] g_t derivative at previous trial value,
+   * \f$ g_t \f$ in Moore-Thuente (1994) \return new trial value
    */
-  double trialValueSelectionMT(double a_l, double f_l, double g_l, double a_u, double f_u, double g_u, double a_t, double f_t, double g_t);
+  double trialValueSelectionMT(
+    double a_l, double f_l, double g_l, double a_u, double f_u, double g_u, double a_t, double f_t,
+    double g_t);
 
   /** \brief Auxiliary function used to determine endpoints of More-Thuente interval.
    * \note \f$ \psi(\alpha) \f$ in Equation 1.6 (Moore, Thuente 1994)
@@ -427,7 +441,9 @@ protected:
    * \param[in] mu the step length, constant \f$ \mu \f$ in Equation 1.1 [More, Thuente 1994]
    * \return sufficient decrease value
    */
-  inline double auxiliaryFunction_PsiMT(double a, double f_a, double f_0, double g_0, double mu = 1.e-4) {
+  inline double auxiliaryFunction_PsiMT(
+    double a, double f_a, double f_0, double g_0, double mu = 1.e-4)
+  {
     return (f_a - f_0 - mu * g_0 * a);
   }
 
@@ -438,7 +454,8 @@ protected:
    * \param[in] mu the step length, constant \f$ \mu \f$ in Equation 1.1 [More, Thuente 1994]
    * \return sufficient decrease derivative
    */
-  inline double auxiliaryFunction_dPsiMT(double g_a, double g_0, double mu = 1.e-4) {
+  inline double auxiliaryFunction_dPsiMT(double g_a, double g_0, double mu = 1.e-4)
+  {
     return (g_a - mu * g_0);
   }
 
@@ -447,18 +464,22 @@ protected:
 
   // double fitness_epsilon_;
 
-  /** \brief The ratio of outliers of points w.r.t. a normal distribution, Equation 6.7 [Magnusson 2009]. */
+  /** \brief The ratio of outliers of points w.r.t. a normal distribution, Equation 6.7 [Magnusson
+   * 2009]. */
   double outlier_ratio_;
 
-  /** \brief The normalization constants used fit the point distribution to a normal distribution, Equation 6.8 [Magnusson 2009]. */
+  /** \brief The normalization constants used fit the point distribution to a normal distribution,
+   * Equation 6.8 [Magnusson 2009]. */
   double gauss_d1_, gauss_d2_, gauss_d3_;
 
-  /** \brief The probability score of the transform applied to the input cloud, Equation 6.9 and 6.10 [Magnusson 2009]. */
+  /** \brief The probability score of the transform applied to the input cloud, Equation 6.9
+   * and 6.10 [Magnusson 2009]. */
   double trans_probability_;
 
   /** \brief Precomputed Angular Gradient
    *
-   * The precomputed angular derivatives for the jacobian of a transformation vector, Equation 6.19 [Magnusson 2009].
+   * The precomputed angular derivatives for the jacobian of a transformation vector, Equation 6.19
+   * [Magnusson 2009].
    */
   Eigen::Vector3d j_ang_a_, j_ang_b_, j_ang_c_, j_ang_d_, j_ang_e_, j_ang_f_, j_ang_g_, j_ang_h_;
 
@@ -466,16 +487,20 @@ protected:
 
   /** \brief Precomputed Angular Hessian
    *
-   * The precomputed angular derivatives for the hessian of a transformation vector, Equation 6.19 [Magnusson 2009].
+   * The precomputed angular derivatives for the hessian of a transformation vector, Equation 6.19
+   * [Magnusson 2009].
    */
-  Eigen::Vector3d h_ang_a2_, h_ang_a3_, h_ang_b2_, h_ang_b3_, h_ang_c2_, h_ang_c3_, h_ang_d1_, h_ang_d2_, h_ang_d3_, h_ang_e1_, h_ang_e2_, h_ang_e3_, h_ang_f1_, h_ang_f2_, h_ang_f3_;
+  Eigen::Vector3d h_ang_a2_, h_ang_a3_, h_ang_b2_, h_ang_b3_, h_ang_c2_, h_ang_c3_, h_ang_d1_,
+    h_ang_d2_, h_ang_d3_, h_ang_e1_, h_ang_e2_, h_ang_e3_, h_ang_f1_, h_ang_f2_, h_ang_f3_;
 
   Eigen::Matrix<float, 16, 4> h_ang;
 
-  /** \brief The first order derivative of the transformation of a point w.r.t. the transform vector, \f$ J_E \f$ in Equation 6.18 [Magnusson 2009]. */
+  /** \brief The first order derivative of the transformation of a point w.r.t. the transform
+   * vector, \f$ J_E \f$ in Equation 6.18 [Magnusson 2009]. */
   //      Eigen::Matrix<double, 3, 6> point_gradient_;
 
-  /** \brief The second order derivative of the transformation of a point w.r.t. the transform vector, \f$ H_E \f$ in Equation 6.20 [Magnusson 2009]. */
+  /** \brief The second order derivative of the transformation of a point w.r.t. the transform
+   * vector, \f$ H_E \f$ in Equation 6.20 [Magnusson 2009]. */
   //      Eigen::Matrix<double, 18, 6> point_hessian_;
 
   Eigen::Matrix<double, 6, 6> hessian_;

--- a/include/pclomp/ndt_omp_impl.hpp
+++ b/include/pclomp/ndt_omp_impl.hpp
@@ -43,9 +43,39 @@
 #define PCL_REGISTRATION_NDT_OMP_IMPL_H_
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget>
+template <typename PointSource, typename PointTarget>
 pclomp::NormalDistributionsTransform<PointSource, PointTarget>::NormalDistributionsTransform()
-    : target_cells_(), outlier_ratio_(0.55), gauss_d1_(), gauss_d2_(), gauss_d3_(), trans_probability_(), regularization_pose_(boost::none), j_ang_a_(), j_ang_b_(), j_ang_c_(), j_ang_d_(), j_ang_e_(), j_ang_f_(), j_ang_g_(), j_ang_h_(), h_ang_a2_(), h_ang_a3_(), h_ang_b2_(), h_ang_b3_(), h_ang_c2_(), h_ang_c3_(), h_ang_d1_(), h_ang_d2_(), h_ang_d3_(), h_ang_e1_(), h_ang_e2_(), h_ang_e3_(), h_ang_f1_(), h_ang_f2_(), h_ang_f3_() {
+: target_cells_(),
+  outlier_ratio_(0.55),
+  gauss_d1_(),
+  gauss_d2_(),
+  gauss_d3_(),
+  trans_probability_(),
+  regularization_pose_(boost::none),
+  j_ang_a_(),
+  j_ang_b_(),
+  j_ang_c_(),
+  j_ang_d_(),
+  j_ang_e_(),
+  j_ang_f_(),
+  j_ang_g_(),
+  j_ang_h_(),
+  h_ang_a2_(),
+  h_ang_a3_(),
+  h_ang_b2_(),
+  h_ang_b3_(),
+  h_ang_c2_(),
+  h_ang_c3_(),
+  h_ang_d1_(),
+  h_ang_d2_(),
+  h_ang_d3_(),
+  h_ang_e1_(),
+  h_ang_e2_(),
+  h_ang_e3_(),
+  h_ang_f1_(),
+  h_ang_f2_(),
+  h_ang_f3_()
+{
   reg_name_ = "NormalDistributionsTransform";
 
   params_.trans_epsilon = 0.1;
@@ -68,8 +98,10 @@ pclomp::NormalDistributionsTransform<PointSource, PointTarget>::NormalDistributi
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget>
-void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeTransformation(PointCloudSource &output, const Eigen::Matrix4f &guess) {
+template <typename PointSource, typename PointTarget>
+void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeTransformation(
+  PointCloudSource & output, const Eigen::Matrix4f & guess)
+{
   nr_iterations_ = 0;
   converged_ = false;
 
@@ -82,7 +114,7 @@ void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeTran
   gauss_d1_ = -log(gauss_c1 + gauss_c2) - gauss_d3_;
   gauss_d2_ = -2 * log((-log(gauss_c1 * exp(-0.5) + gauss_c2) - gauss_d3_) / gauss_d1_);
 
-  if(guess != Eigen::Matrix4f::Identity()) {
+  if (guess != Eigen::Matrix4f::Identity()) {
     // Initialise final transformation to the guessed one
     final_transformation_ = guess;
     // Apply guessed transformation prior to search for neighbours
@@ -98,36 +130,39 @@ void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeTran
   Eigen::Matrix<double, 6, 1> p, delta_p, score_gradient;
   Eigen::Vector3f init_translation = eig_transformation.translation();
   Eigen::Vector3f init_rotation = eig_transformation.rotation().eulerAngles(0, 1, 2);
-  p << init_translation(0), init_translation(1), init_translation(2), init_rotation(0), init_rotation(1), init_rotation(2);
+  p << init_translation(0), init_translation(1), init_translation(2), init_rotation(0),
+    init_rotation(1), init_rotation(2);
 
   Eigen::Matrix<double, 6, 6> hessian;
 
   double score = 0;
   double delta_p_norm;
 
-  if(regularization_pose_) {
+  if (regularization_pose_) {
     Eigen::Transform<float, 3, Eigen::Affine, Eigen::ColMajor> regularization_pose_transformation;
     regularization_pose_transformation.matrix() = regularization_pose_.get();
     regularization_pose_translation_ = regularization_pose_transformation.translation();
   }
 
-  // Calculate derivatives of initial transform vector, subsequent derivative calculations are done in the step length determination.
+  // Calculate derivatives of initial transform vector, subsequent derivative calculations are done
+  // in the step length determination.
   score = computeDerivatives(score_gradient, hessian, output, p);
 
-  while(!converged_) {
+  while (!converged_) {
     // Store previous transformation
     previous_transformation_ = transformation_;
 
     // Solve for decent direction using newton method, line 23 in Algorithm 2 [Magnusson 2009]
-    Eigen::JacobiSVD<Eigen::Matrix<double, 6, 6>> sv(hessian, Eigen::ComputeFullU | Eigen::ComputeFullV);
+    Eigen::JacobiSVD<Eigen::Matrix<double, 6, 6>> sv(
+      hessian, Eigen::ComputeFullU | Eigen::ComputeFullV);
     // Negative for maximization as opposed to minimization
     delta_p = sv.solve(-score_gradient);
 
     // Calculate step length with guaranteed sufficient decrease [More, Thuente 1994]
     delta_p_norm = delta_p.norm();
 
-    if(delta_p_norm == 0 || delta_p_norm != delta_p_norm) {
-      if(input_->points.empty()) {
+    if (delta_p_norm == 0 || delta_p_norm != delta_p_norm) {
+      if (input_->points.empty()) {
         trans_probability_ = 0.0f;
       } else {
         trans_probability_ = score / static_cast<double>(input_->points.size());
@@ -138,29 +173,40 @@ void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeTran
     }
 
     delta_p.normalize();
-    delta_p_norm = computeStepLengthMT(p, delta_p, delta_p_norm, params_.step_size, params_.trans_epsilon / 2, score, score_gradient, hessian, output);
+    delta_p_norm = computeStepLengthMT(
+      p, delta_p, delta_p_norm, params_.step_size, params_.trans_epsilon / 2, score, score_gradient,
+      hessian, output);
     delta_p *= delta_p_norm;
 
-    transformation_ = (Eigen::Translation<float, 3>(static_cast<float>(delta_p(0)), static_cast<float>(delta_p(1)), static_cast<float>(delta_p(2))) * Eigen::AngleAxis<float>(static_cast<float>(delta_p(3)), Eigen::Vector3f::UnitX()) * Eigen::AngleAxis<float>(static_cast<float>(delta_p(4)), Eigen::Vector3f::UnitY()) * Eigen::AngleAxis<float>(static_cast<float>(delta_p(5)), Eigen::Vector3f::UnitZ()))
-                          .matrix();
+    transformation_ =
+      (Eigen::Translation<float, 3>(
+         static_cast<float>(delta_p(0)), static_cast<float>(delta_p(1)),
+         static_cast<float>(delta_p(2))) *
+       Eigen::AngleAxis<float>(static_cast<float>(delta_p(3)), Eigen::Vector3f::UnitX()) *
+       Eigen::AngleAxis<float>(static_cast<float>(delta_p(4)), Eigen::Vector3f::UnitY()) *
+       Eigen::AngleAxis<float>(static_cast<float>(delta_p(5)), Eigen::Vector3f::UnitZ()))
+        .matrix();
 
     transformation_array_.push_back(final_transformation_);
 
     p = p + delta_p;
 
     // Update Visualizer (untested)
-    if(update_visualizer_ != 0) update_visualizer_(output, std::vector<int>(), *target_, std::vector<int>());
+    if (update_visualizer_ != 0)
+      update_visualizer_(output, std::vector<int>(), *target_, std::vector<int>());
 
-    if(nr_iterations_ > params_.max_iterations || (nr_iterations_ && (std::fabs(delta_p_norm) < params_.trans_epsilon))) {
+    if (
+      nr_iterations_ > params_.max_iterations ||
+      (nr_iterations_ && (std::fabs(delta_p_norm) < params_.trans_epsilon))) {
       converged_ = true;
     }
 
     nr_iterations_++;
   }
 
-  // Store transformation probability. The relative differences within each scan registration are accurate
-  // but the normalization constants need to be modified for it to be globally accurate
-  if(input_->points.empty()) {
+  // Store transformation probability. The relative differences within each scan registration are
+  // accurate but the normalization constants need to be modified for it to be globally accurate
+  if (input_->points.empty()) {
     trans_probability_ = 0.0f;
   } else {
     trans_probability_ = score / static_cast<double>(input_->points.size());
@@ -170,17 +216,22 @@ void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeTran
 }
 
 #ifndef _OPENMP
-int omp_get_max_threads() {
+int omp_get_max_threads()
+{
   return 1;
 }
-int omp_get_thread_num() {
+int omp_get_thread_num()
+{
   return 0;
 }
 #endif
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget>
-double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeDerivatives(Eigen::Matrix<double, 6, 1> &score_gradient, Eigen::Matrix<double, 6, 6> &hessian, PointCloudSource &trans_cloud, Eigen::Matrix<double, 6, 1> &p, bool compute_hessian) {
+template <typename PointSource, typename PointTarget>
+double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeDerivatives(
+  Eigen::Matrix<double, 6, 1> & score_gradient, Eigen::Matrix<double, 6, 6> & hessian,
+  PointCloudSource & trans_cloud, Eigen::Matrix<double, 6, 1> & p, bool compute_hessian)
+{
   score_gradient.setZero();
   hessian.setZero();
   double score = 0;
@@ -191,10 +242,12 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeDe
   std::vector<double> scores(input_->points.size());
   std::vector<double> nearest_voxel_scores(input_->points.size());
   std::vector<size_t> found_neigborhood_voxel_nums(input_->points.size());
-  std::vector<Eigen::Matrix<double, 6, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 6, 1>>> score_gradients(input_->points.size());
-  std::vector<Eigen::Matrix<double, 6, 6>, Eigen::aligned_allocator<Eigen::Matrix<double, 6, 6>>> hessians(input_->points.size());
+  std::vector<Eigen::Matrix<double, 6, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 6, 1>>>
+    score_gradients(input_->points.size());
+  std::vector<Eigen::Matrix<double, 6, 6>, Eigen::aligned_allocator<Eigen::Matrix<double, 6, 6>>>
+    hessians(input_->points.size());
   std::vector<int> neighborhood_counts(input_->points.size());
-  for(std::size_t i = 0; i < input_->points.size(); i++) {
+  for (std::size_t i = 0; i < input_->points.size(); i++) {
     scores[i] = 0;
     nearest_voxel_scores[i] = 0;
     found_neigborhood_voxel_nums[i] = 0;
@@ -211,7 +264,7 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeDe
 
   // Update gradient and hessian for each point, line 17 in Algorithm 2 [Magnusson 2009]
 #pragma omp parallel for num_threads(params_.num_threads) schedule(guided, 8)
-  for(std::size_t idx = 0; idx < input_->points.size(); idx++) {
+  for (std::size_t idx = 0; idx < input_->points.size(); idx++) {
     int thread_n = omp_get_thread_num();
 
     // Original Point and Transformed Point
@@ -232,11 +285,11 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeDe
 
     x_trans_pt = trans_cloud.points[idx];
 
-    auto &neighborhood = neighborhoods[thread_n];
-    auto &distances = distancess[thread_n];
+    auto & neighborhood = neighborhoods[thread_n];
+    auto & distances = distancess[thread_n];
 
     // Find neighbors (Radius search has been experimentally faster than direct neighbor checking.
-    switch(params_.search_method) {
+    switch (params_.search_method) {
       case KDTREE:
         target_cells_.radiusSearch(x_trans_pt, params_.resolution, neighborhood, distances);
         break;
@@ -258,7 +311,9 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeDe
     Eigen::Matrix<double, 6, 6> hessian_pt = Eigen::Matrix<double, 6, 6>::Zero();
     int neighborhood_count = 0;
 
-    for(typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it = neighborhood.begin(); neighborhood_it != neighborhood.end(); neighborhood_it++) {
+    for (typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it =
+           neighborhood.begin();
+         neighborhood_it != neighborhood.end(); neighborhood_it++) {
       cell = *neighborhood_it;
       x_pt = input_->points[idx];
       x = Eigen::Vector3d(x_pt.x, x_pt.y, x_pt.z);
@@ -270,18 +325,22 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeDe
       // Uses precomputed covariance for speed.
       c_inv = cell->getInverseCov();
 
-      // Compute derivative of transform function w.r.t. transform vector, J_E and H_E in Equations 6.18 and 6.20 [Magnusson 2009]
+      // Compute derivative of transform function w.r.t. transform vector, J_E and H_E in
+      // Equations 6.18 and 6.20 [Magnusson 2009]
       computePointDerivatives(x, point_gradient_, point_hessian_);
-      // Update score, gradient and hessian, lines 19-21 in Algorithm 2, according to Equations 6.10, 6.12 and 6.13, respectively [Magnusson 2009]
-      double score_pt = updateDerivatives(score_gradient_pt, hessian_pt, point_gradient_, point_hessian_, x_trans, c_inv, compute_hessian);
+      // Update score, gradient and hessian, lines 19-21 in Algorithm 2, according to
+      // Equations 6.10, 6.12 and 6.13, respectively [Magnusson 2009]
+      double score_pt = updateDerivatives(
+        score_gradient_pt, hessian_pt, point_gradient_, point_hessian_, x_trans, c_inv,
+        compute_hessian);
       neighborhood_count++;
       sum_score_pt += score_pt;
-      if(score_pt > nearest_voxel_score_pt) {
+      if (score_pt > nearest_voxel_score_pt) {
         nearest_voxel_score_pt = score_pt;
       }
     }
 
-    if(!neighborhood.empty()) {
+    if (!neighborhood.empty()) {
       ++found_neigborhood_voxel_nums[idx];
     }
 
@@ -293,7 +352,7 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeDe
   }
 
   // Ensure that the result is invariant against the summing up order
-  for(std::size_t i = 0; i < input_->points.size(); i++) {
+  for (std::size_t i = 0; i < input_->points.size(); i++) {
     score += scores[i];
     nearest_voxel_score += nearest_voxel_scores[i];
     found_neigborhood_voxel_num += found_neigborhood_voxel_nums[i];
@@ -302,7 +361,7 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeDe
     total_neighborhood_count += neighborhood_counts[i];
   }
 
-  if(regularization_pose_) {
+  if (regularization_pose_) {
     float regularization_score = 0.0f;
     Eigen::Matrix<double, 6, 1> regularization_gradient = Eigen::Matrix<double, 6, 1>::Zero();
     Eigen::Matrix<double, 6, 6> regularization_hessian = Eigen::Matrix<double, 6, 6>::Zero();
@@ -314,14 +373,22 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeDe
     const float longitudinal_distance = dy * sin_yaw + dx * cos_yaw;
     const auto neighborhood_count_weight = static_cast<float>(total_neighborhood_count);
 
-    regularization_score = -params_.regularization_scale_factor * neighborhood_count_weight * longitudinal_distance * longitudinal_distance;
+    regularization_score = -params_.regularization_scale_factor * neighborhood_count_weight *
+                           longitudinal_distance * longitudinal_distance;
 
-    regularization_gradient(0, 0) = params_.regularization_scale_factor * neighborhood_count_weight * 2.0f * cos_yaw * longitudinal_distance;
-    regularization_gradient(1, 0) = params_.regularization_scale_factor * neighborhood_count_weight * 2.0f * sin_yaw * longitudinal_distance;
+    regularization_gradient(0, 0) = params_.regularization_scale_factor *
+                                    neighborhood_count_weight * 2.0f * cos_yaw *
+                                    longitudinal_distance;
+    regularization_gradient(1, 0) = params_.regularization_scale_factor *
+                                    neighborhood_count_weight * 2.0f * sin_yaw *
+                                    longitudinal_distance;
 
-    regularization_hessian(0, 0) = -params_.regularization_scale_factor * neighborhood_count_weight * 2.0f * cos_yaw * cos_yaw;
-    regularization_hessian(0, 1) = -params_.regularization_scale_factor * neighborhood_count_weight * 2.0f * cos_yaw * sin_yaw;
-    regularization_hessian(1, 1) = -params_.regularization_scale_factor * neighborhood_count_weight * 2.0f * sin_yaw * sin_yaw;
+    regularization_hessian(0, 0) =
+      -params_.regularization_scale_factor * neighborhood_count_weight * 2.0f * cos_yaw * cos_yaw;
+    regularization_hessian(0, 1) =
+      -params_.regularization_scale_factor * neighborhood_count_weight * 2.0f * cos_yaw * sin_yaw;
+    regularization_hessian(1, 1) =
+      -params_.regularization_scale_factor * neighborhood_count_weight * 2.0f * sin_yaw * sin_yaw;
     regularization_hessian(1, 0) = regularization_hessian(0, 1);
 
     score += regularization_score;
@@ -329,8 +396,9 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeDe
     hessian += regularization_hessian;
   }
 
-  if(found_neigborhood_voxel_num != 0) {
-    nearest_voxel_transformation_likelihood_ = nearest_voxel_score / static_cast<double>(found_neigborhood_voxel_num);
+  if (found_neigborhood_voxel_num != 0) {
+    nearest_voxel_transformation_likelihood_ =
+      nearest_voxel_score / static_cast<double>(found_neigborhood_voxel_num);
   } else {
     nearest_voxel_transformation_likelihood_ = 0.0;
   }
@@ -339,11 +407,13 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeDe
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget>
-void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeAngleDerivatives(Eigen::Matrix<double, 6, 1> &p, bool compute_hessian) {
+template <typename PointSource, typename PointTarget>
+void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeAngleDerivatives(
+  Eigen::Matrix<double, 6, 1> & p, bool compute_hessian)
+{
   // Simplified math for near 0 angles
   double cx, cy, cz, sx, sy, sz;
-  if(fabs(p(3)) < 10e-5) {
+  if (fabs(p(3)) < 10e-5) {
     // p(3) = 0;
     cx = 1.0;
     sx = 0.0;
@@ -351,7 +421,7 @@ void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeAngl
     cx = cos(p(3));
     sx = sin(p(3));
   }
-  if(fabs(p(4)) < 10e-5) {
+  if (fabs(p(4)) < 10e-5) {
     // p(4) = 0;
     cy = 1.0;
     sy = 0.0;
@@ -360,7 +430,7 @@ void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeAngl
     sy = sin(p(4));
   }
 
-  if(fabs(p(5)) < 10e-5) {
+  if (fabs(p(5)) < 10e-5) {
     // p(5) = 0;
     cz = 1.0;
     sz = 0.0;
@@ -380,17 +450,22 @@ void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeAngl
   j_ang_h_ << (sx * cz + cx * sy * sz), (cx * sy * cz - sx * sz), 0;
 
   j_ang.setZero();
-  j_ang.row(0).noalias() = Eigen::Vector4f((-sx * sz + cx * sy * cz), (-sx * cz - cx * sy * sz), (-cx * cy), 0.0f);
-  j_ang.row(1).noalias() = Eigen::Vector4f((cx * sz + sx * sy * cz), (cx * cz - sx * sy * sz), (-sx * cy), 0.0f);
+  j_ang.row(0).noalias() =
+    Eigen::Vector4f((-sx * sz + cx * sy * cz), (-sx * cz - cx * sy * sz), (-cx * cy), 0.0f);
+  j_ang.row(1).noalias() =
+    Eigen::Vector4f((cx * sz + sx * sy * cz), (cx * cz - sx * sy * sz), (-sx * cy), 0.0f);
   j_ang.row(2).noalias() = Eigen::Vector4f((-sy * cz), sy * sz, cy, 0.0f);
   j_ang.row(3).noalias() = Eigen::Vector4f(sx * cy * cz, (-sx * cy * sz), sx * sy, 0.0f);
   j_ang.row(4).noalias() = Eigen::Vector4f((-cx * cy * cz), cx * cy * sz, (-cx * sy), 0.0f);
   j_ang.row(5).noalias() = Eigen::Vector4f((-cy * sz), (-cy * cz), 0, 0.0f);
-  j_ang.row(6).noalias() = Eigen::Vector4f((cx * cz - sx * sy * sz), (-cx * sz - sx * sy * cz), 0, 0.0f);
-  j_ang.row(7).noalias() = Eigen::Vector4f((sx * cz + cx * sy * sz), (cx * sy * cz - sx * sz), 0, 0.0f);
+  j_ang.row(6).noalias() =
+    Eigen::Vector4f((cx * cz - sx * sy * sz), (-cx * sz - sx * sy * cz), 0, 0.0f);
+  j_ang.row(7).noalias() =
+    Eigen::Vector4f((sx * cz + cx * sy * sz), (cx * sy * cz - sx * sz), 0, 0.0f);
 
-  if(compute_hessian) {
-    // Precomputed angular hessian components. Letters correspond to Equation 6.21 and numbers correspond to row index [Magnusson 2009]
+  if (compute_hessian) {
+    // Precomputed angular hessian components. Letters correspond to Equation 6.21 and numbers
+    // correspond to row index [Magnusson 2009]
     h_ang_a2_ << (-cx * sz - sx * sy * cz), (-cx * cz + sx * sy * sz), sx * cy;
     h_ang_a3_ << (-sx * sz + cx * sy * cz), (-cx * sy * sz - sx * cz), (-cx * cy);
 
@@ -413,36 +488,50 @@ void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeAngl
     h_ang_f3_ << (-sx * sz + cx * sy * cz), (-cx * sy * sz - sx * cz), 0;
 
     h_ang.setZero();
-    h_ang.row(0).noalias() = Eigen::Vector4f((-cx * sz - sx * sy * cz), (-cx * cz + sx * sy * sz), sx * cy, 0.0f);     // a2
-    h_ang.row(1).noalias() = Eigen::Vector4f((-sx * sz + cx * sy * cz), (-cx * sy * sz - sx * cz), (-cx * cy), 0.0f);  // a3
+    h_ang.row(0).noalias() =
+      Eigen::Vector4f((-cx * sz - sx * sy * cz), (-cx * cz + sx * sy * sz), sx * cy, 0.0f);  // a2
+    h_ang.row(1).noalias() = Eigen::Vector4f(
+      (-sx * sz + cx * sy * cz), (-cx * sy * sz - sx * cz), (-cx * cy), 0.0f);  // a3
 
-    h_ang.row(2).noalias() = Eigen::Vector4f((cx * cy * cz), (-cx * cy * sz), (cx * sy), 0.0f);  // b2
-    h_ang.row(3).noalias() = Eigen::Vector4f((sx * cy * cz), (-sx * cy * sz), (sx * sy), 0.0f);  // b3
+    h_ang.row(2).noalias() =
+      Eigen::Vector4f((cx * cy * cz), (-cx * cy * sz), (cx * sy), 0.0f);  // b2
+    h_ang.row(3).noalias() =
+      Eigen::Vector4f((sx * cy * cz), (-sx * cy * sz), (sx * sy), 0.0f);  // b3
 
-    h_ang.row(4).noalias() = Eigen::Vector4f((-sx * cz - cx * sy * sz), (sx * sz - cx * sy * cz), 0, 0.0f);  // c2
-    h_ang.row(5).noalias() = Eigen::Vector4f((cx * cz - sx * sy * sz), (-sx * sy * cz - cx * sz), 0, 0.0f);  // c3
+    h_ang.row(4).noalias() =
+      Eigen::Vector4f((-sx * cz - cx * sy * sz), (sx * sz - cx * sy * cz), 0, 0.0f);  // c2
+    h_ang.row(5).noalias() =
+      Eigen::Vector4f((cx * cz - sx * sy * sz), (-sx * sy * cz - cx * sz), 0, 0.0f);  // c3
 
-    h_ang.row(6).noalias() = Eigen::Vector4f((-cy * cz), (cy * sz), (sy), 0.0f);                  // d1
-    h_ang.row(7).noalias() = Eigen::Vector4f((-sx * sy * cz), (sx * sy * sz), (sx * cy), 0.0f);   // d2
-    h_ang.row(8).noalias() = Eigen::Vector4f((cx * sy * cz), (-cx * sy * sz), (-cx * cy), 0.0f);  // d3
+    h_ang.row(6).noalias() = Eigen::Vector4f((-cy * cz), (cy * sz), (sy), 0.0f);  // d1
+    h_ang.row(7).noalias() =
+      Eigen::Vector4f((-sx * sy * cz), (sx * sy * sz), (sx * cy), 0.0f);  // d2
+    h_ang.row(8).noalias() =
+      Eigen::Vector4f((cx * sy * cz), (-cx * sy * sz), (-cx * cy), 0.0f);  // d3
 
     h_ang.row(9).noalias() = Eigen::Vector4f((sy * sz), (sy * cz), 0, 0.0f);               // e1
     h_ang.row(10).noalias() = Eigen::Vector4f((-sx * cy * sz), (-sx * cy * cz), 0, 0.0f);  // e2
     h_ang.row(11).noalias() = Eigen::Vector4f((cx * cy * sz), (cx * cy * cz), 0, 0.0f);    // e3
 
-    h_ang.row(12).noalias() = Eigen::Vector4f((-cy * cz), (cy * sz), 0, 0.0f);                                 // f1
-    h_ang.row(13).noalias() = Eigen::Vector4f((-cx * sz - sx * sy * cz), (-cx * cz + sx * sy * sz), 0, 0.0f);  // f2
-    h_ang.row(14).noalias() = Eigen::Vector4f((-sx * sz + cx * sy * cz), (-cx * sy * sz - sx * cz), 0, 0.0f);  // f3
+    h_ang.row(12).noalias() = Eigen::Vector4f((-cy * cz), (cy * sz), 0, 0.0f);  // f1
+    h_ang.row(13).noalias() =
+      Eigen::Vector4f((-cx * sz - sx * sy * cz), (-cx * cz + sx * sy * sz), 0, 0.0f);  // f2
+    h_ang.row(14).noalias() =
+      Eigen::Vector4f((-sx * sz + cx * sy * cz), (-cx * sy * sz - sx * cz), 0, 0.0f);  // f3
   }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget>
-void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computePointDerivatives(Eigen::Vector3d &x, Eigen::Matrix<float, 4, 6> &point_gradient_, Eigen::Matrix<float, 24, 6> &point_hessian_, bool compute_hessian) const {
+template <typename PointSource, typename PointTarget>
+void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computePointDerivatives(
+  Eigen::Vector3d & x, Eigen::Matrix<float, 4, 6> & point_gradient_,
+  Eigen::Matrix<float, 24, 6> & point_hessian_, bool compute_hessian) const
+{
   Eigen::Vector4f x4(x[0], x[1], x[2], 0.0f);
 
   // Calculate first derivative of Transformation Equation 6.17 w.r.t. transform vector p.
-  // Derivative w.r.t. ith element of transform vector corresponds to column i, Equation 6.18 and 6.19 [Magnusson 2009]
+  // Derivative w.r.t. ith element of transform vector corresponds to column i, Equation 6.18
+  // and 6.19 [Magnusson 2009]
   Eigen::Matrix<float, 8, 1> x_j_ang = j_ang * x4;
 
   point_gradient_(1, 3) = x_j_ang[0];
@@ -454,7 +543,7 @@ void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computePoin
   point_gradient_(1, 5) = x_j_ang[6];
   point_gradient_(2, 5) = x_j_ang[7];
 
-  if(compute_hessian) {
+  if (compute_hessian) {
     Eigen::Matrix<float, 16, 1> x_h_ang = h_ang * x4;
 
     // Vectors from Equation 6.21 [Magnusson 2009]
@@ -466,7 +555,8 @@ void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computePoin
     Eigen::Vector4f f(x_h_ang[12], x_h_ang[13], x_h_ang[14], 0.0f);
 
     // Calculate second derivative of Transformation Equation 6.17 w.r.t. transform vector p.
-    // Derivative w.r.t. ith and jth elements of transform vector corresponds to the 3x1 block matrix starting at (3i,j), Equation 6.20 and 6.21 [Magnusson 2009]
+    // Derivative w.r.t. ith and jth elements of transform vector corresponds to the 3x1 block
+    // matrix starting at (3i,j), Equation 6.20 and 6.21 [Magnusson 2009]
     point_hessian_.block<4, 1>((9 / 3) * 4, 3) = a;
     point_hessian_.block<4, 1>((12 / 3) * 4, 3) = b;
     point_hessian_.block<4, 1>((15 / 3) * 4, 3) = c;
@@ -480,10 +570,14 @@ void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computePoin
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget>
-void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computePointDerivatives(Eigen::Vector3d &x, Eigen::Matrix<double, 3, 6> &point_gradient_, Eigen::Matrix<double, 18, 6> &point_hessian_, bool compute_hessian) const {
+template <typename PointSource, typename PointTarget>
+void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computePointDerivatives(
+  Eigen::Vector3d & x, Eigen::Matrix<double, 3, 6> & point_gradient_,
+  Eigen::Matrix<double, 18, 6> & point_hessian_, bool compute_hessian) const
+{
   // Calculate first derivative of Transformation Equation 6.17 w.r.t. transform vector p.
-  // Derivative w.r.t. ith element of transform vector corresponds to column i, Equation 6.18 and 6.19 [Magnusson 2009]
+  // Derivative w.r.t. ith element of transform vector corresponds to column i, Equation 6.18
+  // and 6.19 [Magnusson 2009]
   point_gradient_(1, 3) = x.dot(j_ang_a_);
   point_gradient_(2, 3) = x.dot(j_ang_b_);
   point_gradient_(0, 4) = x.dot(j_ang_c_);
@@ -493,7 +587,7 @@ void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computePoin
   point_gradient_(1, 5) = x.dot(j_ang_g_);
   point_gradient_(2, 5) = x.dot(j_ang_h_);
 
-  if(compute_hessian) {
+  if (compute_hessian) {
     // Vectors from Equation 6.21 [Magnusson 2009]
     Eigen::Vector3d a, b, c, d, e, f;
 
@@ -505,7 +599,8 @@ void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computePoin
     f << x.dot(h_ang_f1_), x.dot(h_ang_f2_), x.dot(h_ang_f3_);
 
     // Calculate second derivative of Transformation Equation 6.17 w.r.t. transform vector p.
-    // Derivative w.r.t. ith and jth elements of transform vector corresponds to the 3x1 block matrix starting at (3i,j), Equation 6.20 and 6.21 [Magnusson 2009]
+    // Derivative w.r.t. ith and jth elements of transform vector corresponds to the 3x1 block
+    // matrix starting at (3i,j), Equation 6.20 and 6.21 [Magnusson 2009]
     point_hessian_.block<3, 1>(9, 3) = a;
     point_hessian_.block<3, 1>(12, 3) = b;
     point_hessian_.block<3, 1>(15, 3) = c;
@@ -519,8 +614,13 @@ void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computePoin
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget>
-double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::updateDerivatives(Eigen::Matrix<double, 6, 1> &score_gradient, Eigen::Matrix<double, 6, 6> &hessian, const Eigen::Matrix<float, 4, 6> &point_gradient4, const Eigen::Matrix<float, 24, 6> &point_hessian_, const Eigen::Vector3d &x_trans, const Eigen::Matrix3d &c_inv, bool compute_hessian) const {
+template <typename PointSource, typename PointTarget>
+double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::updateDerivatives(
+  Eigen::Matrix<double, 6, 1> & score_gradient, Eigen::Matrix<double, 6, 6> & hessian,
+  const Eigen::Matrix<float, 4, 6> & point_gradient4,
+  const Eigen::Matrix<float, 24, 6> & point_hessian_, const Eigen::Vector3d & x_trans,
+  const Eigen::Matrix3d & c_inv, bool compute_hessian) const
+{
   Eigen::Matrix<float, 1, 4> x_trans4(x_trans[0], x_trans[1], x_trans[2], 0.0f);
   Eigen::Matrix4f c_inv4 = Eigen::Matrix4f::Zero();
   c_inv4.topLeftCorner(3, 3) = c_inv.cast<float>();
@@ -535,29 +635,36 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::updateDer
   e_x_cov_x = gauss_d2 * e_x_cov_x;
 
   // Error checking for invalid values.
-  if(e_x_cov_x > 1 || e_x_cov_x < 0 || e_x_cov_x != e_x_cov_x) return (0);
+  if (e_x_cov_x > 1 || e_x_cov_x < 0 || e_x_cov_x != e_x_cov_x) return (0);
 
   // Reusable portion of Equation 6.12 and 6.13 [Magnusson 2009]
   e_x_cov_x *= gauss_d1_;
 
   Eigen::Matrix<float, 4, 6> c_inv4_x_point_gradient4 = c_inv4 * point_gradient4;
-  Eigen::Matrix<float, 6, 1> x_trans4_dot_c_inv4_x_point_gradient4 = x_trans4 * c_inv4_x_point_gradient4;
+  Eigen::Matrix<float, 6, 1> x_trans4_dot_c_inv4_x_point_gradient4 =
+    x_trans4 * c_inv4_x_point_gradient4;
 
   score_gradient.noalias() += (e_x_cov_x * x_trans4_dot_c_inv4_x_point_gradient4).cast<double>();
 
-  if(compute_hessian) {
+  if (compute_hessian) {
     Eigen::Matrix<float, 1, 4> x_trans4_x_c_inv4 = x_trans4 * c_inv4;
-    Eigen::Matrix<float, 6, 6> point_gradient4_colj_dot_c_inv4_x_point_gradient4_col_i = point_gradient4.transpose() * c_inv4_x_point_gradient4;
+    Eigen::Matrix<float, 6, 6> point_gradient4_colj_dot_c_inv4_x_point_gradient4_col_i =
+      point_gradient4.transpose() * c_inv4_x_point_gradient4;
     Eigen::Matrix<float, 6, 1> x_trans4_dot_c_inv4_x_ext_point_hessian_4ij;
 
-    for(int i = 0; i < 6; i++) {
+    for (int i = 0; i < 6; i++) {
       // Sigma_k^-1 d(T(x,p))/dpi, Reusable portion of Equation 6.12 and 6.13 [Magnusson 2009]
       // Update gradient, Equation 6.12 [Magnusson 2009]
-      x_trans4_dot_c_inv4_x_ext_point_hessian_4ij.noalias() = x_trans4_x_c_inv4 * point_hessian_.block<4, 6>(i * 4, 0);
+      x_trans4_dot_c_inv4_x_ext_point_hessian_4ij.noalias() =
+        x_trans4_x_c_inv4 * point_hessian_.block<4, 6>(i * 4, 0);
 
-      for(int j = 0; j < hessian.cols(); j++) {
+      for (int j = 0; j < hessian.cols(); j++) {
         // Update hessian, Equation 6.13 [Magnusson 2009]
-        hessian(i, j) += e_x_cov_x * (-gauss_d2 * x_trans4_dot_c_inv4_x_point_gradient4(i) * x_trans4_dot_c_inv4_x_point_gradient4(j) + x_trans4_dot_c_inv4_x_ext_point_hessian_4ij(j) + point_gradient4_colj_dot_c_inv4_x_point_gradient4_col_i(j, i));
+        hessian(i, j) +=
+          e_x_cov_x * (-gauss_d2 * x_trans4_dot_c_inv4_x_point_gradient4(i) *
+                         x_trans4_dot_c_inv4_x_point_gradient4(j) +
+                       x_trans4_dot_c_inv4_x_ext_point_hessian_4ij(j) +
+                       point_gradient4_colj_dot_c_inv4_x_point_gradient4_col_i(j, i));
       }
     }
   }
@@ -566,8 +673,11 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::updateDer
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget>
-void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeHessian(Eigen::Matrix<double, 6, 6> &hessian, PointCloudSource &trans_cloud, Eigen::Matrix<double, 6, 1> &) {
+template <typename PointSource, typename PointTarget>
+void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeHessian(
+  Eigen::Matrix<double, 6, 6> & hessian, PointCloudSource & trans_cloud,
+  Eigen::Matrix<double, 6, 1> &)
+{
   // Original Point and Transformed Point
   PointSource x_pt, x_trans_pt;
   // Original Point and Transformed Point (for math)
@@ -586,16 +696,17 @@ void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeHess
 
   hessian.setZero();
 
-  // Precompute Angular Derivatives unnecessary because only used after regular derivative calculation
+  // Precompute Angular Derivatives unnecessary because only used after regular derivative
+  // calculation
 
   // Update hessian for each point, line 17 in Algorithm 2 [Magnusson 2009]
-  for(size_t idx = 0; idx < input_->points.size(); idx++) {
+  for (size_t idx = 0; idx < input_->points.size(); idx++) {
     x_trans_pt = trans_cloud.points[idx];
 
     // Find neighbors (Radius search has been experimentally faster than direct neighbor checking.
     std::vector<TargetGridLeafConstPtr> neighborhood;
     std::vector<float> distances;
-    switch(params_.search_method) {
+    switch (params_.search_method) {
       case KDTREE:
         target_cells_.radiusSearch(x_trans_pt, params_.resolution, neighborhood, distances);
         break;
@@ -611,7 +722,9 @@ void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeHess
         break;
     }
 
-    for(typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it = neighborhood.begin(); neighborhood_it != neighborhood.end(); neighborhood_it++) {
+    for (typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it =
+           neighborhood.begin();
+         neighborhood_it != neighborhood.end(); neighborhood_it++) {
       cell = *neighborhood_it;
 
       {
@@ -625,9 +738,11 @@ void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeHess
         // Uses precomputed covariance for speed.
         c_inv = cell->getInverseCov();
 
-        // Compute derivative of transform function w.r.t. transform vector, J_E and H_E in Equations 6.18 and 6.20 [Magnusson 2009]
+        // Compute derivative of transform function w.r.t. transform vector, J_E and H_E in
+        // Equations 6.18 and 6.20 [Magnusson 2009]
         computePointDerivatives(x, point_gradient_, point_hessian_);
-        // Update hessian, lines 21 in Algorithm 2, according to Equations 6.10, 6.12 and 6.13, respectively [Magnusson 2009]
+        // Update hessian, lines 21 in Algorithm 2, according to Equations 6.10, 6.12 and 6.13,
+        // respectively [Magnusson 2009]
         updateHessian(hessian, point_gradient_, point_hessian_, x_trans, c_inv);
       }
     }
@@ -635,48 +750,58 @@ void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeHess
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget>
-void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::updateHessian(Eigen::Matrix<double, 6, 6> &hessian, const Eigen::Matrix<double, 3, 6> &point_gradient_, const Eigen::Matrix<double, 18, 6> &point_hessian_, const Eigen::Vector3d &x_trans, const Eigen::Matrix3d &c_inv) const {
+template <typename PointSource, typename PointTarget>
+void pclomp::NormalDistributionsTransform<PointSource, PointTarget>::updateHessian(
+  Eigen::Matrix<double, 6, 6> & hessian, const Eigen::Matrix<double, 3, 6> & point_gradient_,
+  const Eigen::Matrix<double, 18, 6> & point_hessian_, const Eigen::Vector3d & x_trans,
+  const Eigen::Matrix3d & c_inv) const
+{
   Eigen::Vector3d cov_dxd_pi;
   // e^(-d_2/2 * (x_k - mu_k)^T Sigma_k^-1 (x_k - mu_k)) Equation 6.9 [Magnusson 2009]
   double e_x_cov_x = gauss_d2_ * exp(-gauss_d2_ * x_trans.dot(c_inv * x_trans) / 2);
 
   // Error checking for invalid values.
-  if(e_x_cov_x > 1 || e_x_cov_x < 0 || e_x_cov_x != e_x_cov_x) return;
+  if (e_x_cov_x > 1 || e_x_cov_x < 0 || e_x_cov_x != e_x_cov_x) return;
 
   // Reusable portion of Equation 6.12 and 6.13 [Magnusson 2009]
   e_x_cov_x *= gauss_d1_;
 
-  for(int i = 0; i < 6; i++) {
+  for (int i = 0; i < 6; i++) {
     // Sigma_k^-1 d(T(x,p))/dpi, Reusable portion of Equation 6.12 and 6.13 [Magnusson 2009]
     cov_dxd_pi = c_inv * point_gradient_.col(i);
 
-    for(int j = 0; j < hessian.cols(); j++) {
+    for (int j = 0; j < hessian.cols(); j++) {
       // Update hessian, Equation 6.13 [Magnusson 2009]
-      hessian(i, j) += e_x_cov_x * (-gauss_d2_ * x_trans.dot(cov_dxd_pi) * x_trans.dot(c_inv * point_gradient_.col(j)) + x_trans.dot(c_inv * point_hessian_.block<3, 1>(3 * i, j)) + point_gradient_.col(j).dot(cov_dxd_pi));
+      hessian(i, j) += e_x_cov_x * (-gauss_d2_ * x_trans.dot(cov_dxd_pi) *
+                                      x_trans.dot(c_inv * point_gradient_.col(j)) +
+                                    x_trans.dot(c_inv * point_hessian_.block<3, 1>(3 * i, j)) +
+                                    point_gradient_.col(j).dot(cov_dxd_pi));
     }
   }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget>
-bool pclomp::NormalDistributionsTransform<PointSource, PointTarget>::updateIntervalMT(double &a_l, double &f_l, double &g_l, double &a_u, double &f_u, double &g_u, double a_t, double f_t, double g_t) {
+template <typename PointSource, typename PointTarget>
+bool pclomp::NormalDistributionsTransform<PointSource, PointTarget>::updateIntervalMT(
+  double & a_l, double & f_l, double & g_l, double & a_u, double & f_u, double & g_u, double a_t,
+  double f_t, double g_t)
+{
   // Case U1 in Update Algorithm and Case a in Modified Update Algorithm [More, Thuente 1994]
-  if(f_t > f_l) {
+  if (f_t > f_l) {
     a_u = a_t;
     f_u = f_t;
     g_u = g_t;
     return (false);
   }
   // Case U2 in Update Algorithm and Case b in Modified Update Algorithm [More, Thuente 1994]
-  else if(g_t * (a_l - a_t) > 0) {
+  else if (g_t * (a_l - a_t) > 0) {
     a_l = a_t;
     f_l = f_t;
     g_l = g_t;
     return (false);
   }
   // Case U3 in Update Algorithm and Case c in Modified Update Algorithm [More, Thuente 1994]
-  else if(g_t * (a_l - a_t) < 0) {
+  else if (g_t * (a_l - a_t) < 0) {
     a_u = a_l;
     f_u = f_l;
     g_u = g_l;
@@ -692,10 +817,13 @@ bool pclomp::NormalDistributionsTransform<PointSource, PointTarget>::updateInter
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget>
-double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::trialValueSelectionMT(double a_l, double f_l, double g_l, double a_u, double f_u, double g_u, double a_t, double f_t, double g_t) {
+template <typename PointSource, typename PointTarget>
+double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::trialValueSelectionMT(
+  double a_l, double f_l, double g_l, double a_u, double f_u, double g_u, double a_t, double f_t,
+  double g_t)
+{
   // Case 1 in Trial Value Selection [More, Thuente 1994]
-  if(f_t > f_l) {
+  if (f_t > f_l) {
     // Calculate the minimizer of the cubic that interpolates f_l, f_t, g_l and g_t
     // Equation 2.4.52 [Sun, Yuan 2006]
     double z = 3 * (f_t - f_l) / (a_t - a_l) - g_t - g_l;
@@ -707,13 +835,13 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::trialValu
     // Equation 2.4.2 [Sun, Yuan 2006]
     double a_q = a_l - 0.5 * (a_l - a_t) * g_l / (g_l - (f_l - f_t) / (a_l - a_t));
 
-    if(std::fabs(a_c - a_l) < std::fabs(a_q - a_l))
+    if (std::fabs(a_c - a_l) < std::fabs(a_q - a_l))
       return (a_c);
     else
       return (0.5 * (a_q + a_c));
   }
   // Case 2 in Trial Value Selection [More, Thuente 1994]
-  else if(g_t * g_l < 0) {
+  else if (g_t * g_l < 0) {
     // Calculate the minimizer of the cubic that interpolates f_l, f_t, g_l and g_t
     // Equation 2.4.52 [Sun, Yuan 2006]
     double z = 3 * (f_t - f_l) / (a_t - a_l) - g_t - g_l;
@@ -725,13 +853,13 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::trialValu
     // Equation 2.4.5 [Sun, Yuan 2006]
     double a_s = a_l - (a_l - a_t) / (g_l - g_t) * g_l;
 
-    if(std::fabs(a_c - a_t) >= std::fabs(a_s - a_t))
+    if (std::fabs(a_c - a_t) >= std::fabs(a_s - a_t))
       return (a_c);
     else
       return (a_s);
   }
   // Case 3 in Trial Value Selection [More, Thuente 1994]
-  else if(std::fabs(g_t) <= std::fabs(g_l)) {
+  else if (std::fabs(g_t) <= std::fabs(g_l)) {
     // Calculate the minimizer of the cubic that interpolates f_l, f_t, g_l and g_t
     // Equation 2.4.52 [Sun, Yuan 2006]
     double z = 3 * (f_t - f_l) / (a_t - a_l) - g_t - g_l;
@@ -744,12 +872,12 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::trialValu
 
     double a_t_next;
 
-    if(std::fabs(a_c - a_t) < std::fabs(a_s - a_t))
+    if (std::fabs(a_c - a_t) < std::fabs(a_s - a_t))
       a_t_next = a_c;
     else
       a_t_next = a_s;
 
-    if(a_t > a_l)
+    if (a_t > a_l)
       return (std::min(a_t + 0.66 * (a_u - a_t), a_t_next));
     else
       return (std::max(a_t + 0.66 * (a_u - a_t), a_t_next));
@@ -766,8 +894,12 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::trialValu
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointSource, typename PointTarget>
-double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeStepLengthMT(const Eigen::Matrix<double, 6, 1> &x, Eigen::Matrix<double, 6, 1> &step_dir, double step_init, double step_max, double step_min, double &score, Eigen::Matrix<double, 6, 1> &score_gradient, Eigen::Matrix<double, 6, 6> &hessian, PointCloudSource &trans_cloud) {
+template <typename PointSource, typename PointTarget>
+double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeStepLengthMT(
+  const Eigen::Matrix<double, 6, 1> & x, Eigen::Matrix<double, 6, 1> & step_dir, double step_init,
+  double step_max, double step_min, double & score, Eigen::Matrix<double, 6, 1> & score_gradient,
+  Eigen::Matrix<double, 6, 6> & hessian, PointCloudSource & trans_cloud)
+{
   // Set the value of phi(0), Equation 1.3 [More, Thuente 1994]
   double phi_0 = -score;
   // Set the value of phi'(0), Equation 1.3 [More, Thuente 1994]
@@ -775,9 +907,9 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeSt
 
   Eigen::Matrix<double, 6, 1> x_t;
 
-  if(d_phi_0 >= 0) {
+  if (d_phi_0 >= 0) {
     // Not a decent direction
-    if(d_phi_0 == 0)
+    if (d_phi_0 == 0)
       return 0;
     else {
       // Reverse step direction and calculate optimal step.
@@ -799,14 +931,16 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeSt
   // Initial endpoints of Interval I,
   double a_l = 0, a_u = 0;
 
-  // Auxiliary function psi is used until I is determined ot be a closed interval, Equation 2.1 [More, Thuente 1994]
+  // Auxiliary function psi is used until I is determined ot be a closed interval, Equation 2.1
+  // [More, Thuente 1994]
   double f_l = auxiliaryFunction_PsiMT(a_l, phi_0, phi_0, d_phi_0, mu);
   double g_l = auxiliaryFunction_dPsiMT(d_phi_0, d_phi_0, mu);
 
   double f_u = auxiliaryFunction_PsiMT(a_u, phi_0, phi_0, d_phi_0, mu);
   double g_u = auxiliaryFunction_dPsiMT(d_phi_0, d_phi_0, mu);
 
-  // Check used to allow More-Thuente step length calculation to be skipped by making step_min == step_max
+  // Check used to allow More-Thuente step length calculation to be skipped by making step_min ==
+  // step_max
   bool interval_converged = (step_max - step_min) < 0, open_interval = true;
 
   double a_t = step_init;
@@ -815,26 +949,33 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeSt
 
   x_t = x + step_dir * a_t;
 
-  final_transformation_ = (Eigen::Translation<float, 3>(static_cast<float>(x_t(0)), static_cast<float>(x_t(1)), static_cast<float>(x_t(2))) * Eigen::AngleAxis<float>(static_cast<float>(x_t(3)), Eigen::Vector3f::UnitX()) * Eigen::AngleAxis<float>(static_cast<float>(x_t(4)), Eigen::Vector3f::UnitY()) * Eigen::AngleAxis<float>(static_cast<float>(x_t(5)), Eigen::Vector3f::UnitZ()))
-                              .matrix();
+  final_transformation_ =
+    (Eigen::Translation<float, 3>(
+       static_cast<float>(x_t(0)), static_cast<float>(x_t(1)), static_cast<float>(x_t(2))) *
+     Eigen::AngleAxis<float>(static_cast<float>(x_t(3)), Eigen::Vector3f::UnitX()) *
+     Eigen::AngleAxis<float>(static_cast<float>(x_t(4)), Eigen::Vector3f::UnitY()) *
+     Eigen::AngleAxis<float>(static_cast<float>(x_t(5)), Eigen::Vector3f::UnitZ()))
+      .matrix();
 
   // New transformed point cloud
   transformPointCloud(*input_, trans_cloud, final_transformation_);
 
-  // Updates score, gradient and hessian.  Hessian calculation is unnecessary but testing showed that most step calculations use the
-  // initial step suggestion and recalculation the reusable portions of the hessian would intail more computation time.
+  // Updates score, gradient and hessian.  Hessian calculation is unnecessary but testing showed
+  // that most step calculations use the initial step suggestion and recalculation the reusable
+  // portions of the hessian would intail more computation time.
   score = computeDerivatives(score_gradient, hessian, trans_cloud, x_t, true);
 
   // --------------------------------------------------------------------------------------------------------------------------------
   // FIXME(YamatoAndo):
   // Currently, using LineSearch causes the following problems:
   // It may converge to a local solution.
-  // There are cases where a loop process is executed without changing the variable values, resulting in unnecessary processing time.
-  // As better convergence results are obtained without using LineSearch, we have decided to disable this feature.
-  // If you have any suggestions on how to solve these issues, we would appreciate it if you could contribute.
+  // There are cases where a loop process is executed without changing the variable values,
+  // resulting in unnecessary processing time. As better convergence results are obtained without
+  // using LineSearch, we have decided to disable this feature. If you have any suggestions on how
+  // to solve these issues, we would appreciate it if you could contribute.
   // --------------------------------------------------------------------------------------------------------------------------------
 
-  if(params_.use_line_search) {
+  if (params_.use_line_search) {
     // Calculate phi(alpha_t)
     double phi_t = -score;
     // Calculate phi'(alpha_t)
@@ -845,10 +986,13 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeSt
     // Calculate psi'(alpha_t)
     double d_psi_t = auxiliaryFunction_dPsiMT(d_phi_t, d_phi_0, mu);
 
-    // Iterate until max number of iterations, interval convergence or a value satisfies the sufficient decrease, Equation 1.1, and curvature condition, Equation 1.2 [More, Thuente 1994]
-    while(!interval_converged && step_iterations < max_step_iterations && !(psi_t <= 0 /*Sufficient Decrease*/ && d_phi_t <= -nu * d_phi_0 /*Curvature Condition*/)) {
+    // Iterate until max number of iterations, interval convergence or a value satisfies the
+    // sufficient decrease, Equation 1.1, and curvature condition, Equation 1.2 [More, Thuente 1994]
+    while (
+      !interval_converged && step_iterations < max_step_iterations &&
+      !(psi_t <= 0 /*Sufficient Decrease*/ && d_phi_t <= -nu * d_phi_0 /*Curvature Condition*/)) {
       // Use auxiliary function if interval I is not closed
-      if(open_interval) {
+      if (open_interval) {
         a_t = trialValueSelectionMT(a_l, f_l, g_l, a_u, f_u, g_u, a_t, psi_t, d_psi_t);
       } else {
         a_t = trialValueSelectionMT(a_l, f_l, g_l, a_u, f_u, g_u, a_t, phi_t, d_phi_t);
@@ -859,8 +1003,13 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeSt
 
       x_t = x + step_dir * a_t;
 
-      final_transformation_ = (Eigen::Translation<float, 3>(static_cast<float>(x_t(0)), static_cast<float>(x_t(1)), static_cast<float>(x_t(2))) * Eigen::AngleAxis<float>(static_cast<float>(x_t(3)), Eigen::Vector3f::UnitX()) * Eigen::AngleAxis<float>(static_cast<float>(x_t(4)), Eigen::Vector3f::UnitY()) * Eigen::AngleAxis<float>(static_cast<float>(x_t(5)), Eigen::Vector3f::UnitZ()))
-                                  .matrix();
+      final_transformation_ =
+        (Eigen::Translation<float, 3>(
+           static_cast<float>(x_t(0)), static_cast<float>(x_t(1)), static_cast<float>(x_t(2))) *
+         Eigen::AngleAxis<float>(static_cast<float>(x_t(3)), Eigen::Vector3f::UnitX()) *
+         Eigen::AngleAxis<float>(static_cast<float>(x_t(4)), Eigen::Vector3f::UnitY()) *
+         Eigen::AngleAxis<float>(static_cast<float>(x_t(5)), Eigen::Vector3f::UnitZ()))
+          .matrix();
 
       // New transformed point cloud
       // Done on final cloud to prevent wasted computation
@@ -880,7 +1029,7 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeSt
       d_psi_t = auxiliaryFunction_dPsiMT(d_phi_t, d_phi_0, mu);
 
       // Check if I is now a closed interval
-      if(open_interval && (psi_t <= 0 && d_psi_t >= 0)) {
+      if (open_interval && (psi_t <= 0 && d_psi_t >= 0)) {
         open_interval = false;
 
         // Converts f_l and g_l from psi to phi
@@ -892,7 +1041,7 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeSt
         g_u = g_u + mu * d_phi_0;
       }
 
-      if(open_interval) {
+      if (open_interval) {
         // Update interval end points using Updating Algorithm [More, Thuente 1994]
         interval_converged = updateIntervalMT(a_l, f_l, g_l, a_u, f_u, g_u, a_t, psi_t, d_psi_t);
       } else {
@@ -907,22 +1056,24 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeSt
   // If inner loop was run then hessian needs to be calculated.
   // Hessian is unnecessary for step length determination but gradients are required
   // so derivative and transform data is stored for the next iteration.
-  if(step_iterations) computeHessian(hessian, trans_cloud, x_t);
+  if (step_iterations) computeHessian(hessian, trans_cloud, x_t);
 
   return (a_t);
 }
 
-template<typename PointSource, typename PointTarget>
-double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::calculateScore(const PointCloudSource &trans_cloud) const {
+template <typename PointSource, typename PointTarget>
+double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::calculateScore(
+  const PointCloudSource & trans_cloud) const
+{
   double score = 0;
 
-  for(std::size_t idx = 0; idx < trans_cloud.points.size(); idx++) {
+  for (std::size_t idx = 0; idx < trans_cloud.points.size(); idx++) {
     PointSource x_trans_pt = trans_cloud.points[idx];
 
     // Find neighbors (Radius search has been experimentally faster than direct neighbor checking.
     std::vector<TargetGridLeafConstPtr> neighborhood;
     std::vector<float> distances;
-    switch(params_.search_method) {
+    switch (params_.search_method) {
       case KDTREE:
         target_cells_.radiusSearch(x_trans_pt, params_.resolution, neighborhood, distances);
         break;
@@ -938,7 +1089,9 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::calculate
         break;
     }
 
-    for(typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it = neighborhood.begin(); neighborhood_it != neighborhood.end(); neighborhood_it++) {
+    for (typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it =
+           neighborhood.begin();
+         neighborhood_it != neighborhood.end(); neighborhood_it++) {
       TargetGridLeafConstPtr cell = *neighborhood_it;
 
       Eigen::Vector3d x_trans = Eigen::Vector3d(x_trans_pt.x, x_trans_pt.y, x_trans_pt.z);
@@ -958,23 +1111,26 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::calculate
   }
 
   double output_score = 0;
-  if(!trans_cloud.points.empty()) {
+  if (!trans_cloud.points.empty()) {
     output_score = (score) / static_cast<double>(trans_cloud.size());
   }
   return output_score;
 }
 
-template<typename PointSource, typename PointTarget>
-double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::calculateTransformationProbability(const PointCloudSource &trans_cloud) const {
+template <typename PointSource, typename PointTarget>
+double
+pclomp::NormalDistributionsTransform<PointSource, PointTarget>::calculateTransformationProbability(
+  const PointCloudSource & trans_cloud) const
+{
   double score = 0;
 
-  for(std::size_t idx = 0; idx < trans_cloud.points.size(); idx++) {
+  for (std::size_t idx = 0; idx < trans_cloud.points.size(); idx++) {
     PointSource x_trans_pt = trans_cloud.points[idx];
 
     // Find neighbors (Radius search has been experimentally faster than direct neighbor checking.
     std::vector<TargetGridLeafConstPtr> neighborhood;
     std::vector<float> distances;
-    switch(params_.search_method) {
+    switch (params_.search_method) {
       case KDTREE:
         target_cells_.radiusSearch(x_trans_pt, params_.resolution, neighborhood, distances);
         break;
@@ -990,7 +1146,9 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::calculate
         break;
     }
 
-    for(typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it = neighborhood.begin(); neighborhood_it != neighborhood.end(); neighborhood_it++) {
+    for (typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it =
+           neighborhood.begin();
+         neighborhood_it != neighborhood.end(); neighborhood_it++) {
       TargetGridLeafConstPtr cell = *neighborhood_it;
 
       Eigen::Vector3d x_trans = Eigen::Vector3d(x_trans_pt.x, x_trans_pt.y, x_trans_pt.z);
@@ -1010,25 +1168,27 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::calculate
   }
 
   double output_score = 0;
-  if(!trans_cloud.points.empty()) {
+  if (!trans_cloud.points.empty()) {
     output_score = (score) / static_cast<double>(trans_cloud.points.size());
   }
   return output_score;
 }
 
-template<typename PointSource, typename PointTarget>
-double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::calculateNearestVoxelTransformationLikelihood(const PointCloudSource &trans_cloud) const {
+template <typename PointSource, typename PointTarget>
+double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::
+  calculateNearestVoxelTransformationLikelihood(const PointCloudSource & trans_cloud) const
+{
   double nearest_voxel_score = 0;
   size_t found_neigborhood_voxel_num = 0;
 
-  for(std::size_t idx = 0; idx < trans_cloud.points.size(); idx++) {
+  for (std::size_t idx = 0; idx < trans_cloud.points.size(); idx++) {
     double nearest_voxel_score_pt = 0;
     PointSource x_trans_pt = trans_cloud.points[idx];
 
     // Find neighbors (Radius search has been experimentally faster than direct neighbor checking.
     std::vector<TargetGridLeafConstPtr> neighborhood;
     std::vector<float> distances;
-    switch(params_.search_method) {
+    switch (params_.search_method) {
       case KDTREE:
         target_cells_.radiusSearch(x_trans_pt, params_.resolution, neighborhood, distances);
         break;
@@ -1044,7 +1204,9 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::calculate
         break;
     }
 
-    for(typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it = neighborhood.begin(); neighborhood_it != neighborhood.end(); neighborhood_it++) {
+    for (typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it =
+           neighborhood.begin();
+         neighborhood_it != neighborhood.end(); neighborhood_it++) {
       TargetGridLeafConstPtr cell = *neighborhood_it;
 
       Eigen::Vector3d x_trans = Eigen::Vector3d(x_trans_pt.x, x_trans_pt.y, x_trans_pt.z);
@@ -1059,19 +1221,19 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::calculate
       // Calculate probability of transformed points existence, Equation 6.9 [Magnusson 2009]
       double score_inc = -gauss_d1_ * e_x_cov_x;
 
-      if(score_inc > nearest_voxel_score_pt) {
+      if (score_inc > nearest_voxel_score_pt) {
         nearest_voxel_score_pt = score_inc;
       }
     }
 
-    if(!neighborhood.empty()) {
+    if (!neighborhood.empty()) {
       ++found_neigborhood_voxel_num;
       nearest_voxel_score += nearest_voxel_score_pt;
     }
   }
 
   double output_score = 0;
-  if(found_neigborhood_voxel_num != 0) {
+  if (found_neigborhood_voxel_num != 0) {
     output_score = nearest_voxel_score / static_cast<double>(found_neigborhood_voxel_num);
   }
   return output_score;

--- a/include/pclomp/ndt_struct.hpp
+++ b/include/pclomp/ndt_struct.hpp
@@ -54,15 +54,18 @@
 #ifndef PCLOMP_NDT_STRUCT_HPP_
 #define PCLOMP_NDT_STRUCT_HPP_
 
-#include <vector>
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
-namespace pclomp {
+#include <vector>
+
+namespace pclomp
+{
 
 enum NeighborSearchMethod { KDTREE, DIRECT26, DIRECT7, DIRECT1 };
 
-struct NdtResult {
+struct NdtResult
+{
   Eigen::Matrix4f pose;
   float transform_probability;
   float nearest_voxel_transformation_likelihood;
@@ -73,7 +76,8 @@ struct NdtResult {
   std::vector<float> nearest_voxel_transformation_likelihood_array;
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  friend std::ostream &operator<<(std::ostream &os, const NdtResult &val) {
+  friend std::ostream & operator<<(std::ostream & os, const NdtResult & val)
+  {
     os << "Pose: " << std::endl << val.pose << std::endl;
     os << "TP: " << val.transform_probability << std::endl;
     os << "NVTP: " << val.nearest_voxel_transformation_likelihood << std::endl;
@@ -83,7 +87,8 @@ struct NdtResult {
   }
 };
 
-struct NdtParams {
+struct NdtParams
+{
   double trans_epsilon;
   double step_size;
   double resolution;

--- a/include/pclomp/voxel_grid_covariance_omp_impl.hpp
+++ b/include/pclomp/voxel_grid_covariance_omp_impl.hpp
@@ -38,19 +38,22 @@
 #ifndef PCL_VOXEL_GRID_COVARIANCE_IMPL_OMP_H_
 #define PCL_VOXEL_GRID_COVARIANCE_IMPL_OMP_H_
 
+#include "voxel_grid_covariance_omp.h"
+
+#include <Eigen/Cholesky>
+#include <Eigen/Dense>
+
 #include <pcl/common/common.h>
 #include <pcl/filters/boost.h>
-#include "voxel_grid_covariance_omp.h"
-#include <Eigen/Dense>
-#include <Eigen/Cholesky>
 
 //////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointT>
-void pclomp::VoxelGridCovariance<PointT>::applyFilter(PointCloud& output) {
+template <typename PointT>
+void pclomp::VoxelGridCovariance<PointT>::applyFilter(PointCloud & output)
+{
   voxel_centroids_leaf_indices_.clear();
 
   // Has the input dataset been set already?
-  if(!input_) {
+  if (!input_) {
     PCL_WARN("[pcl::%s::applyFilter] No input dataset given!\n", getClassName().c_str());
     output.width = output.height = 0;
     output.points.clear();
@@ -64,8 +67,10 @@ void pclomp::VoxelGridCovariance<PointT>::applyFilter(PointCloud& output) {
 
   Eigen::Vector4f min_p, max_p;
   // Get the minimum and maximum dimensions
-  if(!filter_field_name_.empty())  // If we don't want to process the entire cloud...
-    pcl::getMinMax3D<PointT>(input_, filter_field_name_, static_cast<float>(filter_limit_min_), static_cast<float>(filter_limit_max_), min_p, max_p, filter_limit_negative_);
+  if (!filter_field_name_.empty())  // If we don't want to process the entire cloud...
+    pcl::getMinMax3D<PointT>(
+      input_, filter_field_name_, static_cast<float>(filter_limit_min_),
+      static_cast<float>(filter_limit_max_), min_p, max_p, filter_limit_negative_);
   else
     pcl::getMinMax3D<PointT>(*input_, min_p, max_p);
 
@@ -74,8 +79,11 @@ void pclomp::VoxelGridCovariance<PointT>::applyFilter(PointCloud& output) {
   int64_t dy = static_cast<int64_t>((max_p[1] - min_p[1]) * inverse_leaf_size_[1]) + 1;
   int64_t dz = static_cast<int64_t>((max_p[2] - min_p[2]) * inverse_leaf_size_[2]) + 1;
 
-  if((dx * dy * dz) > std::numeric_limits<int32_t>::max()) {
-    PCL_WARN("[pcl::%s::applyFilter] Leaf size is too small for the input dataset. Integer indices would overflow.", getClassName().c_str());
+  if ((dx * dy * dz) > std::numeric_limits<int32_t>::max()) {
+    PCL_WARN(
+      "[pcl::%s::applyFilter] Leaf size is too small for the input dataset. Integer indices would "
+      "overflow.",
+      getClassName().c_str());
     output.clear();
     return;
   }
@@ -101,53 +109,63 @@ void pclomp::VoxelGridCovariance<PointT>::applyFilter(PointCloud& output) {
 
   int centroid_size = 4;
 
-  if(downsample_all_data_) centroid_size = boost::mpl::size<FieldList>::value;
+  if (downsample_all_data_) centroid_size = boost::mpl::size<FieldList>::value;
 
   // ---[ RGB special case
   std::vector<pcl::PCLPointField> fields;
   int rgba_index = -1;
   rgba_index = pcl::getFieldIndex<PointT>("rgb", fields);
-  if(rgba_index == -1) rgba_index = pcl::getFieldIndex<PointT>("rgba", fields);
-  if(rgba_index >= 0) {
+  if (rgba_index == -1) rgba_index = pcl::getFieldIndex<PointT>("rgba", fields);
+  if (rgba_index >= 0) {
     rgba_index = fields[rgba_index].offset;
     centroid_size += 3;
   }
 
-  // If we don't want to process the entire cloud, but rather filter points far away from the viewpoint first...
-  if(!filter_field_name_.empty()) {
+  // If we don't want to process the entire cloud, but rather filter points far away from the
+  // viewpoint first...
+  if (!filter_field_name_.empty()) {
     // Get the distance field index
     std::vector<pcl::PCLPointField> fields;
     int distance_idx = pcl::getFieldIndex<PointT>(filter_field_name_, fields);
-    if(distance_idx == -1) PCL_WARN("[pcl::%s::applyFilter] Invalid filter field name. Index is %d.\n", getClassName().c_str(), distance_idx);
+    if (distance_idx == -1)
+      PCL_WARN(
+        "[pcl::%s::applyFilter] Invalid filter field name. Index is %d.\n", getClassName().c_str(),
+        distance_idx);
 
     // First pass: go over all points and insert them into the right leaf
-    for(size_t cp = 0; cp < input_->points.size(); ++cp) {
-      if(!input_->is_dense)
+    for (size_t cp = 0; cp < input_->points.size(); ++cp) {
+      if (!input_->is_dense)
         // Check if the point is invalid
-        if(!std::isfinite(input_->points[cp].x) || !std::isfinite(input_->points[cp].y) || !std::isfinite(input_->points[cp].z)) continue;
+        if (
+          !std::isfinite(input_->points[cp].x) || !std::isfinite(input_->points[cp].y) ||
+          !std::isfinite(input_->points[cp].z))
+          continue;
 
       // Get the distance value
-      const uint8_t* pt_data = reinterpret_cast<const uint8_t*>(&input_->points[cp]);
+      const uint8_t * pt_data = reinterpret_cast<const uint8_t *>(&input_->points[cp]);
       float distance_value = 0;
       memcpy(&distance_value, pt_data + fields[distance_idx].offset, sizeof(float));
 
-      if(filter_limit_negative_) {
+      if (filter_limit_negative_) {
         // Use a threshold for cutting out points which inside the interval
-        if((distance_value < filter_limit_max_) && (distance_value > filter_limit_min_)) continue;
+        if ((distance_value < filter_limit_max_) && (distance_value > filter_limit_min_)) continue;
       } else {
         // Use a threshold for cutting out points which are too close/far away
-        if((distance_value > filter_limit_max_) || (distance_value < filter_limit_min_)) continue;
+        if ((distance_value > filter_limit_max_) || (distance_value < filter_limit_min_)) continue;
       }
 
-      int ijk0 = static_cast<int>(floor(input_->points[cp].x * inverse_leaf_size_[0]) - static_cast<float>(min_b_[0]));
-      int ijk1 = static_cast<int>(floor(input_->points[cp].y * inverse_leaf_size_[1]) - static_cast<float>(min_b_[1]));
-      int ijk2 = static_cast<int>(floor(input_->points[cp].z * inverse_leaf_size_[2]) - static_cast<float>(min_b_[2]));
+      int ijk0 = static_cast<int>(
+        floor(input_->points[cp].x * inverse_leaf_size_[0]) - static_cast<float>(min_b_[0]));
+      int ijk1 = static_cast<int>(
+        floor(input_->points[cp].y * inverse_leaf_size_[1]) - static_cast<float>(min_b_[1]));
+      int ijk2 = static_cast<int>(
+        floor(input_->points[cp].z * inverse_leaf_size_[2]) - static_cast<float>(min_b_[2]));
 
       // Compute the centroid leaf index
       int idx = ijk0 * divb_mul_[0] + ijk1 * divb_mul_[1] + ijk2 * divb_mul_[2];
 
-      Leaf& leaf = leaves_[idx];
-      if(leaf.nr_points == 0) {
+      Leaf & leaf = leaves_[idx];
+      if (leaf.nr_points == 0) {
         leaf.centroid.resize(centroid_size);
         leaf.centroid.setZero();
       }
@@ -159,22 +177,24 @@ void pclomp::VoxelGridCovariance<PointT>::applyFilter(PointCloud& output) {
       leaf.cov_ += pt3d * pt3d.transpose();
 
       // Do we need to process all the fields?
-      if(!downsample_all_data_) {
+      if (!downsample_all_data_) {
         Eigen::Vector4f pt(input_->points[cp].x, input_->points[cp].y, input_->points[cp].z, 0);
         leaf.centroid.template head<4>() += pt;
       } else {
         // Copy all the fields
         Eigen::VectorXf centroid = Eigen::VectorXf::Zero(centroid_size);
         // ---[ RGB special case
-        if(rgba_index >= 0) {
+        if (rgba_index >= 0) {
           // fill r/g/b data
           int rgb;
-          memcpy(&rgb, reinterpret_cast<const char*>(&input_->points[cp]) + rgba_index, sizeof(int));
+          memcpy(
+            &rgb, reinterpret_cast<const char *>(&input_->points[cp]) + rgba_index, sizeof(int));
           centroid[centroid_size - 3] = static_cast<float>((rgb >> 16) & 0x0000ff);
           centroid[centroid_size - 2] = static_cast<float>((rgb >> 8) & 0x0000ff);
           centroid[centroid_size - 1] = static_cast<float>((rgb) & 0x0000ff);
         }
-        pcl::for_each_type<FieldList>(pcl::NdCopyPointEigenFunctor<PointT>(input_->points[cp], centroid));
+        pcl::for_each_type<FieldList>(
+          pcl::NdCopyPointEigenFunctor<PointT>(input_->points[cp], centroid));
         leaf.centroid += centroid;
       }
       ++leaf.nr_points;
@@ -183,21 +203,28 @@ void pclomp::VoxelGridCovariance<PointT>::applyFilter(PointCloud& output) {
   // No distance filtering, process all data
   else {
     // First pass: go over all points and insert them into the right leaf
-    for(size_t cp = 0; cp < input_->points.size(); ++cp) {
-      if(!input_->is_dense)
+    for (size_t cp = 0; cp < input_->points.size(); ++cp) {
+      if (!input_->is_dense)
         // Check if the point is invalid
-        if(!std::isfinite(input_->points[cp].x) || !std::isfinite(input_->points[cp].y) || !std::isfinite(input_->points[cp].z)) continue;
+        if (
+          !std::isfinite(input_->points[cp].x) || !std::isfinite(input_->points[cp].y) ||
+          !std::isfinite(input_->points[cp].z))
+          continue;
 
-      int ijk0 = static_cast<int>(floor(input_->points[cp].x * inverse_leaf_size_[0]) - static_cast<float>(min_b_[0]));
-      int ijk1 = static_cast<int>(floor(input_->points[cp].y * inverse_leaf_size_[1]) - static_cast<float>(min_b_[1]));
-      int ijk2 = static_cast<int>(floor(input_->points[cp].z * inverse_leaf_size_[2]) - static_cast<float>(min_b_[2]));
+      int ijk0 = static_cast<int>(
+        floor(input_->points[cp].x * inverse_leaf_size_[0]) - static_cast<float>(min_b_[0]));
+      int ijk1 = static_cast<int>(
+        floor(input_->points[cp].y * inverse_leaf_size_[1]) - static_cast<float>(min_b_[1]));
+      int ijk2 = static_cast<int>(
+        floor(input_->points[cp].z * inverse_leaf_size_[2]) - static_cast<float>(min_b_[2]));
 
       // Compute the centroid leaf index
       int idx = ijk0 * divb_mul_[0] + ijk1 * divb_mul_[1] + ijk2 * divb_mul_[2];
 
-      // int idx = (((input_->points[cp].getArray4fmap () * inverse_leaf_size_).template cast<int> ()).matrix () - min_b_).dot (divb_mul_);
-      Leaf& leaf = leaves_[idx];
-      if(leaf.nr_points == 0) {
+      // int idx = (((input_->points[cp].getArray4fmap () * inverse_leaf_size_).template cast<int>
+      // ()).matrix () - min_b_).dot (divb_mul_);
+      Leaf & leaf = leaves_[idx];
+      if (leaf.nr_points == 0) {
         leaf.centroid.resize(centroid_size);
         leaf.centroid.setZero();
       }
@@ -209,22 +236,24 @@ void pclomp::VoxelGridCovariance<PointT>::applyFilter(PointCloud& output) {
       leaf.cov_ += pt3d * pt3d.transpose();
 
       // Do we need to process all the fields?
-      if(!downsample_all_data_) {
+      if (!downsample_all_data_) {
         Eigen::Vector4f pt(input_->points[cp].x, input_->points[cp].y, input_->points[cp].z, 0);
         leaf.centroid.template head<4>() += pt;
       } else {
         // Copy all the fields
         Eigen::VectorXf centroid = Eigen::VectorXf::Zero(centroid_size);
         // ---[ RGB special case
-        if(rgba_index >= 0) {
+        if (rgba_index >= 0) {
           // Fill r/g/b data, assuming that the order is BGRA
           int rgb;
-          memcpy(&rgb, reinterpret_cast<const char*>(&input_->points[cp]) + rgba_index, sizeof(int));
+          memcpy(
+            &rgb, reinterpret_cast<const char *>(&input_->points[cp]) + rgba_index, sizeof(int));
           centroid[centroid_size - 3] = static_cast<float>((rgb >> 16) & 0x0000ff);
           centroid[centroid_size - 2] = static_cast<float>((rgb >> 8) & 0x0000ff);
           centroid[centroid_size - 1] = static_cast<float>((rgb) & 0x0000ff);
         }
-        pcl::for_each_type<FieldList>(pcl::NdCopyPointEigenFunctor<PointT>(input_->points[cp], centroid));
+        pcl::for_each_type<FieldList>(
+          pcl::NdCopyPointEigenFunctor<PointT>(input_->points[cp], centroid));
         leaf.centroid += centroid;
       }
       ++leaf.nr_points;
@@ -233,21 +262,22 @@ void pclomp::VoxelGridCovariance<PointT>::applyFilter(PointCloud& output) {
 
   // Second pass: go over all leaves and compute centroids and covariance matrices
   output.points.reserve(leaves_.size());
-  if(searchable_) voxel_centroids_leaf_indices_.reserve(leaves_.size());
+  if (searchable_) voxel_centroids_leaf_indices_.reserve(leaves_.size());
   int cp = 0;
-  if(save_leaf_layout_) leaf_layout_.resize(div_b_[0] * div_b_[1] * div_b_[2], -1);
+  if (save_leaf_layout_) leaf_layout_.resize(div_b_[0] * div_b_[1] * div_b_[2], -1);
 
   // Eigen values and vectors calculated to prevent near singular matrices
   Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> eigensolver;
   Eigen::Matrix3d eigen_val;
   Eigen::Vector3d pt_sum;
 
-  // Eigen values less than a threshold of max eigen value are inflated to a set fraction of the max eigen value.
+  // Eigen values less than a threshold of max eigen value are inflated to a set fraction of the max
+  // eigen value.
   double min_covar_eigvalue;
 
-  for(auto it = leaves_.begin(); it != leaves_.end(); ++it) {
+  for (auto it = leaves_.begin(); it != leaves_.end(); ++it) {
     // Normalize the centroid
-    Leaf& leaf = it->second;
+    Leaf & leaf = it->second;
 
     // Normalize the centroid
     leaf.centroid /= static_cast<float>(leaf.nr_points);
@@ -256,34 +286,39 @@ void pclomp::VoxelGridCovariance<PointT>::applyFilter(PointCloud& output) {
     // Normalize mean
     leaf.mean_ /= leaf.nr_points;
 
-    // If the voxel contains sufficient points, its covariance is calculated and is added to the voxel centroids and output clouds.
-    // Points with less than the minimum points will have a can not be accurately approximated using a normal distribution.
-    if(leaf.nr_points >= min_points_per_voxel_) {
-      if(save_leaf_layout_) leaf_layout_[it->first] = cp++;
+    // If the voxel contains sufficient points, its covariance is calculated and is added to the
+    // voxel centroids and output clouds. Points with less than the minimum points will have a can
+    // not be accurately approximated using a normal distribution.
+    if (leaf.nr_points >= min_points_per_voxel_) {
+      if (save_leaf_layout_) leaf_layout_[it->first] = cp++;
 
       output.push_back(PointT());
 
       // Do we need to process all the fields?
-      if(!downsample_all_data_) {
+      if (!downsample_all_data_) {
         output.points.back().x = leaf.centroid[0];
         output.points.back().y = leaf.centroid[1];
         output.points.back().z = leaf.centroid[2];
       } else {
-        pcl::for_each_type<FieldList>(pcl::NdCopyEigenPointFunctor<PointT>(leaf.centroid, output.back()));
+        pcl::for_each_type<FieldList>(
+          pcl::NdCopyEigenPointFunctor<PointT>(leaf.centroid, output.back()));
         // ---[ RGB special case
-        if(rgba_index >= 0) {
+        if (rgba_index >= 0) {
           // pack r/g/b into rgb
-          float r = leaf.centroid[centroid_size - 3], g = leaf.centroid[centroid_size - 2], b = leaf.centroid[centroid_size - 1];
-          int rgb = (static_cast<int>(r)) << 16 | (static_cast<int>(g)) << 8 | (static_cast<int>(b));
-          memcpy(reinterpret_cast<char*>(&output.points.back()) + rgba_index, &rgb, sizeof(float));
+          float r = leaf.centroid[centroid_size - 3], g = leaf.centroid[centroid_size - 2],
+                b = leaf.centroid[centroid_size - 1];
+          int rgb =
+            (static_cast<int>(r)) << 16 | (static_cast<int>(g)) << 8 | (static_cast<int>(b));
+          memcpy(reinterpret_cast<char *>(&output.points.back()) + rgba_index, &rgb, sizeof(float));
         }
       }
 
       // Stores the voxel indices for fast access searching
-      if(searchable_) voxel_centroids_leaf_indices_.push_back(static_cast<int>(it->first));
+      if (searchable_) voxel_centroids_leaf_indices_.push_back(static_cast<int>(it->first));
 
       // Single pass covariance calculation
-      leaf.cov_ = (leaf.cov_ - 2 * (pt_sum * leaf.mean_.transpose())) / leaf.nr_points + leaf.mean_ * leaf.mean_.transpose();
+      leaf.cov_ = (leaf.cov_ - 2 * (pt_sum * leaf.mean_.transpose())) / leaf.nr_points +
+                  leaf.mean_ * leaf.mean_.transpose();
       leaf.cov_ *= (leaf.nr_points - 1.0) / leaf.nr_points;
 
       // Normalize Eigen Val such that max no more than 100x min.
@@ -291,7 +326,7 @@ void pclomp::VoxelGridCovariance<PointT>::applyFilter(PointCloud& output) {
       eigen_val = eigensolver.eigenvalues().asDiagonal();
       leaf.evecs_ = eigensolver.eigenvectors();
 
-      if(eigen_val(0, 0) < 0 || eigen_val(1, 1) < 0 || eigen_val(2, 2) <= 0) {
+      if (eigen_val(0, 0) < 0 || eigen_val(1, 1) < 0 || eigen_val(2, 2) <= 0) {
         leaf.nr_points = -1;
         continue;
       }
@@ -299,10 +334,10 @@ void pclomp::VoxelGridCovariance<PointT>::applyFilter(PointCloud& output) {
       // Avoids matrices near singularities (eq 6.11)[Magnusson 2009]
 
       min_covar_eigvalue = min_covar_eigvalue_mult_ * eigen_val(2, 2);
-      if(eigen_val(0, 0) < min_covar_eigvalue) {
+      if (eigen_val(0, 0) < min_covar_eigvalue) {
         eigen_val(0, 0) = min_covar_eigvalue;
 
-        if(eigen_val(1, 1) < min_covar_eigvalue) {
+        if (eigen_val(1, 1) < min_covar_eigvalue) {
           eigen_val(1, 1) = min_covar_eigvalue;
         }
 
@@ -311,7 +346,9 @@ void pclomp::VoxelGridCovariance<PointT>::applyFilter(PointCloud& output) {
       leaf.evals_ = eigen_val.diagonal();
 
       leaf.icov_ = leaf.cov_.inverse();
-      if(leaf.icov_.maxCoeff() == std::numeric_limits<float>::infinity() || leaf.icov_.minCoeff() == -std::numeric_limits<float>::infinity()) {
+      if (
+        leaf.icov_.maxCoeff() == std::numeric_limits<float>::infinity() ||
+        leaf.icov_.minCoeff() == -std::numeric_limits<float>::infinity()) {
         leaf.nr_points = -1;
       }
     }
@@ -321,24 +358,31 @@ void pclomp::VoxelGridCovariance<PointT>::applyFilter(PointCloud& output) {
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointT>
-int pclomp::VoxelGridCovariance<PointT>::getNeighborhoodAtPoint(const Eigen::MatrixXi& relative_coordinates, const PointT& reference_point, std::vector<LeafConstPtr>& neighbors) const {
+template <typename PointT>
+int pclomp::VoxelGridCovariance<PointT>::getNeighborhoodAtPoint(
+  const Eigen::MatrixXi & relative_coordinates, const PointT & reference_point,
+  std::vector<LeafConstPtr> & neighbors) const
+{
   neighbors.clear();
 
   // Find displacement coordinates
-  Eigen::Vector4i ijk(static_cast<int>(floor(reference_point.x / leaf_size_[0])), static_cast<int>(floor(reference_point.y / leaf_size_[1])), static_cast<int>(floor(reference_point.z / leaf_size_[2])), 0);
+  Eigen::Vector4i ijk(
+    static_cast<int>(floor(reference_point.x / leaf_size_[0])),
+    static_cast<int>(floor(reference_point.y / leaf_size_[1])),
+    static_cast<int>(floor(reference_point.z / leaf_size_[2])), 0);
   Eigen::Array4i diff2min = min_b_ - ijk;
   Eigen::Array4i diff2max = max_b_ - ijk;
   neighbors.reserve(relative_coordinates.cols());
 
   // Check each neighbor to see if it is occupied and contains sufficient points
   // Slower than radius search because needs to check 26 indices
-  for(int ni = 0; ni < relative_coordinates.cols(); ni++) {
-    Eigen::Vector4i displacement = (Eigen::Vector4i() << relative_coordinates.col(ni), 0).finished();
+  for (int ni = 0; ni < relative_coordinates.cols(); ni++) {
+    Eigen::Vector4i displacement =
+      (Eigen::Vector4i() << relative_coordinates.col(ni), 0).finished();
     // Checking if the specified cell is in the grid
-    if((diff2min <= displacement.array()).all() && (diff2max >= displacement.array()).all()) {
+    if ((diff2min <= displacement.array()).all() && (diff2max >= displacement.array()).all()) {
       auto leaf_iter = leaves_.find(((ijk + displacement - min_b_).dot(divb_mul_)));
-      if(leaf_iter != leaves_.end() && leaf_iter->second.nr_points >= min_points_per_voxel_) {
+      if (leaf_iter != leaves_.end() && leaf_iter->second.nr_points >= min_points_per_voxel_) {
         LeafConstPtr leaf = &(leaf_iter->second);
         neighbors.push_back(leaf);
       }
@@ -349,8 +393,10 @@ int pclomp::VoxelGridCovariance<PointT>::getNeighborhoodAtPoint(const Eigen::Mat
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointT>
-int pclomp::VoxelGridCovariance<PointT>::getNeighborhoodAtPoint(const PointT& reference_point, std::vector<LeafConstPtr>& neighbors) const {
+template <typename PointT>
+int pclomp::VoxelGridCovariance<PointT>::getNeighborhoodAtPoint(
+  const PointT & reference_point, std::vector<LeafConstPtr> & neighbors) const
+{
   neighbors.clear();
 
   // Find displacement coordinates
@@ -359,8 +405,10 @@ int pclomp::VoxelGridCovariance<PointT>::getNeighborhoodAtPoint(const PointT& re
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointT>
-int pclomp::VoxelGridCovariance<PointT>::getNeighborhoodAtPoint7(const PointT& reference_point, std::vector<LeafConstPtr>& neighbors) const {
+template <typename PointT>
+int pclomp::VoxelGridCovariance<PointT>::getNeighborhoodAtPoint7(
+  const PointT & reference_point, std::vector<LeafConstPtr> & neighbors) const
+{
   neighbors.clear();
 
   Eigen::MatrixXi relative_coordinates(3, 7);
@@ -376,21 +424,25 @@ int pclomp::VoxelGridCovariance<PointT>::getNeighborhoodAtPoint7(const PointT& r
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointT>
-int pclomp::VoxelGridCovariance<PointT>::getNeighborhoodAtPoint1(const PointT& reference_point, std::vector<LeafConstPtr>& neighbors) const {
+template <typename PointT>
+int pclomp::VoxelGridCovariance<PointT>::getNeighborhoodAtPoint1(
+  const PointT & reference_point, std::vector<LeafConstPtr> & neighbors) const
+{
   neighbors.clear();
   return getNeighborhoodAtPoint(Eigen::MatrixXi::Zero(3, 1), reference_point, neighbors);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointT>
-void pclomp::VoxelGridCovariance<PointT>::getDisplayCloud(pcl::PointCloud<pcl::PointXYZ>& cell_cloud) {
+template <typename PointT>
+void pclomp::VoxelGridCovariance<PointT>::getDisplayCloud(
+  pcl::PointCloud<pcl::PointXYZ> & cell_cloud)
+{
   cell_cloud.clear();
 
   int pnt_per_cell = 1000;
   boost::mt19937 rng;
   boost::normal_distribution<> nd(0.0, leaf_size_.head(3).norm());
-  boost::variate_generator<boost::mt19937&, boost::normal_distribution<> > var_nor(rng, nd);
+  boost::variate_generator<boost::mt19937 &, boost::normal_distribution<> > var_nor(rng, nd);
 
   Eigen::LLT<Eigen::Matrix3d> llt_of_cov;
   Eigen::Matrix3d cholesky_decomp;
@@ -399,24 +451,28 @@ void pclomp::VoxelGridCovariance<PointT>::getDisplayCloud(pcl::PointCloud<pcl::P
   Eigen::Vector3d dist_point;
 
   // Generate points for each occupied voxel with sufficient points.
-  for(auto it = leaves_.begin(); it != leaves_.end(); ++it) {
-    Leaf& leaf = it->second;
+  for (auto it = leaves_.begin(); it != leaves_.end(); ++it) {
+    Leaf & leaf = it->second;
 
-    if(leaf.nr_points >= min_points_per_voxel_) {
+    if (leaf.nr_points >= min_points_per_voxel_) {
       cell_mean = leaf.mean_;
       llt_of_cov.compute(leaf.cov_);
       cholesky_decomp = llt_of_cov.matrixL();
 
-      // Random points generated by sampling the normal distribution given by voxel mean and covariance matrix
-      for(int i = 0; i < pnt_per_cell; i++) {
+      // Random points generated by sampling the normal distribution given by voxel mean and
+      // covariance matrix
+      for (int i = 0; i < pnt_per_cell; i++) {
         rand_point = Eigen::Vector3d(var_nor(), var_nor(), var_nor());
         dist_point = cell_mean + cholesky_decomp * rand_point;
-        cell_cloud.push_back(pcl::PointXYZ(static_cast<float>(dist_point(0)), static_cast<float>(dist_point(1)), static_cast<float>(dist_point(2))));
+        cell_cloud.push_back(pcl::PointXYZ(
+          static_cast<float>(dist_point(0)), static_cast<float>(dist_point(1)),
+          static_cast<float>(dist_point(2))));
       }
     }
   }
 }
 
-#define PCL_INSTANTIATE_VoxelGridCovariance(T) template class PCL_EXPORTS pcl::VoxelGridCovariance<T>;
+#define PCL_INSTANTIATE_VoxelGridCovariance(T) \
+  template class PCL_EXPORTS pcl::VoxelGridCovariance<T>;
 
 #endif  // PCL_VOXEL_GRID_COVARIANCE_IMPL_H_

--- a/src/multigrid_pclomp/multi_voxel_grid_covariance_omp.cpp
+++ b/src/multigrid_pclomp/multi_voxel_grid_covariance_omp.cpp
@@ -1,5 +1,6 @@
-#include <multigrid_pclomp/multi_voxel_grid_covariance_omp.h>
 #include <multigrid_pclomp/multi_voxel_grid_covariance_omp_impl.hpp>
+
+#include <multigrid_pclomp/multi_voxel_grid_covariance_omp.h>
 
 template class pclomp::MultiVoxelGridCovariance<pcl::PointXYZ>;
 template class pclomp::MultiVoxelGridCovariance<pcl::PointXYZI>;

--- a/src/multigrid_pclomp/multigrid_ndt_omp.cpp
+++ b/src/multigrid_pclomp/multigrid_ndt_omp.cpp
@@ -1,5 +1,6 @@
-#include <multigrid_pclomp/multigrid_ndt_omp.h>
 #include <multigrid_pclomp/multigrid_ndt_omp_impl.hpp>
+
+#include <multigrid_pclomp/multigrid_ndt_omp.h>
 
 template class pclomp::MultiGridNormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>;
 template class pclomp::MultiGridNormalDistributionsTransform<pcl::PointXYZI, pcl::PointXYZI>;

--- a/src/pclomp/gicp_omp.cpp
+++ b/src/pclomp/gicp_omp.cpp
@@ -1,5 +1,8 @@
+// this cannot be swapped
+// clang-format off
 #include <pclomp/gicp_omp.h>
 #include <pclomp/gicp_omp_impl.hpp>
+// clang-format on
 
 template class pclomp::GeneralizedIterativeClosestPoint<pcl::PointXYZ, pcl::PointXYZ>;
 template class pclomp::GeneralizedIterativeClosestPoint<pcl::PointXYZI, pcl::PointXYZI>;

--- a/src/pclomp/ndt_omp.cpp
+++ b/src/pclomp/ndt_omp.cpp
@@ -1,5 +1,6 @@
-#include <pclomp/ndt_omp.h>
 #include <pclomp/ndt_omp_impl.hpp>
+
+#include <pclomp/ndt_omp.h>
 
 template class pclomp::NormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>;
 template class pclomp::NormalDistributionsTransform<pcl::PointXYZI, pcl::PointXYZI>;

--- a/src/pclomp/voxel_grid_covariance_omp.cpp
+++ b/src/pclomp/voxel_grid_covariance_omp.cpp
@@ -1,5 +1,6 @@
-#include <pclomp/voxel_grid_covariance_omp.h>
 #include <pclomp/voxel_grid_covariance_omp_impl.hpp>
+
+#include <pclomp/voxel_grid_covariance_omp.h>
 
 template class pclomp::VoxelGridCovariance<pcl::PointXYZ>;
 template class pclomp::VoxelGridCovariance<pcl::PointXYZI>;


### PR DESCRIPTION
Update the `.clang-format` to synchronize with autoware.universe, and apply clang-format to the codes.
Some of the header was not possible to reorder, it will be ignore with `// clang-format off`.

Checked with `compare_regression_test_result.py`, and confirmed the test is passing.

(copy of #56 which was not able to pass the checks because of some error on fetching the branch from forked repo.)