### PR TITLE
remove temporal compatibility

### DIFF
--- a/include/estimate_covariance/estimate_covariance.hpp
+++ b/include/estimate_covariance/estimate_covariance.hpp
@@ -23,11 +23,6 @@ struct ResultOfMultiNdtCovarianceEstimation
 /** \brief Estimate functions */
 Eigen::Matrix2d estimate_xy_covariance_by_laplace_approximation(
   const Eigen::Matrix<double, 6, 6> & hessian);
-// temporal compatibility until
-//   https://github.com/autowarefoundation/autoware.universe/pull/8124
-// get merged
-Eigen::Matrix2d estimate_xy_covariance_by_Laplace_approximation(
-  const Eigen::Matrix<double, 6, 6> & hessian);
 ResultOfMultiNdtCovarianceEstimation estimate_xy_covariance_by_multi_ndt(
   const NdtResult & ndt_result,
   const std::shared_ptr<

--- a/src/estimate_covariance/estimate_covariance.cpp
+++ b/src/estimate_covariance/estimate_covariance.cpp
@@ -14,18 +14,6 @@ Eigen::Matrix2d estimate_xy_covariance_by_laplace_approximation(
   return covariance_xy;
 }
 
-// temporal compatibility until
-//   https://github.com/autowarefoundation/autoware.universe/pull/8124
-// get merged
-Eigen::Matrix2d estimate_xy_covariance_by_Laplace_approximation(
-  const Eigen::Matrix<double, 6, 6> & hessian)
-{
-  const Eigen::Matrix2d hessian_xy = hessian.block<2, 2>(0, 0);
-  Eigen::Matrix2d covariance_xy = -hessian_xy.inverse();
-  return covariance_xy;
-}
-
-
 ResultOfMultiNdtCovarianceEstimation estimate_xy_covariance_by_multi_ndt(
   const NdtResult & ndt_result,
   const std::shared_ptr<


### PR DESCRIPTION
# Description

This PR removes the temporal compatibility that was added in https://github.com/tier4/ndt_omp/pull/57 .
- It will remove `estimate_xy_covariance_by_Laplace_approximation`