### PR TITLE
fix(voxel_grid_covariance_omp): remove cin in radius search

### DIFF
--- a/include/pclomp/voxel_grid_covariance_omp.h
+++ b/include/pclomp/voxel_grid_covariance_omp.h
@@ -497,7 +497,6 @@ namespace pclomp
 		  auto leaf = leaves_.find(voxel_centroids_leaf_indices_[*iter]);
 		  if (leaf == leaves_.end()) {
 			  std::cerr << "error : could not find the leaf corresponding to the voxel" << std::endl;
-			  std::cin.ignore(1);
 		  }
           k_leaves.push_back (&(leaf->second));
         }


### PR DESCRIPTION
## Description

### Why
* To ensure std:cin will not be called every time running radiusSearch in ndt_omp

### What
* Remove std:cin from radiusSearch in ndt_omp

## Related links
* https://tier4.atlassian.net/browse/AEAP-1682
* https://tier4.atlassian.net/browse/AEAP-1792

## Tests performed
* The only changes in this PR is to remove std:cin in radiusSearch, which will not affect functionality and performance of localization. 
* From the simulation, the vehicle is moving properly without any emergency error.

![Peek 2024-11-14 11-09](https://github.com/user-attachments/assets/10b60e5b-0024-46ad-ba58-70e2b493b1af)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
