### PR TITLE
feat: caluculate nearest voxel score each point

### DIFF
--- a/include/multigrid_pclomp/multigrid_ndt_omp.h
+++ b/include/multigrid_pclomp/multigrid_ndt_omp.h
@@ -262,7 +262,8 @@ public:
   // lower is better
   double calculateTransformationProbability(const PointCloudSource & cloud) const;
   double calculateNearestVoxelTransformationLikelihood(const PointCloudSource & cloud) const;
-  pcl::PointCloud<pcl::PointXYZI>::Ptr calculateNearestVoxelScoreEachPoint(const PointCloudSource & cloud) const;
+  pcl::PointCloud<pcl::PointXYZI>::Ptr calculateNearestVoxelScoreEachPoint(
+    const PointCloudSource & cloud) const;
 
   inline void setRegularizationScaleFactor(float regularization_scale_factor)
   {

--- a/include/multigrid_pclomp/multigrid_ndt_omp.h
+++ b/include/multigrid_pclomp/multigrid_ndt_omp.h
@@ -263,6 +263,8 @@ public:
   double calculateTransformationProbability(const PointCloudSource & cloud) const;
   double calculateNearestVoxelTransformationLikelihood(const PointCloudSource & cloud) const;
 
+  inline pcl::PointCloud<pcl::PointXYZI>::Ptr getScorePoints() const { return (score_points_); }
+
   inline void setRegularizationScaleFactor(float regularization_scale_factor)
   {
     params_.regularization_scale_factor = regularization_scale_factor;
@@ -553,6 +555,8 @@ protected:
 
   boost::optional<Eigen::Matrix4f> regularization_pose_;
   Eigen::Vector3f regularization_pose_translation_;
+
+  pcl::PointCloud<pcl::PointXYZI>::Ptr score_points_{new pcl::PointCloud<pcl::PointXYZI>};
 
   NdtParams params_;
 

--- a/include/multigrid_pclomp/multigrid_ndt_omp.h
+++ b/include/multigrid_pclomp/multigrid_ndt_omp.h
@@ -264,8 +264,6 @@ public:
   double calculateNearestVoxelTransformationLikelihood(const PointCloudSource & cloud) const;
   pcl::PointCloud<pcl::PointXYZI>::Ptr calculateNearestVoxelScoreEachPoint(const PointCloudSource & cloud) const;
 
-  //inline pcl::PointCloud<pcl::PointXYZI>::Ptr getScorePoints() const { return (score_points_); }
-
   inline void setRegularizationScaleFactor(float regularization_scale_factor)
   {
     params_.regularization_scale_factor = regularization_scale_factor;

--- a/include/multigrid_pclomp/multigrid_ndt_omp.h
+++ b/include/multigrid_pclomp/multigrid_ndt_omp.h
@@ -262,7 +262,7 @@ public:
   // lower is better
   double calculateTransformationProbability(const PointCloudSource & cloud) const;
   double calculateNearestVoxelTransformationLikelihood(const PointCloudSource & cloud) const;
-  pcl::PointCloud<pcl::PointXYZI>::Ptr calculateNearestVoxelScoreEachPoint(
+  pcl::PointCloud<pcl::PointXYZI> calculateNearestVoxelScoreEachPoint(
     const PointCloudSource & cloud) const;
 
   inline void setRegularizationScaleFactor(float regularization_scale_factor)
@@ -555,8 +555,6 @@ protected:
 
   boost::optional<Eigen::Matrix4f> regularization_pose_;
   Eigen::Vector3f regularization_pose_translation_;
-
-  pcl::PointCloud<pcl::PointXYZI>::Ptr score_points_{new pcl::PointCloud<pcl::PointXYZI>};
 
   NdtParams params_;
 

--- a/include/multigrid_pclomp/multigrid_ndt_omp.h
+++ b/include/multigrid_pclomp/multigrid_ndt_omp.h
@@ -262,8 +262,9 @@ public:
   // lower is better
   double calculateTransformationProbability(const PointCloudSource & cloud) const;
   double calculateNearestVoxelTransformationLikelihood(const PointCloudSource & cloud) const;
+  pcl::PointCloud<pcl::PointXYZI>::Ptr calculateNearestVoxelScoreEachPoint(const PointCloudSource & cloud) const;
 
-  inline pcl::PointCloud<pcl::PointXYZI>::Ptr getScorePoints() const { return (score_points_); }
+  //inline pcl::PointCloud<pcl::PointXYZI>::Ptr getScorePoints() const { return (score_points_); }
 
   inline void setRegularizationScaleFactor(float regularization_scale_factor)
   {

--- a/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp
+++ b/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp
@@ -1157,6 +1157,7 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::
         nearest_voxel_score_pt = score_inc;
       }
     }
+
     t_nvs[tid] += nearest_voxel_score_pt;
     ++t_found_nnvn[tid];
   }

--- a/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp
+++ b/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp
@@ -1177,9 +1177,8 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::
 }
 
 template <typename PointSource, typename PointTarget>
-pcl::PointCloud<pcl::PointXYZI> MultiGridNormalDistributionsTransform<
-  PointSource, PointTarget>::calculateNearestVoxelScoreEachPoint(const PointCloudSource &
-                                                                   trans_cloud) const
+pcl::PointCloud<pcl::PointXYZI> MultiGridNormalDistributionsTransform<PointSource, PointTarget>::
+  calculateNearestVoxelScoreEachPoint(const PointCloudSource & trans_cloud) const
 {
   // Thread-wise results
   std::vector<pcl::PointCloud<pcl::PointXYZI>> threads_pc(params_.num_threads);

--- a/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp
+++ b/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp
@@ -1121,9 +1121,6 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::
   std::vector<size_t> t_found_nnvn(params_.num_threads);
   std::vector<pcl::PointCloud<pcl::PointXYZI>> threads_pc(params_.num_threads);
   pcl::PointCloud<pcl::PointXYZI>::Ptr score_points (new pcl::PointCloud<pcl::PointXYZI>);
-  const float min_nvs = 1.0f;
-  const float max_nvs = 4.0f;
-  const float k = 255/(max_nvs - min_nvs);
 
   for (int i = 0; i < params_.num_threads; ++i) {
     t_nvs[i] = 0;
@@ -1170,19 +1167,10 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::
     sensor_point_score.x = trans_cloud.points[idx].x;
     sensor_point_score.y = trans_cloud.points[idx].y;
     sensor_point_score.z = trans_cloud.points[idx].z;
-    if(nearest_voxel_score_pt > max_nvs){
-      sensor_point_score.intensity = 255;
-    }
-    else if(min_nvs > nearest_voxel_score_pt){
-      sensor_point_score.intensity = 0;
-    }
-    else{
-      sensor_point_score.intensity = (nearest_voxel_score_pt - min_nvs) * k;
-    }
-    //std::cerr<< "nearest_voxel_score_pt:" << nearest_voxel_score_pt << std::endl;
+    sensor_point_score.intensity = nearest_voxel_score_pt;
     threads_pc[tid].points.push_back(sensor_point_score);
   }
-  
+
   // Sum up point-wise scores
   for (size_t idx = 0; idx < params_.num_threads; ++idx) {
     found_neighborhood_voxel_num += t_found_nnvn[idx];
@@ -1192,10 +1180,7 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::
     }
   }
 
-  if(score_points){
-    *score_points_ = *score_points;
-  }
-
+  *score_points_ = *score_points;
   double output_score = 0;
 
   if (found_neighborhood_voxel_num != 0) {

--- a/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp
+++ b/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp
@@ -1177,12 +1177,13 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::
 }
 
 template <typename PointSource, typename PointTarget>
-pcl::PointCloud<pcl::PointXYZI>::Ptr MultiGridNormalDistributionsTransform<PointSource, PointTarget>::
-  calculateNearestVoxelScoreEachPoint(const PointCloudSource & trans_cloud) const
+pcl::PointCloud<pcl::PointXYZI>::Ptr MultiGridNormalDistributionsTransform<
+  PointSource, PointTarget>::calculateNearestVoxelScoreEachPoint(const PointCloudSource &
+                                                                   trans_cloud) const
 {
   // Thread-wise results
   std::vector<pcl::PointCloud<pcl::PointXYZI>> threads_pc(params_.num_threads);
-  pcl::PointCloud<pcl::PointXYZI>::Ptr score_points (new pcl::PointCloud<pcl::PointXYZI>);
+  pcl::PointCloud<pcl::PointXYZI>::Ptr score_points(new pcl::PointCloud<pcl::PointXYZI>);
 
 #pragma omp parallel for num_threads(params_.num_threads) schedule(guided, 8)
   for (size_t idx = 0; idx < trans_cloud.size(); ++idx) {
@@ -1227,7 +1228,7 @@ pcl::PointCloud<pcl::PointXYZI>::Ptr MultiGridNormalDistributionsTransform<Point
 
   // Sum up point-wise scores
   for (size_t idx = 0; idx < params_.num_threads; ++idx) {
-    for(size_t p_idx = 0; p_idx < threads_pc[idx].size(); ++p_idx){
+    for (size_t p_idx = 0; p_idx < threads_pc[idx].size(); ++p_idx) {
       score_points->points.push_back(threads_pc[idx].points[p_idx]);
     }
   }

--- a/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp
+++ b/include/multigrid_pclomp/multigrid_ndt_omp_impl.hpp
@@ -1177,13 +1177,13 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::
 }
 
 template <typename PointSource, typename PointTarget>
-pcl::PointCloud<pcl::PointXYZI>::Ptr MultiGridNormalDistributionsTransform<
+pcl::PointCloud<pcl::PointXYZI> MultiGridNormalDistributionsTransform<
   PointSource, PointTarget>::calculateNearestVoxelScoreEachPoint(const PointCloudSource &
                                                                    trans_cloud) const
 {
   // Thread-wise results
   std::vector<pcl::PointCloud<pcl::PointXYZI>> threads_pc(params_.num_threads);
-  pcl::PointCloud<pcl::PointXYZI>::Ptr score_points(new pcl::PointCloud<pcl::PointXYZI>);
+  pcl::PointCloud<pcl::PointXYZI> score_points;
 
 #pragma omp parallel for num_threads(params_.num_threads) schedule(guided, 8)
   for (size_t idx = 0; idx < trans_cloud.size(); ++idx) {
@@ -1229,7 +1229,7 @@ pcl::PointCloud<pcl::PointXYZI>::Ptr MultiGridNormalDistributionsTransform<
   // Sum up point-wise scores
   for (size_t idx = 0; idx < params_.num_threads; ++idx) {
     for (size_t p_idx = 0; p_idx < threads_pc[idx].size(); ++p_idx) {
-      score_points->points.push_back(threads_pc[idx].points[p_idx]);
+      score_points.points.push_back(threads_pc[idx].points[p_idx]);
     }
   }
 

--- a/include/pclomp/ndt_struct.hpp
+++ b/include/pclomp/ndt_struct.hpp
@@ -57,8 +57,6 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
-#include <pcl/common/common.h>
-
 #include <vector>
 
 namespace pclomp

--- a/include/pclomp/ndt_struct.hpp
+++ b/include/pclomp/ndt_struct.hpp
@@ -59,6 +59,8 @@
 
 #include <vector>
 
+#include <pcl/common/common.h>
+
 namespace pclomp
 {
 

--- a/include/pclomp/ndt_struct.hpp
+++ b/include/pclomp/ndt_struct.hpp
@@ -57,9 +57,9 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
-#include <vector>
-
 #include <pcl/common/common.h>
+
+#include <vector>
 
 namespace pclomp
 {


### PR DESCRIPTION
## Description
To visualize matching score each point,  a function is implemented to output a point cloud containing the value of the score of each point.

This score is the highest value of the neighboring voxels of each point.

## Related links
[autoware_universe](https://github.com/autowarefoundation/autoware.universe/pull/8856)