### PR TITLE
fix: fixed target from ref to sha

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Run pre-commit
         uses: autowarefoundation/autoware-github-actions/pre-commit@v1

--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
An error occurs in https://github.com/tier4/ndt_omp/pull/60 .

In autoware.universe, the target branch is specified by sha instead of ref, so I made the same fix in this repository.

https://github.com/autowarefoundation/autoware.universe/blob/e9dcf99f5c18481d669d7afe97a2f8487ee47d31/.github/workflows/build-and-test-differential.yaml#L49