### PR TITLE
fix: compatiablity issues with ros 2 jazzy

### DIFF
--- a/include/pclomp/gicp_omp_impl.hpp
+++ b/include/pclomp/gicp_omp_impl.hpp
@@ -40,6 +40,7 @@
 #ifndef PCL_REGISTRATION_IMPL_GICP_OMP_HPP_
 #define PCL_REGISTRATION_IMPL_GICP_OMP_HPP_
 
+#include "pclomp/gicp_omp.h"
 #include <pcl/registration/boost.h>
 #include <pcl/registration/exceptions.h>
 
@@ -233,7 +234,7 @@ void pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::
     if (result) {
       break;
     }
-    result = bfgs.testGradient(gradient_tol);
+    result = bfgs.testGradient(/*gradient_tol*/);
   } while (result == BFGSSpace::Running && inner_iterations_ < max_inner_iterations_);
   if (
     result == BFGSSpace::NoProgress || result == BFGSSpace::Success ||

--- a/include/pclomp/ndt_omp.h
+++ b/include/pclomp/ndt_omp.h
@@ -48,6 +48,7 @@
 #include <unsupported/Eigen/NonLinearOptimization>
 
 #include "boost/optional.hpp"
+#include <set>
 
 #include <pcl/registration/registration.h>
 


### PR DESCRIPTION
The repo fails to compile in ROS 2 Jazzy without these changes. It seems that the `epsilon` argument of `BFGS<T>::testGradient` was removed in later versions of PCL.